### PR TITLE
Fix pandoc

### DIFF
--- a/linux-user/main.c
+++ b/linux-user/main.c
@@ -682,6 +682,11 @@ static void handle_arg_mmap_start(const char *arg)
     mmap_next_start = strtol(arg, NULL, 0);
 }
 
+static void handle_arg_mmap_fixed(const char *arg)
+{
+    option_mmap_fixed = strtol(arg, NULL, 0);
+}
+
 static void handle_arg_latx_mem_test(const char *arg)
 {
     option_mem_test = strtol(arg, NULL, 0);
@@ -817,6 +822,8 @@ static const struct qemu_argument arg_table[] = {
     "",           "anonymize latx for guest"},
     {"latx-mmap_start",    "LATX_MMAP_START",     true,  handle_arg_mmap_start,
     "",           "adjust the initial address of mmap"},
+    {"latx-mmap_fixed",    "LATX_MMAP_FIXED",     true,  handle_arg_mmap_fixed,
+    "",           "force mmap with address to be MAP_FIXED"},
 #endif
 #if defined(CONFIG_LATX_DEBUG) || defined(CONFIG_DEBUG_TCG)
 #ifdef CONFIG_LATX

--- a/linux-user/mmap.c
+++ b/linux-user/mmap.c
@@ -626,6 +626,7 @@ abi_ulong mmap_find_vma_2g(abi_ulong start, abi_ulong size, abi_ulong align)
 extern int latx_wine;
 void kzt_wine_bridge(abi_ulong start, int fd);
 #endif
+abi_ulong option_mmap_fixed;
 abi_long target_mmap(abi_ulong start, abi_ulong len, int target_prot,
                      int flags, int fd, uint64_t offset, int rlimit_as_account)
 {
@@ -640,6 +641,8 @@ abi_long target_mmap(abi_ulong start, abi_ulong len, int target_prot,
         len = 0x4000;
     }
 #endif
+    if (start && option_mmap_fixed)
+        flags |= MAP_FIXED;
 
     mmap_lock();
     trace_target_mmap(start, len, target_prot, flags, fd, offset);

--- a/linux-user/qemu.h
+++ b/linux-user/qemu.h
@@ -529,6 +529,7 @@ abi_long target_mremap(abi_ulong old_addr, abi_ulong old_size,
                        abi_ulong new_addr, int rlimit_as_account);
 int target_msync(abi_ulong start, abi_ulong len, int flags);
 extern unsigned long last_brk;
+extern abi_ulong option_mmap_fixed;
 extern abi_ulong mmap_next_start;
 abi_ulong mmap_find_vma(abi_ulong, abi_ulong, abi_ulong);
 void mmap_fork_start(void);


### PR DESCRIPTION
Some applications use mmap with address hint but without MAP_FIXED set.
If a different address returned, the application would not behave correctly.

Add a flag LATX_MMAP_FIXED to control this.

use `export LATX_MMAP_FIXED=1` to enable.

CLOSES #67


The sencond commit fix madvise create too many PageFlagsNode, makes pandoc too slow.