### PR TITLE
LATX, doc: recommend oma for AOSC OS

### DIFF
--- a/README.en.rst
+++ b/README.en.rst
@@ -183,7 +183,7 @@ STEP2:
 
 .. code-block:: bash
 
-    apt install -y gcc nettle pcre2 libffi gnutls glib zlib glib-static libgcrypt-static libgpg-error-static libnfs-static pcre-static zlib-static zstd-static openssl-static
+    oma install -y gcc nettle pcre2 libffi gnutls glib zlib glib-static libgcrypt-static libgpg-error-static libnfs-static pcre-static zlib-static zstd-static openssl-static
 
 
 STEP3:

--- a/README.rst
+++ b/README.rst
@@ -166,7 +166,7 @@ STEP2:
 
 .. code-block:: bash
 
-    apt install -y gcc nettle pcre2 libffi gnutls glib zlib glib-static libgcrypt-static libgpg-error-static libnfs-static pcre-static zlib-static zstd-static openssl-static
+    oma install -y gcc nettle pcre2 libffi gnutls glib zlib glib-static libgcrypt-static libgpg-error-static libnfs-static pcre-static zlib-static zstd-static openssl-static
 
 
 STEP3:


### PR DESCRIPTION
AOSC OS uses oma as its default package manager (apt is supplied as a fallback).

See: https://aosc.io/oma
See: https://github.com/AOSC-Dev/oma