### PR TITLE
LATX, opt: Only set rounding when configuring MXCSR; disable it when …

### DIFF
--- a/linux-user/main.c
+++ b/linux-user/main.c
@@ -623,6 +623,7 @@ static void handle_arg_latx_softfpu(const char *arg)
     option_softfpu = strtol(arg, NULL, 0);
     if (option_softfpu) {
         option_aot = 0;
+        option_set_rounding_opt = 0;
     }
 }
 
@@ -679,6 +680,11 @@ static void handle_arg_latx_jrra(const char *arg)
 static void handle_arg_latx_smc(const char *arg)
 {
     option_smc_opt = strtol(arg, NULL, 0);
+}
+
+static void handle_arg_latx_rounding(const char *arg)
+{
+    option_set_rounding_opt = strtol(arg, NULL, 0);
 }
 
 static void handle_arg_latx_anonym(const char *arg)
@@ -809,6 +815,8 @@ static const struct qemu_argument arg_table[] = {
     "",           "enable softfpu fast"},
     {"latx-prlimit",    "LATX_PRLIMIT",     true,  handle_arg_latx_prlimit,
     "",           "enable prlimit"},
+    {"latx-rounding",    "LATX_ROUNDING_OPT",     true,  handle_arg_latx_rounding,
+    "",           "enable rounding opt"},
 #if defined(CONFIG_LATX_AVX_OPT)
     {"latx-avx-cpuid",    "LATX_AVX_CPUID",     true,  handle_arg_latx_avx_cpuid,
     "",           "enable avx cpuid"},

--- a/target/i386/latx/include/latx-options.h
+++ b/target/i386/latx/include/latx-options.h
@@ -76,6 +76,7 @@ extern int option_real_maps;
 extern int option_monitor_shared_mem;
 extern int option_shadow_file;
 extern int option_smc_opt;
+extern int option_set_rounding_opt;
 static inline int latx_smc_inv_page(void) { return option_smc_opt == 0; }
 static inline int latx_smc_inv_tb(void) { return option_smc_opt != 0; }
 static inline int latx_smc_shmm(void) { return option_smc_opt & 0x2; }

--- a/target/i386/latx/latx-options.c
+++ b/target/i386/latx/latx-options.c
@@ -89,6 +89,7 @@ int option_real_maps;
 int option_monitor_shared_mem;
 int option_shadow_file;
 int option_smc_opt;
+int option_set_rounding_opt;
 
 unsigned long long counter_tb_exec;
 unsigned long long counter_tb_tr;
@@ -149,6 +150,12 @@ void options_init(void)
 
 #ifdef CONFIG_LATX_SMC_OPT
     option_smc_opt = 0;
+#endif
+
+#ifdef CONFIG_LATX_AVX_OPT
+    option_set_rounding_opt = 0;
+#else
+    option_set_rounding_opt = 1;
 #endif
 }
 

--- a/target/i386/latx/translator/tr-opnd-process.c
+++ b/target/i386/latx/translator/tr-opnd-process.c
@@ -1183,6 +1183,7 @@ void store_freg_to_ir1(IR2_OPND opnd2, IR1_OPND *opnd1, bool is_xmm_hi,
 
 IR2_OPND set_fpu_fcsr_rounding_field_by_x86(void)
 {
+    if (option_set_rounding_opt) return zero_ir2_opnd;
     CPUArchState* env = (CPUArchState*)(lsenv->cpu_state);
     CPUState *cpu = env_cpu(env);
     if (!close_latx_parallel && !(cpu->tcg_cflags & CF_PARALLEL)) {
@@ -1213,6 +1214,7 @@ IR2_OPND set_fpu_fcsr_rounding_field_by_x86(void)
 
 void set_fpu_rounding_mode(IR2_OPND rm)
 {
+    if (option_set_rounding_opt) return;
     CPUArchState* env = (CPUArchState*)(lsenv->cpu_state);
     CPUState *cpu = env_cpu(env);
     if (close_latx_parallel) {


### PR DESCRIPTION
…AVX or soft-float is enabled.