### PR TITLE
LATX, fix: Fix build64-dbg.sh typo about low memory mode

### DIFF
--- a/latxbuild/build64-dbg.sh
+++ b/latxbuild/build64-dbg.sh
@@ -21,7 +21,7 @@ help() {
 }
 
 parseArgs() {
-    while getopts "cO:h" opt; do
+    while getopts "cO:l:h" opt; do
         case ${opt} in
         c)
             make_configure=1


### PR DESCRIPTION
Hi,

调试debug版发现build64-dbg.sh笔误：
```
Illegal option -l
Usage:
  -c              configure
  -O              [options]
                  defaule: -O 1
                  -O 0 : Disable all optimization, include basic
                  -O 1 : Open stable optimization
                  -O 2 : Open unstable optimization, include O1
                  -O 3 : Open testing optimization, include O2
  -l              low memory mode
                  -l 0 : Open shadow file, close CONFIG_LATX_LARGE_CC
                  -l 1 : l0 + close CONFIG_LATX_SPLIT_TB, CONFIG_LATX_TU, CONFIG_LATX_JRRA
                  -l 2 : l1 + set 64MB code cache, close CONFIG_LATX_INSTS_PATTERN
  -h              help
```

请review之。

Thanks,
Leslie Zhai