### PR TITLE
build: Remove autogenerated version header and use meson option

### DIFF
--- a/linux-user/main.c
+++ b/linux-user/main.c
@@ -55,7 +55,6 @@ int mydebug = 1;
 #include "latx-config.h"
 #include "latx-options.h"
 #include "aot.h"
-#include "latx-version.h"
 #include <openssl/evp.h>
 #endif
 #ifdef CONFIG_LATX_PERF

--- a/meson.build
+++ b/meson.build
@@ -16,11 +16,6 @@ sh = find_program('sh')
 cc = meson.get_compiler('c')
 config_host = keyval.load(meson.current_build_dir() / 'config-host.mak')
 enable_static = 'CONFIG_STATIC' in config_host
-
-latx_version_h = vcs_tag(command : ['git', 'describe'],
-                        fallback : 'unknown',
-			input : 'linux-user/latx-version.h.in',
-                        output :'latx-version.h')
 # Allow both shared and static libraries unless --enable-static
 static_kwargs = enable_static ? {'static': true} : {}
 
@@ -97,6 +92,16 @@ endif
 ################
 # Dependencies #
 ################
+
+latx_version = get_option('latx_version')
+if latx_version == ''
+  latx_version = run_command('git', 'describe', '--always', check: false).stdout().strip()
+endif
+if latx_version == ''
+  latx_version = 'unknown'
+endif
+
+add_project_arguments('-DLATX_VERSION="' + latx_version + '"', language: ['c', 'cpp'])
 
 # The path to glib.h is added to all compilation commands.  This was
 # grandfathered in from the QEMU Makefiles.

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -127,3 +127,5 @@ option('fdt', type: 'combo', value: 'auto',
        description: 'Whether and how to find the libfdt library')
 option('tests', type : 'feature', value : 'auto',
        description: 'Tests build support')
+option('latx_version', type: 'string', value: '',
+       description: 'Custom version string')

--- a/target/i386/latx/include/aot.h
+++ b/target/i386/latx/include/aot.h
@@ -10,7 +10,6 @@
 #include "qemu/cutils.h"
 #include "qemu/units.h"
 #include "segment.h"
-#include "latx-version.h"
 #include "aot_link_seg.h"
 #include "ts.h"
 #include "aot_lib.h"


### PR DESCRIPTION
修正在 `QEMU` 环境中构建失败的问题
- https://github.com/loong64/lat/actions/runs/14941307230/job/41978743809

```sh
438.8                  from ../target/i386/latx/include/profile.h:7,
438.8                  from ../target/i386/latx/latx-config.c:10:
438.8 ../target/i386/latx/include/aot.h:13:10: fatal error: latx-version.h: No such file or directory
438.8    13 | #include "latx-version.h"
438.8       |          ^~~~~~~~~~~~~~~~
```