### PR TITLE
LATX, fix: Increase NEW_STACK_SIZE to fix wrappedlibjvm assert(k->is_initialized()) failed: need to increase java_thread_min_stack_allowed calculation

### DIFF
--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -8813,7 +8813,7 @@ abi_long do_arch_prctl(CPUX86State *env, int code, abi_ulong addr)
 
 #endif /* defined(TARGET_I386) */
 
-#define NEW_STACK_SIZE 0x40000
+#define NEW_STACK_SIZE 0x200000
 
 
 static pthread_mutex_t clone_lock = PTHREAD_MUTEX_INITIALIZER;


### PR DESCRIPTION
Hi,

将box64的wrappedlibjvm库封装backport到lat跑jtreg测试用例：[runtime/jni/getCreatedJavaVMs/TestGetCreatedJavaVMs.java](https://github.com/openjdk/jdk/blob/master/test/hotspot/jtreg/runtime/jni/getCreatedJavaVMs/exeGetCreatedJavaVMs.c) 复现jdk side断言错误：
```
[2025-08-18T11:08:39.161783530Z] Gathering output for process 5270
[2025-08-18T11:08:39.248516150Z] Waiting for completion for process 5270
[2025-08-18T11:08:42.764097510Z] Waiting for completion finished for process 5270
Output and diagnostic info for process 5270 was saved into 'pid-5270-output.log'
 stdout: [#
# A fatal error has been detected by the Java Runtime Environment:
#
#  Internal Error (/home/zhaixiang/repo/private/jdk-latx/src/hotspot/share/utilities/exceptions.cpp:244), pid=5270, tid=5275
#  assert(k->is_initialized()) failed: need to increase java_thread_min_stack_allowed calculation
#
# JRE version:  (23.0) (fastdebug build )
# Java VM: OpenJDK 64-Bit Server VM (fastdebug 23-internal-adhoc.zhaixiang.jdk-latx, mixed mode, sharing, tiered, compressed oops, compressed class ptrs, g1 gc, linux-loongarch64)
# Problematic frame:
# V  [libjvm.so+0x9ea704]  Exceptions::throw_stack_overflow_exception(JavaThread*, char const*, int, methodHandle const&)+0x504
...
[KZT]: File starting with 'libjvm.' found: libjvm.so at /home/zhaixiang/repo/private/jdk-latx/build/linux-loongarch64-server-fastdebug/images/jdk/lib/server/
BOX64_LD_LIBRARY_PATH: /home/zhaixiang/repo/private/jdk-latx/build/linux-x86_64-server-release/images/jdk/lib/server/
Using default BOX64_PATH: ./:bin/
Adding "/home/zhaixiang/repo/private/jdk-latx/build/linux-x86_64-server-release/images/test/hotspot/jtreg/native/GetCreatedJavaVMs" as #0 in elf collection
Trying to add "libpthread.so.0" to maplib
Trying to load "libpthread.so.0" 
Simplified name is "libpthread.so.0" 
Faillure to create lib => fail
Error loading needed lib libpthread.so.0
Trying to add "libjvm.so" to maplib
Trying to load "libjvm.so" 
Simplified name is "libjvm.so" 
Using native(wrapped) libjvm.so
...
Applying 7 Relocation(s) with Addend for /home/zhaixiang/repo/private/jdk-latx/build/linux-x86_64-server-release/images/test/hotspot/jtreg/native/GetCreatedJavaVMs
Applying 14 PLT Relocation(s) with Addend for /home/zhaixiang/repo/private/jdk-latx/build/linux-x86_64-server-release/images/test/hotspot/jtreg/native/GetCreatedJavaVMs
RelocateElfRELA : Apply Global R_X86_64_JUMP_SLOT @0x5500003fc8 with sym=JNI_GetCreatedJavaVMs (0x5508a8c790 -> 0xfff56a40a0)
elf_data_interpret fix addr 0x5500003fc8
RelocateElfRELA : Apply Global R_X86_64_JUMP_SLOT @0x5500003fd0 with sym=JNI_CreateJavaVM (0x5508a8c510 -> 0xfff56a40c0)
elf_data_interpret fix addr 0x5500003fd0
------------init_tb_callback_bridge--cpu=0xffeecf0010--pid=5270---latx_ld_callback 0xffc800052c to 0xffc8000740----
kzt_add_fucn_by_addr add pc = 55000011fb jmp blok=0xffc800052c tb=0xffa8000000
------------init_tb_callback_bridge--cpu=0xffeecf0010--pid=5270---latx_ld_callback 0xffc8000800 to 0xffc8000a14----
kzt_add_fucn_by_addr add pc = 5508017c15 jmp blok=0xffc8000800 tb=0xffa8000100
------------init_tb_callback_bridge--cpu=0x7f8475aca0--pid=5270---latx_ld_callback 0xffc8000ad0 to 0xffc8000ce4----
kzt_add_fucn_by_addr add pc = 55000011fb jmp blok=0xffc8000ad0 tb=0xffa8000000
------------kzt_add_fucn_by_addr tb has fixed return --cpu=0x7f8475aca0--pid=5270------
------------init_tb_callback_bridge--cpu=0x7f8475aca0--pid=5270---latx_ld_callback 0xffc8000ce4 to 0xffc8000ef8----
kzt_add_fucn_by_addr add pc = 5508017c15 jmp blok=0xffc8000ce4 tb=0xffa8000100
------------kzt_add_fucn_by_addr tb has fixed return --cpu=0x7f8475aca0--pid=5270------
DEBUG: my__JNI_CreateJavaVM:208 ret: 0 vm: 0x5509d73e20 penv: 0x5509d73e28 args: 0x5509d73e30
]
 exitValue = 133

Exception in thread "main" java.lang.RuntimeException: Expected to get exit value of [0], exit value is: [133]
    at jdk.test.lib.process.OutputAnalyzer.shouldHaveExitValue(OutputAnalyzer.java:521)
    at TestGetCreatedJavaVMs.main(TestGetCreatedJavaVMs.java:39)
```

对比box64跑该测试用例通过，通过对比box64的[my_pthread_create的stacksize](https://github.com/ptitSeb/box64/blob/main/src/libtools/threads.c#L508)，该patch将lat的NEW_STACK_SIZE调大到2MB，该jtreg测试用例Passed。

请review之。

Thanks,
Leslie Zhai