### PR TITLE
LATX, linux-user: add support for epoll_pwait2 syscall

### DIFF
--- a/linux-user/i386/syscall_32.tbl
+++ b/linux-user/i386/syscall_32.tbl
@@ -444,3 +444,4 @@
 437	i386	openat2			sys_openat2
 438	i386	pidfd_getfd		sys_pidfd_getfd
 439	i386	faccessat2		sys_faccessat2
+441	i386	epoll_pwait2		sys_epoll_pwait2		compat_sys_epoll_pwait2

--- a/linux-user/x86_64/syscall_64.tbl
+++ b/linux-user/x86_64/syscall_64.tbl
@@ -361,6 +361,7 @@
 437	common	openat2			sys_openat2
 438	common	pidfd_getfd		sys_pidfd_getfd
 439	common	faccessat2		sys_faccessat2
+441	common	epoll_pwait2		sys_epoll_pwait2
 
 #
 # x32-specific system call numbers start at 512 to avoid cache impact


### PR DESCRIPTION
标题：LATX, linux-user：增加 `epoll_pwait2` 系统调用的支持

此补丁添加了 `epoll_pwait2` 系统调用（syscall）的支持。Wine 10.x 版本会在支持该系统调用的平台上使用这个新的系统调用。

/ English version follows

This pull request adds support for `epoll_pwait2`. Wine 10.x will use this syscall on newer systems where it is available.