### PR TITLE
LATX, docs: align commit convention with traceability rules

### DIFF
--- a/COMMIT_CONVENTION.en.md
+++ b/COMMIT_CONVENTION.en.md
@@ -1,0 +1,75 @@
+# Git Commit Convention (derived from existing history)
+
+To keep commits traceable, follow the rules below based on patterns already used in the project.
+
+## Recommended title format
+- **Suggested structure**: `<scope>[, <type>]: <concise description>`.
+- **Scope**: module or subproject name (for example `LATX`, `lat`, `KZT`, `linux-user`), consistent with the path or subsystem.
+- **Type**: common values are `feat` (feature), `fix` (bug fix), `opt` (optimization); for special cases use `temporary fix` (short-term workaround) or `Build(deps)` (dependency or CI maintenance).
+- **Subject**: one short imperative/declarative English phrase summarizing the change; do not end with a period.
+
+## Type suggestions (extend as needed)
+| Type             | Meaning / scope                                           | Example title snippet               |
+| ---------------- | --------------------------------------------------------- | ----------------------------------- |
+| `LATX, infra`    | Infrastructure, build system, CI/CD changes not affecting product behavior | `LATX, infra: Add tracing for ...` |
+| `LATX, feat`     | Product-facing feature additions                          | `LATX, feat: introduce smc ...` |
+| `LATX, fix`      | Bug fixes                                                 | `LATX, fix: Handle null ...`       |
+| `LATX, opt`      | Performance or implementation optimizations               | `LATX, opt: Refine glue ...`       |
+| `LATX, refactor` | Function/feature refactors                                | `LATX, refactor: Split ...`        |
+| `LATX, style`    | Formatting or comment tweaks that do not change behavior  | `LATX, style: Reflow comments`     |
+| `LATX-X64, *`    | Changes specific to 64-bit; `*` matches the types above (e.g., fix) | `LATX-X64, fix: ...`               |
+| `linux-user`     | linux-user related (e.g., syscall changes)                | `linux-user, fix: ...`             |
+| `LATX, docs`     | Documentation                                              | `LATX, docs: Update convention`    |
+| Other historical types | Special cases like `temporary fix` or `Build(deps)` are also allowed | `Build(deps): Bump ...`            |
+
+> Separate scope and type with a comma, and separate type and description with a colon. If no type is used, keep only the colon, for example `cpus: Make {start,end}_exclusive() recursive`.
+
+### `feat` vs `infra` decision guide
+
+#### `feat` — feature-level additions
+
+**If the change gives the translator a new visible capability or behavior, it is `feat`.**
+
+Typical cases:
+- New APIs, instruction translation, or instruction support
+- New command-line options or feature flags
+- New business logic or user-visible behavior
+
+**Decision rule:**
+> “Would users care if this appears in the release notes?”
+**Yes → feat**
+
+---
+
+#### `infra` — engineering infrastructure
+
+**Changes to engineering environment, build system, CI/CD, toolchains, or development scripts that do not alter product behavior.**
+
+Typical cases:
+- Modifications to Makefile / CMake / Meson / Bazel
+- Developer-only tracing or analysis tools
+
+**Decision rule:**
+> “Can users perceive any behavior change?”
+**No → infra**
+
+## Title examples (copy as-is)
+- `LATX, feat: Support CONFIG_LATX_GLUE_MASK in indirect jmp glue`
+- `LATX, opt: Reduce thread contention in fast path`
+- `Build(deps): Update meson to 1.3.0`
+
+## Commit body requirements
+1. **Prefer keeping a body**: avoid empty bodies except for `style`, `docs`, or trivial commits where the first line fully explains the change.
+2. **`fix` must name the target**: state which application/test set or git issue is fixed to aid traceability.
+3. **Body content suggestions**:
+   - Provide background, motivation, solution, and validation; no need to expand details in the title.
+   - Keep a single commit focused on one topic; avoid grouping unrelated changes.
+   - For temporary workarounds or risky changes, describe impact scope, alternatives, and cleanup plan to ease follow-up.
+
+## Pre-push checklist
+- Keep the title short and without a trailing period.
+- Does it include a scope consistent with the subsystem?
+- Does the type match the scenario? Should you mark it as `temporary fix` or `Build(deps)`?
+- Is the description clear about the change/reason, avoiding vague phrases like “update code” or “fix bug”?
+- Is the commit body filled in as required (especially for `fix`)?
+- If it is a temporary solution or needs follow-up, is TODO / follow-up noted in the body?

