### PR TITLE
LATX, fix: Remove TU_UNLINK_STUB_INVALID

### DIFF
--- a/accel/tcg/cpu-exec.c
+++ b/accel/tcg/cpu-exec.c
@@ -622,8 +622,7 @@ static inline void tb_add_jump(TranslationBlock *tb, int n,
 
 #ifdef CONFIG_LATX_TU
     if (use_tu_jmp(tb)) {
-        assert(tb->tu_jmp[TU_TB_INDEX_TARGET] != TB_JMP_RESET_OFFSET_INVALID
-            && tb->tu_unlink.stub_offset != TU_UNLINK_STUB_INVALID);
+        assert(tb->tu_jmp[TU_TB_INDEX_TARGET] != TB_JMP_RESET_OFFSET_INVALID);
         tu_relink(tb);
         goto out_unlock_next;
     }

--- a/include/exec/exec-all.h
+++ b/include/exec/exec-all.h
@@ -573,7 +573,6 @@ struct TranslationBlock {
 
     union {
         uintptr_t jmp_target_arg[2];  /* target address or offset */
-#define TU_UNLINK_STUB_INVALID 0xffffffff /* TU no unlink stub. */
         struct tu_unlink tu_unlink;
     };
 

--- a/target/i386/latx/latx-signal.c
+++ b/target/i386/latx/latx-signal.c
@@ -220,10 +220,7 @@ void tb_exit_to_qemu(CPUArchState *env, ucontext_t *uc)
 #ifdef CONFIG_LATX_TU
         if (use_tu_jmp(current_tb)) {
             assert(current_tb->tu_jmp[TU_TB_INDEX_TARGET] != TB_JMP_RESET_OFFSET_INVALID);
-            assert(current_tb->tu_unlink.stub_offset != TU_UNLINK_STUB_INVALID);
-            if (current_tb->tu_unlink.stub_offset != TU_UNLINK_STUB_INVALID) {
-                unlink_tu_jmp(current_tb);
-            }
+            unlink_tu_jmp(current_tb);
             return;
         }
 #endif

--- a/target/i386/latx/optimization/tu.c
+++ b/target/i386/latx/optimization/tu.c
@@ -168,7 +168,6 @@ void tu_reset_tb(TranslationBlock *tb)
     tb->jmp_target_arg[TU_TB_INDEX_NEXT] = TB_JMP_RESET_OFFSET_INVALID;
     tb->jmp_stub_reset_offset[0] = TB_JMP_RESET_OFFSET_INVALID;
     tb->jmp_stub_reset_offset[1] = TB_JMP_RESET_OFFSET_INVALID;
-    tb->tu_unlink.stub_offset = TU_UNLINK_STUB_INVALID;
 #endif
 
 #ifdef CONFIG_LATX_AOT
@@ -862,7 +861,6 @@ static void mov_unlink_stub_to_end(uint32_t tb_num_in_tu, TranslationBlock **tb_
     for (int i = 0; i < tb_num_in_tu; i++) {
         tb = tb_list[i];
         if (use_tu_jmp(tb)) {
-            assert(tb->tu_unlink.stub_offset != TU_UNLINK_STUB_INVALID);
 #ifdef CONFIG_LATX_INSTS_PATTERN
             tb->eflags_target_arg[0] = TB_JMP_RESET_OFFSET_INVALID;
             tb->eflags_target_arg[1] = TB_JMP_RESET_OFFSET_INVALID;
@@ -908,7 +906,7 @@ static void mov_unlink_stub_to_end(uint32_t tb_num_in_tu, TranslationBlock **tb_
 
     for (int i = 0; i < tb_num_in_tu; i++) {
         tb = tb_list[i];
-        if (use_tu_jmp(tb) && tb->tu_unlink.stub_offset != TU_UNLINK_STUB_INVALID) {
+        if (use_tu_jmp(tb)) {
             tb->tu_unlink.stub_offset = curr_pos  + tb->tu_unlink.stub_offset
                 - (uintptr_t)tb->tc.ptr;
         }
@@ -942,7 +940,6 @@ void translate_tu(uint32 tb_num_in_tu, TranslationBlock **tb_list)
 retry:
     for (uint32_t i = 0; i < tb_num_in_tu; i++) {
         tb = tb_list[i];
-        tb->tu_unlink.stub_offset = TU_UNLINK_STUB_INVALID;
         gen_code_size = translate_tb_in_tu(tb);
         uintptr_t gen_code_buf = (uintptr_t)tcg_ctx->code_gen_ptr + gen_code_size;
         qatomic_set(&tcg_ctx->code_gen_ptr, (void *)gen_code_buf);

--- a/target/i386/latx/translator/translate.c
+++ b/target/i386/latx/translator/translate.c
@@ -415,10 +415,7 @@ int label_dispose(TranslationBlock *tb, TRANSLATION_DATA *lat_ctx)
                     tb->tu_jmp[i] = ir2_label[label_id];
                 }
             }
-            /* tu_unlink_stub_offset and target_pc are union, tu_unlink_stub_offset always */
-            /* not equal TU_UNLINK_STUB_INVALID in TB_GEN_CODE. */
-            if (tb->s_data->tu_tb_mode != TB_GEN_CODE &&
-                    tb->tu_unlink.stub_offset != TU_UNLINK_STUB_INVALID) {
+            if (use_tu_jmp(tb)) {
                 label_id = tb->tu_unlink.stub_offset;
                 tb->tu_unlink.stub_offset = ir2_label[label_id];
             }


### PR DESCRIPTION
Since jmp_target_arg and tu_unlink are in the same union, initializing tu_unlink with TU_UNLINK_STUB_INVALID may cause some errors. Currently, the validity of tu_unlink can be determined using use_tu_jmp(), therefore UNLINK_STUB_INVALID is being removed.