### PR TITLE
LATX, fix: SIGSEGV handling support for new world

### DIFF
--- a/accel/tcg/translate-all.c
+++ b/accel/tcg/translate-all.c
@@ -4314,11 +4314,20 @@ static void set_interpret_glue_code(ucontext_t *uc, unsigned int inst, int rj)
 {
     int cpu_index = current_cpu->cpu_index;
     uint32_t *glue = cpu_index * 4 + interpret_glue;
-
+#ifndef CONFIG_LOONGARCH_NEW_WORLD
     /* save guest addr to scr0 */
     UC_SCR(uc)[0] = UC_GR(uc)[rj];
     /* save epc to scr1 */
     UC_SCR(uc)[1] = UC_PC(uc) + 4;
+#else
+    struct extctx_layout extctx;
+    memset(&extctx, 0, sizeof(extctx));
+    parse_extcontext(uc, &extctx);
+    /* save guest addr to scr0 */
+    UC_LBT(&extctx)->regs[0] = UC_GR(uc)[rj];
+    /* save epc to scr1 */
+    UC_LBT(&extctx)->regs[1] = UC_PC(uc) + 4;
+#endif
     /*
      * glue:
      *     inst

--- a/linux-user/signal.c
+++ b/linux-user/signal.c
@@ -1031,12 +1031,12 @@ static void host_signal_handler(int host_signum, siginfo_t *info,
         if (current_tb) {
             /* clear scr0 */
 #ifndef CONFIG_LOONGARCH_NEW_WORLD
-            UC_FREG(uc)[0].__val64[0] = 0;
+            UC_SCR(uc)[0] = 0;
 #else
-	    struct extctx_layout extctx;
-	    memset(&extctx, 0, sizeof(extctx));
-	    parse_extcontext(uc, &extctx);
-	    UC_LBT(&extctx)->regs[0] = 0;
+            struct extctx_layout extctx;
+            memset(&extctx, 0, sizeof(extctx));
+            parse_extcontext(uc, &extctx);
+            UC_LBT(&extctx)->regs[0] = 0;
 #endif
             /* set the next TB and point the epc to the epilogue */
             UC_GR(uc)[reg_statics_map[S_UD1]] = current_tb->pc;

--- a/target/i386/latx/latx-signal.c
+++ b/target/i386/latx/latx-signal.c
@@ -59,7 +59,7 @@ void unlink_indirect_jmp(CPUArchState *env, TranslationBlock *tb, ucontext_t *uc
 
 #ifndef CONFIG_LOONGARCH_NEW_WORLD
     /* clear scr0 */
-    UC_FREG(uc)[0].__val64[0] = 0;
+    UC_SCR(uc)[0] = 0;
 #else
     struct extctx_layout extctx;
     memset(&extctx, 0, sizeof(extctx));


### PR DESCRIPTION
This patch adds support for SIGSEGV handling in the new world of LATX.
As `UC_SCR` is not supported in the new world, we need to use extcontext
to modify the `SCR` in signal context.

Close #41

Signed-off-by: Qi HU <github@spcsky.com>