--- a/COMMIT_CONVENTION.md
+++ b/COMMIT_CONVENTION.md
@@ -1,0 +1,75 @@
+# Git 提交规范（基于历史提交总结）
+
+为了使代码有良好的可追溯性，根据项目现有提交记录补充如下规范。
+
+## 标题基础格式
+- **推荐结构**：`<范围>[, <类型>]: <简洁描述>`。
+- **范围（Scope）**：模块或子项目名称（如 `LATX`、`lat`、`KZT`、`linux-user`），与路径或子系统保持一致。
+- **类型（Type）**：常用 `feat`（新特性）、`fix`（修复）、`opt`（优化）；特殊场景使用 `temporary fix`（临时修复）、`Build(deps)`（依赖或 CI 维护）。
+- **描述（Subject）**：一句话概括改动，祈使/陈述语气的简短英文描述，避免句号结尾。
+
+## Type 约定（可按需扩充）
+| Type             | 含义 / 适用场景                                    | 示例标题片段                       |
+| ---------------- | -------------------------------------------------- | ---------------------------------- |
+| `LATX, infra`    | 对基础设施、构建系统、CI/CD等不影响产品功能的修改  | `LATX, infra: Add tracing for ...` |
+| `LATX, feat`     | 对产品面向业务的功能增加                           | `LATX, feat: introduce smc ...` |
+| `LATX, fix`      | bug 修复                                           | `LATX, fix: Handle null ...`       |
+| `LATX, opt`      | 性能或实现优化                                     | `LATX, opt: Refine glue ...`       |
+| `LATX, refactor` | 函数 / 功能重构                                    | `LATX, refactor: Split ...`        |
+| `LATX, style`    | 不影响功能的格式、注释调整                         | `LATX, style: Reflow comments`     |
+| `LATX-X64, *`    | 改动仅针对 64 位，`*` 同上各类（如 fix）           | `LATX-X64, fix: ...`               |
+| `linux-user`     | linux-user 相关（如 syscall 改动）                 | `linux-user, fix: ...`             |
+| `LATX, docs`     | 文档                                               | `LATX, docs: Update convention`    |
+| 其他历史类型     | 特殊场景下也可用 `temporary fix`、`Build(deps)` 等 | `Build(deps): Bump ...`            |
+
+> 范围与类型之间用逗号分隔，类型与描述之间用冒号；无类型时直接用冒号，例如 `cpus: Make {start,end}_exclusive() recursive`。
+
+### `feat` vs `infra` 区分指南
+
+#### `feat` ——  功能级新增（Feature）
+
+** 只要本次修改让翻译器新增了可感知的能力或行为”，就是 `feat`。 **
+
+典型场景：
+- 新增 API、指令翻译、指令支持
+- 新增命令行参数、功能开关
+- 新增业务逻辑或用户可看到的行为
+
+** 判断标准：**
+> “如果写进 release note，用户会在意吗？”
+** 会 → feat  **
+
+---
+
+#### `infra` ——  工程基础设施（Infrastructure）
+
+** 工程环境、构建系统、CI/CD、工具链、开发脚本等方面的改动，不改变产品行为。**
+
+典型场景：
+- 修改 Makefile / CMake / Meson / Bazel
+- 开发者自用的追踪或分析工具等
+
+** 判断标准：**
+> “用户是否能感知行为变化？”
+** 不能 → infra  **
+
+## 标题示例（可直接套用）
+- `LATX, feat: Support CONFIG_LATX_GLUE_MASK in indirect jmp glue`
+- `LATX, opt: Reduce thread contention in fast path`
+- `Build(deps): Update meson to 1.3.0`
+
+## commit body 要求
+1. **建议保留正文**：除 `style`、`docs` 类型，或极其简单且首行即可描述清楚的提交外，不提倡无正文的提交。
+2. **fix 类型需指明修复对象**：正文中写明修复了哪个应用程序/测试集或 git issue 等，便于追溯。
+3. **正文内容建议**：
+   - 补充背景、动机、方案与验证方式，不必在标题展开细节。
+   - 单个提交聚焦单一主题，避免一次提交多个无关改动。
+   - 对临时修复或风险点，正文说明影响范围、替代方案与清理计划，方便后续跟进。
+
+## 提交前检查清单
+- 标题不宜过长，描述末尾不加句号。
+- 是否包含范围且范围名称与子系统一致？
+- 类型是否符合场景，是否需要 `temporary fix` 或 `Build(deps)` 等特殊标识？
+- 描述是否清晰指向改动 / 原因，避免只有模糊词（如 “update code”、“fix bug”）。
+- 是否按上述要求填写 commit body（尤其对 `fix` 类型）？
+- 若为临时方案或有后续计划，正文是否注明 TODO / 后续跟进？

--- a/README.en.rst
+++ b/README.en.rst
@@ -19,6 +19,11 @@ the box64 project.
 
 `中文版本点击这里 >> <README.rst>`_
 
+Commit Convention
+========
+
+`Commit Convention (English) <COMMIT_CONVENTION.en.md>`_
+
 
 Project Background
 ========

--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,11 @@ LATX 基于 QEMU 6 版本开发并进行了深度优化，性能相比原生 QEM
 
 `See the English Version Here >> <README.en.rst>`_
 
+提交规范
+========
+
+`提交规范（中文） <COMMIT_CONVENTION.md>`_
+
 
 项目背景
 ========


### PR DESCRIPTION
## Summary
- add commit message guide with scope/type format and examples
- add explicit type table covering LATX, LATX-X64, linux-user and docs cases
- document commit body requirements for fix submissions and general traceability