### PR TITLE
LATX, fix: Fix struct target_stat64

### DIFF
--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -13609,8 +13609,6 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
                 __put_user(st.st_ctim.tv_nsec,
                            &target_st->target_st_ctime_nsec);
 #endif
-                /* workaround for wineserver64 + wine32 */
-                target_st->st_dev = target_st->st_dev & 0xffff;
                 unlock_user_struct(target_st, arg2, 1);
             }
         }

--- a/linux-user/syscall_defs.h
+++ b/linux-user/syscall_defs.h
@@ -1680,8 +1680,8 @@ struct target_stat {
  */
 #define TARGET_HAS_STRUCT_STAT64
 struct target_stat64 {
-	unsigned short	st_dev;
-	unsigned char	__pad0[10];
+    unsigned long long st_dev;
+    unsigned int    __pad1;
 
 #define TARGET_STAT64_HAS_BROKEN_ST_INO	1
 	abi_ulong	__st_ino;


### PR DESCRIPTION
之前对 fstat 的 st_dev 按照 32 位的系统调用进行了截断，是为了解决 deepin-wine6 运行失败的问题。该 wine 使用 64 位的 server 和 32 位的 client，两端通信依赖使用 st_dev 建立的目录，如"/tmp/.wine-1000/server-305-166a42"。server 使用的 st_dev 为 10305 client 使用的为 305，无法建立通信，因此在 fstat 的模拟中将 10305 截断。

上述方法并未从根本上解决问题，其根因为翻译器中 target_stat64 结构中 st_dev 定义 不恰当，本补丁进行了修复。

CLOSE: 27