### PR TITLE
Revert "LATX, fix: Fix ioctl command mismatch due to high 16 bits"

### DIFF
--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -8159,21 +8159,13 @@ static abi_long do_ioctl(int fd, int cmd, abi_ulong arg)
     ie += ioctl_cache_val;
 
 #ifdef TARGET_X86_64
-    if ((uint16_t)ioctl_cache_unsupported_cmd[hash] == (uint16_t)cmd) {
+    if (ioctl_cache_unsupported_cmd[hash] == cmd) {
         ret = get_errno(safe_ioctl(fd, cmd, arg));
         return ret;
     }
 #endif
     /* slow path to iterate the ioctl_entries */
-    if ((uint16_t)ie->target_cmd != (uint16_t)cmd) {
-#ifdef CONFIG_LATX_DEBUG
-        if (ie->target_cmd != cmd) {
-            qemu_log_mask(LAT_LOG_SYSCALL,
-                    "[LATX_SYSCALL] do_ioctl fd " TARGET_FMT_ld
-                    " cmd 0x" TARGET_FMT_lx " ie->target_cmd != cmd\n",
-                    arg1, arg2);
-        }
-#endif
+    if (ie->target_cmd != cmd) {
         switch(TARGET_IOC_NR(cmd)) {
             case TARGET_IOC_NR(TARGET_HIDIOCSFEATURE(0)):
             case TARGET_IOC_NR(TARGET_HIDIOCGFEATURE(0)):
@@ -8198,7 +8190,7 @@ static abi_long do_ioctl(int fd, int cmd, abi_ulong arg)
                 return -TARGET_ENOSYS;
 #endif
             }
-            if ((uint16_t)ie->target_cmd == (uint16_t)cmd) {
+            if (ie->target_cmd == cmd) {
                 ioctl_cache[hash] = i;
 #ifdef TARGET_X86_64
                 ioctl_cache_unsupported_cmd[hash] = 0;


### PR DESCRIPTION
测试发现该补丁破坏了 64 位 ioctl 的兼容性，revert.

This reverts commit 7892d979813c550df04ed84c537df2b5864eb6d5.