### PR TITLE
LATX, fix: SIGSEGV handling support for new world

### DIFF
--- a/accel/tcg/translate-all.c
+++ b/accel/tcg/translate-all.c
@@ -4310,6 +4310,7 @@ static bool no_right(int64_t addr, int bit_count,
     return false;
 }
 
+#ifndef CONFIG_LOONGARCH_NEW_WORLD
 static void set_interpret_glue_code(ucontext_t *uc, unsigned int inst, int rj)
 {
     int cpu_index = current_cpu->cpu_index;
@@ -4330,6 +4331,7 @@ static void set_interpret_glue_code(ucontext_t *uc, unsigned int inst, int rj)
     glue[2] = 0x48000300;
     UC_PC(uc) = (unsigned long)glue;
 }
+#endif
 
 int shared_private_interpret(siginfo_t *info, ucontext_t *uc)
 {

--- a/linux-user/signal.c
+++ b/linux-user/signal.c
@@ -1030,14 +1030,14 @@ static void host_signal_handler(int host_signum, siginfo_t *info,
         TranslationBlock *current_tb = tcg_tb_lookup(UC_PC(uc));
         if (current_tb) {
             /* clear scr0 */
-#ifndef CONFIG_LOONGARCH_NEW_WORLD
-            UC_FREG(uc)[0].__val64[0] = 0;
-#else
-	    struct extctx_layout extctx;
-	    memset(&extctx, 0, sizeof(extctx));
-	    parse_extcontext(uc, &extctx);
-	    UC_LBT(&extctx)->regs[0] = 0;
-#endif
+ #ifndef CONFIG_LOONGARCH_NEW_WORLD
+            UC_SCR(uc)[0] = 0;
+ #else
+	        struct extctx_layout extctx;
+	        memset(&extctx, 0, sizeof(extctx));
+	        parse_extcontext(uc, &extctx);
+	        UC_LBT(&extctx)->regs[0] = 0;
+ #endif
             /* set the next TB and point the epc to the epilogue */
             UC_GR(uc)[reg_statics_map[S_UD1]] = current_tb->pc;
             UC_PC(uc) = context_switch_native_to_bt_ret_0;

--- a/target/i386/latx/latx-signal.c
+++ b/target/i386/latx/latx-signal.c
@@ -59,7 +59,7 @@ void unlink_indirect_jmp(CPUArchState *env, TranslationBlock *tb, ucontext_t *uc
 
 #ifndef CONFIG_LOONGARCH_NEW_WORLD
     /* clear scr0 */
-    UC_FREG(uc)[0].__val64[0] = 0;
+    UC_SCR(uc)[0] = 0;
 #else
     struct extctx_layout extctx;
     memset(&extctx, 0, sizeof(extctx));


### PR DESCRIPTION
This patch adds support for SIGSEGV handling in the new world of LATX. As `UC_SCR` is not supported in the new world, we need to use extcontext to modify the `SCR` in signal context.

CLOSE #41