### PR TITLE
KZT: optimize NewLibrary avoid loading duplicated library

### DIFF
--- a/linux-user/exit.c
+++ b/linux-user/exit.c
@@ -36,6 +36,10 @@ extern void __gcov_dump(void);
 #include "latx-perf.h"
 #endif
 
+#ifdef CONFIG_LATX_KZT
+#include "library.h"
+#endif
+
 void preexit_cleanup(CPUArchState *env, int code)
 {
 #ifdef CONFIG_LATX_PERF
@@ -54,6 +58,11 @@ void preexit_cleanup(CPUArchState *env, int code)
 #ifdef CONFIG_LATX_PROFILER
         if (qemu_loglevel_mask(LAT_LOG_PROFILE))
             dump_exec_info();
+#endif
+#ifdef CONFIG_LATX_KZT
+    if (option_kzt) {
+        FreeLoadedLibs();
+    }
 #endif
         gdb_exit(code);
         qemu_plugin_atexit_cb();

--- a/target/i386/latx/context/elfloader.c
+++ b/target/i386/latx/context/elfloader.c
@@ -955,7 +955,7 @@ uname(1) man page description of the -i option). For more details of this token
 expansion, see “System Specific Shared Objects”
 */
 extern const char *interp_prefix;
-int LoadNeededLibs(elfheader_t* h, lib_t *maplib, needed_libs_t* neededlibs, library_t *deplib, int local, int bindnow, box64context_t *box64)
+int LoadNeededLibs(elfheader_t* h, lib_t *maplib, needed_libs_t* neededlibs, library_t *deplib, int local, int bindnow, box64context_t *box64, int init_main_elf)
 {
     if (!h->latx_hasfix) return 1;
     if(relocation_dump) DumpDynamicRPath(h);
@@ -1038,7 +1038,7 @@ int LoadNeededLibs(elfheader_t* h, lib_t *maplib, needed_libs_t* neededlibs, lib
         }
 
     // TODO: Add LD_LIBRARY_PATH and RPATH handling
-    if(AddNeededLib(maplib, neededlibs, deplib, local, bindnow, nlibs, cnt, box64)) {
+    if(AddNeededLib(maplib, neededlibs, deplib, local, bindnow, nlibs, cnt, box64, init_main_elf)) {
         printf_log(LOG_INFO, "Error loading one of needed lib\n");
         if(!allow_missing_libs)
             return 1;   //error...

--- a/target/i386/latx/context/librarian.c
+++ b/target/i386/latx/context/librarian.c
@@ -299,7 +299,7 @@ int AddNeededLib_add(lib_t* maplib, needed_libs_t* neededlibs, library_t* deplib
     return 0;
 }
 
-int AddNeededLib(lib_t* maplib, needed_libs_t* neededlibs, library_t* deplib, int local, int bindnow, const char** paths, int npath, box64context_t* box64)
+int AddNeededLib(lib_t* maplib, needed_libs_t* neededlibs, library_t* deplib, int local, int bindnow, const char** paths, int npath, box64context_t* box64, int init_main_elf)
 {
     if(!neededlibs) {
         neededlibs = box_calloc(1, sizeof(needed_libs_t));

--- a/target/i386/latx/context/myalign.c
+++ b/target/i386/latx/context/myalign.c
@@ -2069,7 +2069,7 @@ static void init_main_elf(elfheader_t* elf_header,int fd, uintptr_t load_addr,
 
     AddMainElfToLinkmap(elf_header);
 
-    if (LoadNeededLibs(elf_header, my_context->maplib, &my_context->neededlibs, NULL, 0, 0, my_context)) {
+    if (LoadNeededLibs(elf_header, my_context->maplib, &my_context->neededlibs, NULL, 0, 0, my_context, 1 /* init_main_elf */)) {
         printf_log(LOG_INFO, "Error: loading needed libs in elf %s\n", my_context->argv[0]);
     }
     ResetSpecialCaseMainElf(elf_header);
@@ -2235,12 +2235,12 @@ static void kzt_tb_callback(CPUX86State *env)
     library_t* lib = NewLibrary(rbasename, my_context);
     if (lib) {
         const char* libs[] = {rbasename};
-        AddNeededLib(my_context->maplib, &my_context->neededlibs, NULL, 0, 1, libs, 1, my_context);
+        AddNeededLib(my_context->maplib, &my_context->neededlibs, NULL, 0, 1, libs, 1, my_context, 0 /* not init_main_elf */);
     }
     if (!lib && (!strncmp(rbasename, "libSDL", 6)||!strncmp(rbasename, "libCgGL.so", strlen("libCgGL.so")))) {
         printf_log(LOG_DEBUG, "%s libSDL need libGL.so.1\n", __func__);
         const char* libs[] = {"libGL.so.1"};
-        AddNeededLib(my_context->maplib, &my_context->neededlibs, NULL, 0, 1, libs, 1, my_context);
+        AddNeededLib(my_context->maplib, &my_context->neededlibs, NULL, 0, 1, libs, 1, my_context, 0 /* not init_main_elf */);
     }
     FILE *f = fopen(rfilename, "rb");
     if(!f) {
@@ -2261,7 +2261,7 @@ static void kzt_tb_callback(CPUX86State *env)
         findx86pthread_setcanceltype(h);
     }
     AddElfHeader(my_context, h);
-    LoadNeededLibs(h, my_context->maplib, &my_context->neededlibs, NULL, 0, 0, my_context);
+    LoadNeededLibs(h, my_context->maplib, &my_context->neededlibs, NULL, 0, 0, my_context, 0 /* not init_main_elf */);
     RelocateElf(my_context->maplib, NULL, 0, h);
     RelocateElfPlt(my_context->maplib, NULL, 0, h);
     if (lib) {

--- a/target/i386/latx/context/wrappedlibdl.c
+++ b/target/i386/latx/context/wrappedlibdl.c
@@ -213,7 +213,7 @@ void* my_dlopen(void *filename, int flag){
             return NULL;
 #endif
         }
-        if(AddNeededLib(NULL, NULL, NULL, is_local, bindnow, libs, 1, my_context)) {
+        if(AddNeededLib(NULL, NULL, NULL, is_local, bindnow, libs, 1, my_context, 0 /* not init_main_elf */)) {
             printf_dlsym(strchr(rfilename,'/')?LOG_DEBUG:LOG_INFO, "Warning: Cannot dlopen(\"%s\"/%p, %X)\n", rfilename, filename, flag);
             if(!dl->last_error)
                 dl->last_error = box_malloc(129);
@@ -392,7 +392,7 @@ void* my_dlsym(void *handle, void *symbol){
                 //if file is wrapped.
                 iswrapped = 1;
                 printf_dlsym(LOG_DEBUG, "find lib \"%s\" shuold be wrapped. init it.\n", libs[0]);
-                if(AddNeededLib(NULL, NULL, NULL, 0, 1, libs, 1, my_context)) {
+                if(AddNeededLib(NULL, NULL, NULL, 0, 1, libs, 1, my_context, 0 /* not init_main_elf */)) {
                     printf_dlsym(LOG_DEBUG, "Warning: Cannot AddNeededLib(\"%s\")\n", libs[0]);
                 }
                 printf_dlsym(LOG_DEBUG, "info: success AddNeededLib(\"%s\")\n", libs[0]);

--- a/target/i386/latx/include/elfloader.h
+++ b/target/i386/latx/include/elfloader.h
@@ -32,7 +32,7 @@ int RelocateElf(lib_t *maplib, lib_t *local_maplib, int bindnow, elfheader_t* he
 int RelocateElfPlt(lib_t *maplib, lib_t* local_maplib, int bindnow, elfheader_t* head);
 void CalcStack(elfheader_t* h, uint64_t* stacksz, size_t* stackalign);
 void AddSymbols(lib_t *maplib, kh_mapsymbols_t* mapsymbols, kh_mapsymbols_t* weaksymbols, kh_mapsymbols_t* localsymbols, elfheader_t* h);
-int LoadNeededLibs(elfheader_t* h, lib_t *maplib, needed_libs_t* neededlibs, library_t *deplib, int local, int bindnow, box64context_t *box64);
+int LoadNeededLibs(elfheader_t* h, lib_t *maplib, needed_libs_t* neededlibs, library_t *deplib, int local, int bindnow, box64context_t *box64, int init_main_elf);
 
 uintptr_t GetElfInit(elfheader_t* h);
 uintptr_t GetElfFini(elfheader_t* h);

--- a/target/i386/latx/include/librarian.h
+++ b/target/i386/latx/include/librarian.h
@@ -29,7 +29,7 @@ kh_mapsymbols_t* GetMapSymbol(lib_t* maplib);
 kh_mapsymbols_t* GetWeakSymbol(lib_t* maplib);
 kh_mapsymbols_t* GetLocalSymbol(lib_t* maplib);
 kh_mapsymbols_t* GetGlobalData(lib_t* maplib);
-int AddNeededLib(lib_t* maplib, needed_libs_t* neededlibs, library_t *deplib, int local, int bindnow, const char** paths, int npath, box64context_t* box64); // 0=success, 1=error
+int AddNeededLib(lib_t* maplib, needed_libs_t* neededlibs, library_t *deplib, int local, int bindnow, const char** paths, int npath, box64context_t* box64, int init_main_elf); // 0=success, 1=error
 int AddNeededLib_add(lib_t* maplib, needed_libs_t* neededlibs, library_t* deplib, int local, const char* path, box64context_t* box64);
 library_t* GetLibMapLib(lib_t* maplib, const char* name);
 library_t* GetLibInternal(const char* name);

--- a/target/i386/latx/include/library.h
+++ b/target/i386/latx/include/library.h
@@ -25,6 +25,9 @@ int EmuLib_GetNoWeak(library_t* lib, const char* name, uintptr_t *offs, uintptr_
 int EmuLib_GetLocal(library_t* lib, const char* name, uintptr_t *offs, uintptr_t *sz, int version, const char* vername, int local);
 int NativeLib_GetLocal(library_t* lib, const char* name, khint_t pre_k, uintptr_t *offs, uintptr_t *sz, int version, const char* vername, int local);
 
+void FreeLoadedLibs(void);
+GList* FindLoadedLibs(const char* path);
+void AppendLoadedLibs(const char* path);
 library_t *NewLibrary(const char* path, box64context_t* box64);
 int ReloadLibrary(library_t* lib);
 int FinalizeLibrary(library_t* lib, lib_t* local_maplib, int bindnow);


### PR DESCRIPTION
Hi,

精简测试用例[1]优化之前：
```
Trying to add "libpthread.so.0" to maplib
Trying to add "libm.so.6" to maplib
Trying to add "libdl.so.2" to maplib
Trying to add "libc.so.6" to maplib
Trying to add "libc.so.6" to maplib
Trying to add "libdl.so.2" to maplib
Trying to add "libc.so.6" to maplib
Trying to add "libc.so.6" to maplib
Trying to add "libc.so.6" to maplib
```

优化之后：
```
Trying to add "libpthread.so.0" to maplib
Trying to add "libm.so.6" to maplib
Trying to add "libdl.so.2" to maplib
Trying to add "libc.so.6" to maplib
Trying to add "libc.so.6" to maplib
Trying to add "libc.so.6" to maplib
Trying to add "libc.so.6" to maplib
```

ELF实际NEEDED依赖库：
```
$ gcc rt.c -lpthread -lm -ldl -o hello-x64
$ ldd ./hello-x64 
    linux-vdso.so.1 =>  (0x00007ffe38199000)
    libpthread.so.0 => /lib64/libpthread.so.0 (0x00007f70fe733000)
    libm.so.6 => /lib64/libm.so.6 (0x00007f70fe431000)
    libdl.so.2 => /lib64/libdl.so.2 (0x00007f70fe22d000)
    libc.so.6 => /lib64/libc.so.6 (0x00007f70fde5f000)
    /lib64/ld-linux-x86-64.so.2 (0x00007f70fe94f000)
```

通过了7z、dav1d、scimark4_c和glmark2测试用例，以及JNI库直通测试用例。
修复了glmark2暴露出之前[AddNeededLib优化](https://github.com/lat-opensource/lat/pull/16/files#diff-0fa436f5eafc6d91abffc0014c83b264be0b8bc03d8f71df0a2bfbb3855f7263)引入的回退：
```
glmark2
...
Error: Failed to load libGL
Error: main: Could not initialize canvas
```
[libGL库直通](https://github.com/lat-opensource/lat/blob/master/target/i386/latx/context/wrappedlibgl.c#L156)后续再看看，感觉`AddNeededLib`还是有机会优化掉“重复的库”使得`Trying to add`与ELF的NEEDED保持一致。

请代码评审。

[1] 精简测试用例
```
#include <stdio.h>
#include <pthread.h>
#include <math.h>
#include <dlfcn.h>
#include <gnu/lib-names.h>

#define PI 3.1415926

double (*cosine)(double);

static void* callback(void* arg)
{
  printf("%s:%d %f\n", __func__, __LINE__, sin(30 * PI / 180.0));
}

int main(int argc, char* argv[])
{
  pthread_t tid;
  printf("Hello World\n");
  void* handle = dlopen(LIBM_SO, RTLD_LAZY);
  if (handle) {
    printf("%s:%d 0x%lx\n", __func__, __LINE__, handle);
    cosine = (double (*)(double)) dlsym(handle, "cos");
    if (cosine) {
      printf("%s:%d %f\n", __func__, __LINE__, cosine(60 * PI / 180.0));
    }
    dlclose(handle);
    handle = NULL;
  } else {
    printf("%s\n", dlerror());
  }
  pthread_create(&tid, NULL, callback, NULL);
  pthread_join(tid, NULL);
  return 0;
}
```

Thanks,
Leslie Zhai