### PR TITLE
LATX, fix: disable KZT by default

### DIFF
--- a/target/i386/latx/latx-options.c
+++ b/target/i386/latx/latx-options.c
@@ -5,7 +5,7 @@
 #include "latx-debug.h"
 
 #if defined(CONFIG_LATX_KZT)
-int option_kzt = 1;
+int option_kzt = 0;
 #endif
 
 #ifdef CONFIG_LATX_FLAG_REDUCTION


### PR DESCRIPTION
默认关闭库直通选项，如有库直通加速需求可通过环境变量 LATX_KZT=1 手动开启