### PR TITLE
fix submodule error

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,15 @@
 [submodule "meson"]
 	path = meson
 	url = https://gitlab.com/qemu-project/meson.git
+[submodule "slirp"]
+	path = slirp
+	url = https://gitlab.com/qemu-project/libslirp.git
+[submodule "tests/fp/berkeley-softfloat-3"]
+	path = tests/fp/berkeley-softfloat-3
+	url = http://gitlab.com/qemu-project/berkeley-softfloat-3.git
+[submodule "tests/fp/berkeley-testfloat-3"]
+	path = tests/fp/berkeley-testfloat-3
+	url = https://gitlab.com/qemu-project/berkeley-testfloat-3.git
+[submodule "ui/keycodemapdb"]
+	path = ui/keycodemapdb
+	url = https://gitlab.com/qemu-project/keycodemapdb.git


### PR DESCRIPTION
$ ./latxbuild/build-release-nw.sh
build for target x86_64-linux-user
=====>
++++
warn: ignoring non-existent submodule ui/keycodemapdb warn: ignoring non-existent submodule tests/fp/berkeley-testfloat-3 warn: ignoring non-existent submodule tests/fp/berkeley-softfloat-3 warn: ignoring non-existent submodule slirp
致命错误：在 .gitmodules 中未找到子模组路径 'dtc' 的 url
/tmp/lat/scripts/git-submodule.sh: failed to update modules

Unable to automatically checkout GIT submodules ''.