### PR TITLE
KZT, fix: Remove return elf_header when elfsize is positive number for FindElfAddress

### DIFF
--- a/target/i386/latx/context/elfloader.c
+++ b/target/i386/latx/context/elfloader.c
@@ -1102,7 +1102,6 @@ elfheader_t* FindElfAddress(box64context_t *context, uintptr_t addr)
     for (int i=0; i<context->elfsize; ++i)
         if(IsAddressInElfSpace(context->elfs[i], addr))
             return context->elfs[i];
-    if(context->elfsize >0) return elf_header;  
     return NULL;
 }
 


### PR DESCRIPTION
Hi,

AOSC开启KZT复现glmark2段错误：
```
export LATX_KZT=1
export LD_LIBRARY_PATH=:./
gdb -ex=r --args /home/zhaixiang/repo/lat/build64-dbg/latx-x86_64 ./bin/glmark2 --data-path ./share/glmark2
...
#1  0x0000007f8086b890 in dump_core_and_abort (target_sig=11) at ../linux-user/signal.c:768
#2  0x0000007f80871e84 in handle_pending_signal (cpu_env=0x7ffff506c360, sig=11, k=0x7f8353dee0) at ../linux-user/signal.c:1469
#3  0x0000007f80872174 in process_pending_signals (cpu_env=0x7ffff506c360) at ../linux-user/signal.c:1557
#4  0x0000007f802e7d94 in cpu_loop (env=0x7ffff506c360) at ../linux-user/x86_64/../i386/cpu_loop.c:371
#5  0x0000007f807c5d9c in RunFunctionWithState (fnc=140737291424960, nargs=1) at ../target/i386/latx/context/callback.c:75
#6  0x0000007f8069ff20 in my_ResourceAlloc_0 (dpy=0x7f83604a50) at ../target/i386/latx/context/wrappedlibx11.c:832
#7  0x00007ffff443a1a0 in XCreateWindow () from /usr/lib/libX11.so.6
#8  0x0000007f806a8254 in my_XCreateWindow (dpy=0x7f83604a50, v2=0x1c9, v3=0, v4=0, v5=800, v6=600, v7=0, v8=24, v9=1, v10=0x7f83611280, v11=10250, v12=0x5508002af0)
    at ../target/i386/latx/context/wrappedlibx11.c:1537
#9  0x0000007f8074b020 in pFppiiuuuiupLp (fcn=547615310112) at ../target/i386/latx/context/wrapper.c:2305
#10 0x00007fffd02ba7b4 in code_gen_buffer ()
#11 0x001400150040000b in ?? ()
...
```

精简测试用例 [libtk8.6.14](https://master.dl.sourceforge.net/project/tcl/Tcl/8.6.14/tk8.6.14-src.tar.gz) 复现相同问题，定位 [findResourceAllocFct调用GetNativeFnc返回NULL](https://github.com/lat-opensource/lat/blob/master/target/i386/latx/context/wrappedlibx11.c#L837)，通过对比box64调用GetNativeFnc返回值`0x7ffff16094c0`不为NULL，通过gdb断点定位GetNativeFnc调用FindElfAddress，latx返回elf_header，但box64返回NULL，box64调用dladdr来check if function exist in some loaded lib。

去掉FindElfAddress“当elfsize为正数返回elf_header”之后，精简测试用例 [libtk8.6.14](https://master.dl.sourceforge.net/project/tcl/Tcl/8.6.14/tk8.6.14-src.tar.gz) 通过，glmark2正常工作，周一我也会在Loongnix Desktop上复测，看看是否引入回退。

请review之。

Thanks,
Leslie Zhai