### PR TITLE
KZT, fix: Fix stack cleanup in RunFunctionWithState.

### DIFF
--- a/target/i386/latx/context/callback.c
+++ b/target/i386/latx/context/callback.c
@@ -78,6 +78,7 @@ uint64_t RunFunctionWithState(uintptr_t fnc, int nargs, ...)
     memcpy(&cs->jmp_env, &buf, sizeof(sigjmp_buf));
     cpu->eip = oldip;
 
+    cpu->regs[R_ESP] += stackn*sizeof(void*);
     cpu->regs[R_R15] = Pop64(cpu);
     cpu->regs[R_R14] = Pop64(cpu);
     cpu->regs[R_R13] = Pop64(cpu);


### PR DESCRIPTION
一些本地直通的函数需要回调Guest的函数时，会通过RunFunctionWithState进行传参，当传参数大于6个时会将数据放到栈上。但是在RunFunctionWithState中出栈时没有设置好ESP，会导致>6个参数的回调失败。