### PR TITLE
KZT: Update find_ld_part for glibc 2.42 (Yongbao x86_64_runtime)

### DIFF
--- a/target/i386/latx/context/wrappedlibc.c
+++ b/target/i386/latx/context/wrappedlibc.c
@@ -3523,27 +3523,6 @@ static void Push64(CPUX86State *cpu, uint64_t v)
     *((uint64_t*)cpu->regs[R_ESP]) = v;
 }
 
-static elfheader_t* loadElfFromFile(const char* name)
-{
-    elfheader_t* h = NULL;
-    char *tmp = ResolveFile(name, &my_context->box64_ld_lib);
-    if (FileExist(tmp, IS_FILE)) {
-        FILE *f = fopen(tmp, "rb");
-        if (!f) {
-            printf_log(LOG_NONE, "Error: Cannot open %s\n", tmp);
-            return NULL;
-        }
-        h = LoadAndCheckElfHeader(f, tmp, 0);
-        ElfHeadReFix(h, loadSoaddrFromMap(tmp));
-        if ((uintptr_t)h->VerSym > (uintptr_t)h->delta) {
-            h->delta = 0;
-        }
-    } else {
-        lsassertm(0, "cannot find %s\n", tmp);
-    }
-    return h;
-}
-
 void kzt_wine_init_x86(void);
 int init_x86dlfun(void);
 int init_x86dlfun(void)
@@ -3561,12 +3540,10 @@ int init_x86dlfun(void)
     void *rsyms[5] = {0};
     int rrsyms = 0;
     ResetSpecialCaseElf(h, syms, 5, rsyms, &rrsyms);
-#ifdef CONFIG_LOONGARCH_NEW_WORLD
     if (rrsyms != 5) {
         h = loadElfFromFile("libdl.so.2");
         ResetSpecialCaseElf(h, syms, 5, rsyms, &rrsyms);
     }
-#endif
     lsassert(rrsyms == 5);
     my_context->dlprivate->x86dlopen = rsyms[0];
     my_context->dlprivate->x86dlsym = rsyms[1];

--- a/target/i386/latx/include/myalign.h
+++ b/target/i386/latx/include/myalign.h
@@ -160,4 +160,5 @@ TranslationBlock * kzt_tb_find_exp(
 void kzt_bridge_init(void);
 void kzt_wine_bridge(abi_ulong start, int fd);
 int latx_dpy_xcb_sync(void *v1);
+elfheader_t* loadElfFromFile(const char* name);
 #endif  //__MY_ALIGN__H_


### PR DESCRIPTION
Hi,

请下载[glibc 2.42 (Yongbao x86_64_runtime)](https://github.com/sunhaiyong1978/loongarch-latx/releases/download/test/x86_64_runtime.tar.gz)，然后通过-L指定sysroot，开启库直通跑glmark2：

```
$ LATX_KZT=1 ./build64-dbg/latx-x86_64 -L /your/path/x86_64/sys-root ./bin/glmark2 --data-path ./share/glmark2
```

复现find_ld_part：

```
=>Lat can't find ldinfo.
 assertion failed in <init_tb_callback_bridge> ../target/i386/latx/context/myalign.c:2654 can't find ld callback tb.# 0 ./build64-dbg/latx-x86_64(print_stack_trace+0x48) [0x7f803772ec]
# 1 ./build64-dbg/latx-x86_64(init_tb_callback_bridge+0xb0) [0x7f807d593c]
# 2 ./build64-dbg/latx-x86_64(kzt_bridge_init+0x78) [0x7f807d5a4c]
# 3 ./build64-dbg/latx-x86_64(main+0x1448) [0x7f8087afec]
# 4 /lib/loongarch64-linux-gnu/libc.so.6(__libc_start_main+0xe8) [0xfff5b60708]
# 5 ./build64-dbg/latx-x86_64(_start+0x6c) [0x7f802e49bc]
追踪与中断点陷阱
```

target/i386/latx/context/wrappedlibdl.c的init_x86dlfun先在libdl.so.2里ResetSpecialCaseElf五个dlfcn，若没找到符号，再在（glibc 2.42 Yongbao x86_64_runtime）libc.so.6里找。

在Loongnix Desktop ABI 1.0测试没有引入回退，请review之。

Thanks,
Leslie Zhai