### PR TITLE
LATX, fix: Fix Assertion `(rj >= 11 && rj <= 20)' failed

### DIFF
--- a/include/qemu/osdep.h
+++ b/include/qemu/osdep.h
@@ -37,6 +37,7 @@
 #define UC_GR(uc) ((uc)->uc_mcontext.__gregs)
 #define UC_PC(uc) ((uc)->uc_mcontext.__pc)
 #ifndef CONFIG_LOONGARCH_NEW_WORLD
+ #define UC_SCR(uc) ((uc)->uc_mcontext.__fpregs->__val64)
  #define UC_FREG(uc) ((uc)->uc_mcontext.__fpregs)
  #define UC_FCSR(uc) ((uc)->uc_mcontext.__fcsr)
 #endif

--- a/target/i386/latx/include/latx-config.h
+++ b/target/i386/latx/include/latx-config.h
@@ -6,6 +6,7 @@
 #include "exec/exec-all.h"
 #include "latx-disassemble-trace.h"
 
+extern void *interpret_glue;
 extern ADDR context_switch_bt_to_native;
 #if defined(CONFIG_LATX_KZT)
 int target_latx_ld_callback(void *code_buf_addr, void (*kzt_tb_callback)(CPUX86State *));
@@ -13,6 +14,7 @@ int target_latx_ld_callback(void *code_buf_addr, void (*kzt_tb_callback)(CPUX86S
 
 int target_latx_host(CPUArchState *env, struct TranslationBlock *tb, int max_insns);
 int target_latx_prologue(void *code_buf_addr);
+void latx_interpret_glue_init(void);
 int target_latx_epilogue(void *code_buf_addr);
 int target_latx_fpu_rotate(void *code_buf_addr);
 void latx_tb_set_jmp_target(struct TranslationBlock *, int, struct TranslationBlock *);

--- a/target/i386/latx/latx-config.c
+++ b/target/i386/latx/latx-config.c
@@ -215,6 +215,16 @@ int target_latx_ld_callback(void *code_buf_addr, void (*kzt_tb_callback)(CPUX86S
 }
 #endif
 
+void latx_interpret_glue_init(void)
+{
+    interpret_glue = mmap(NULL, qemu_host_page_size,
+                            PROT_EXEC | PROT_READ | PROT_WRITE,
+                            MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (interpret_glue == MAP_FAILED) {
+        fprintf(stderr, "[LATX-LOG] alloc interpret_glue error!\n");
+    }
+}
+
 /*
  * prologue <=> bt to native
  */

--- a/target/i386/latx/translator/translate.c
+++ b/target/i386/latx/translator/translate.c
@@ -57,6 +57,7 @@ ADDR context_switch_bt_to_native;
 ADDR context_switch_native_to_bt_ret_0;
 ADDR context_switch_native_to_bt;
 ADDR ss_match_fail_native;
+void *interpret_glue;
 
 ADDR native_rotate_fpu_by; /* native_rotate_fpu_by(step, return_address) */
 ADDR indirect_jmp_glue;

--- a/tcg/loongarch/tcg-target.c.inc
+++ b/tcg/loongarch/tcg-target.c.inc
@@ -1782,6 +1782,7 @@ static void tcg_target_qemu_prologue(TCGContext *s)
 
     int inst_nr = 0;
 
+    latx_interpret_glue_init();
 // --------------------------------- prologue ------------------------------- //
     inst_nr = target_latx_prologue(s->code_ptr);
     if (option_dump)


### PR DESCRIPTION
In the function shared_private_interpret(), the base register of the faulting instruction was overwriting with the shadow page address. If the base register was not a itemp reg, this could corrupt its value and break subsequent instructions.

CLOSES #39