### PR TITLE
[WRAPPER] Add bridge for Display's resource_alloc when directly call XOpenIM but not XOpenDisplay

### DIFF
--- a/target/i386/latx/include/generated/wrappedlibx11types.h
+++ b/target/i386/latx/include/generated/wrappedlibx11types.h
@@ -34,6 +34,7 @@ typedef int32_t (*iFpppllipppppp_t)(void*, void*, void*, intptr_t, intptr_t, int
 typedef void* (*pFppiiuuuiupLp_t)(void*, void*, int32_t, int32_t, uint32_t, uint32_t, uint32_t, int32_t, uint32_t, void*, uintptr_t, void*);
 typedef void* (*pFppLp_t)(void*, void*, uintptr_t, void*);
 typedef int32_t (*iFppLp_t)(void*, void*, uintptr_t, void*);
+typedef void* (*pFpppp_t)(void*, void*, void*, void*);
 
 #define SUPER() ADDED_FUNCTIONS() \
         GO(XDestroyImage, iFp_t) \
@@ -75,7 +76,8 @@ typedef int32_t (*iFppLp_t)(void*, void*, uintptr_t, void*);
         GO(XCreateWindow, pFppiiuuuiupLp_t) \
         GO(XFreeColormap, iFpp_t) \
         GO(XCreateGC, pFppLp_t) \
-        GO(XChangeGC, iFppLp_t)
+        GO(XChangeGC, iFppLp_t) \
+        GO(XOpenIM, pFpppp_t)
 /*
 #define SUPER() ADDED_FUNCTIONS() \
         GO(XOpenDisplay, pFp_t)

--- a/target/i386/latx/include/wrappedlibx11_private.h
+++ b/target/i386/latx/include/wrappedlibx11_private.h
@@ -838,7 +838,7 @@ GO(XNoOp, iFp)
 GO(XOffsetRegion, iFpii)
 GO(XOMOfOC, pFp)
 GOM(XOpenDisplay, pFEp)
-GO(XOpenIM, pFpppp)
+GOM(XOpenIM, pFpppp)
 // _XOpenLC
 GO(XOpenOM, pFpppp)
 // _XParseBaseFontNameList


### PR DESCRIPTION
Hi,

测试用例：[Scilab 6.0.1](https://www.scilab.org/download/6.0.1/scilab-6.0.1.bin.linux-x86_64.tar.gz)
Display的resource_alloc入口地址是本地LoongArch原生代码入口地址，测试用例没有调用XOpenDisplay，而是调用XOpenIM，所以需要给XOpenIM添加“bridge”，该补丁实现[XOpenIM添加“bridge”](https://github.com/ptitSeb/box64/pull/2795)，并调用kzt_tbbridge_insert添加resource_alloc用来支持x64上下文回调LA主机入口地址。
测试用例：[Scilab 6.0.1](https://www.scilab.org/download/6.0.1/scilab-6.0.1.bin.linux-x86_64.tar.gz)继续前进。
请review之。

Thanks,
Leslie Zhai