### PR TITLE
LATX, fix: Fix stack smashing detected error in ir2_dump()

### DIFF
--- a/target/i386/latx/ir2/ir2.c
+++ b/target/i386/latx/ir2/ir2.c
@@ -370,7 +370,7 @@ void ir2_dump_init(void)
 
 int ir2_dump(const IR2_INST *ir2, bool print)
 {
-    char str[64];
+    char str[128];
     int size = 0;
 
     /* an empty IR2_INST was inserted into the ir2 */


### PR DESCRIPTION
Increase buffer size from 64 to 128 characters to prevent buffer overflow that was causing stack corruption and termination with "stack smashing detected" error.

The larger buffer ensures safe string operations within the ir2_dump function when handling IR2 instruction formatting.