### PR TITLE
fix build error in anolis

### DIFF
--- a/README.en.rst
+++ b/README.en.rst
@@ -162,7 +162,7 @@ STEP1:
 .. code-block:: bash
 
     git clone --depth=1 --recursive https://github.com/lat-opensource/lat
-    cd lat/latxbuild
+    cd lat
 
 
 STEP2:
@@ -190,7 +190,7 @@ STEP3:
 
 .. code-block:: bash
 
-    ./build-release.sh
+    ./latxbuild/build-release.sh
 
 
 Future Plans (TODO)

--- a/README.rst
+++ b/README.rst
@@ -145,7 +145,7 @@ STEP1:
 .. code-block:: bash
 
     git clone --depth=1 --recursive https://github.com/lat-opensource/lat
-    cd lat/latxbuild
+    cd lat
 
 
 STEP2:
@@ -173,7 +173,7 @@ STEP3:
 
 .. code-block:: bash
 
-    ./build-release.sh
+    ./latxbuild/build-release.sh
 
 
 未来规划（TODO）

--- a/latxbuild/build-release.sh
+++ b/latxbuild/build-release.sh
@@ -55,7 +55,6 @@ build() {
         --disable-docs
         --disable-werror
         --disable-pie
-        --static
         --disable-linux-io-uring
     )
 


### PR DESCRIPTION
1、进到lat/latxbuild中执行build-release.sh会提示找不到VERSION，按照readme无法正确编译
2、在rpm系列的操作系统中部分库文件只有动态库，没有静态库，建议删除static参数