### PR TITLE
KZT, fix: Fixed desired memory protection of the mapping for pages need readable

### DIFF
--- a/linux-user/elfload.c
+++ b/linux-user/elfload.c
@@ -2785,10 +2785,18 @@ static void load_elf_image(const char *image_name, const ImageSource *src,
      * In both cases, we will overwrite pages in this range with mappings
      * from the executable.
      */
-    load_addr = target_mmap(loaddr, len, PROT_NONE,
-                            MAP_PRIVATE | MAP_ANON | MAP_NORESERVE |
-                            (ehdr->e_type == ET_EXEC ? MAP_FIXED : 0),
-                            -1, 0, 1);
+#ifdef CONFIG_LATX_KZT
+    if (option_kzt)
+        load_addr = target_mmap(loaddr, len, PROT_READ,
+                                MAP_PRIVATE | MAP_ANON | MAP_NORESERVE |
+                                (ehdr->e_type == ET_EXEC ? MAP_FIXED : 0),
+                                -1, 0, 1);
+    else
+#endif // CONFIG_LATX_KZT
+        load_addr = target_mmap(loaddr, len, PROT_NONE,
+                                MAP_PRIVATE | MAP_ANON | MAP_NORESERVE |
+                                (ehdr->e_type == ET_EXEC ? MAP_FIXED : 0),
+                                -1, 0, 1);
     if (load_addr == -1) {
         goto exit_mmap;
     }


### PR DESCRIPTION
Hi,

开启KZT，跑find_ld_part的[fuzz测试](https://github.com/sunhaiyong1978/loongarch-latx/releases/download/test/x86_64-multi-version.tar.gz)：

```
export LATX_KZT=1

./build64-dbg/latx-x86_64 -L /your/path/target-gcc_10.5.0-glibc_2.41/usr /your/path/box64/tests/test01 2>&1|tee target-gcc_10.5.0-glibc_2.41.log
#FAIL 
=> ./build64-dbg/latx-x86_64 -L /your/path/target-gcc_13.2.0-glibc_2.42/usr /your/path/box64/tests/test01 2>&1|tee target-gcc_13.2.0-glibc_2.42.log
./build64-dbg/latx-x86_64 -L /your/path/target-gcc_15.2.0-glibc_2.36/usr /your/path/box64/tests/test01 2>&1|tee target-gcc_15.2.0-glibc_2.36.log
./build64-dbg/latx-x86_64 -L /your/path/target-gcc_15.2.0-glibc_2.39/usr /your/path/box64/tests/test01 2>&1|tee target-gcc_15.2.0-glibc_2.39.log
./build64-dbg/latx-x86_64 -L /your/path/target-gcc_15.2.0-glibc_2.42/usr /your/path/box64/tests/test01 2>&1|tee target-gcc_15.2.0-glibc_2.42.log
./build64-dbg/latx-x86_64 -L /your/path/target-gcc_11.5.0-glibc_2.41/usr /your/path/box64/tests/test01 2>&1|tee target-gcc_11.5.0-glibc_2.41.log
./build64-dbg/latx-x86_64 -L /your/path/target-gcc_14.2.0-glibc_2.42/usr /your/path/box64/tests/test01 2>&1|tee target-gcc_14.2.0-glibc_2.42.log
./build64-dbg/latx-x86_64 -L /your/path/target-gcc_15.2.0-glibc_2.37/usr /your/path/box64/tests/test01 2>&1|tee target-gcc_15.2.0-glibc_2.37.log
./build64-dbg/latx-x86_64 -L /your/path/target-gcc_15.2.0-glibc_2.40/usr /your/path/box64/tests/test01 2>&1|tee target-gcc_15.2.0-glibc_2.40.log
./build64-dbg/latx-x86_64 -L /your/path/target-gcc_12.2.0-glibc_2.42/usr /your/path/box64/tests/test01 2>&1|tee target-gcc_12.2.0-glibc_2.42.log
./build64-dbg/latx-x86_64 -L /your/path/target-gcc_15.2.0-glibc_2.35/usr /your/path/box64/tests/test01 2>&1|tee target-gcc_15.2.0-glibc_2.35.log
./build64-dbg/latx-x86_64 -L /your/path/target-gcc_15.2.0-glibc_2.38/usr /your/path/box64/tests/test01 2>&1|tee target-gcc_15.2.0-glibc_2.38.log
./build64-dbg/latx-x86_64 -L /your/path/target-gcc_15.2.0-glibc_2.41/usr /your/path/box64/tests/test01 2>&1|tee target-gcc_15.2.0-glibc_2.41.log
``` 

复现段错误表象： 基址0x5508048003，偏移0xfff，LD访问失败：

```
...
Thread 1 "latx-x86_64" received signal SIGSEGV, Segmentation fault.
__GI___memmem (ne_len=11, needle=0xffffff55a8, hs_len=<optimized out>, haystack=<optimized out>) at memmem.c:101
...
(gdb) bt
#0  __GI___memmem (ne_len=11, needle=0xffffff55a8, hs_len=<optimized out>, haystack=<optimized out>) at memmem.c:101
#1  __GI___memmem (haystack=<optimized out>, hs_len=<optimized out>, needle=0xffffff55a8, ne_len=11) at memmem.c:53
#2  0x0000007f807daf28 in find_ld_part (start=0x550802fb15 "A\\A]A^A_]\303\307@\020\001", len=265920) at ../target/i386/latx/context/myalign.c:2560
#3  0x0000007f807db530 in find_ld_bridge (info=0x7f834a7190 <info1>) at ../target/i386/latx/context/myalign.c:2651
#4  0x0000007f807db598 in init_tb_callback_bridge (cpu=0xfff5e08010, info=0x7f834a7190 <info1>) at ../target/i386/latx/context/myalign.c:2661
#5  0x0000007f807db720 in kzt_bridge_init () at ../target/i386/latx/context/myalign.c:2680
#6  0x0000007f80880e24 in main (argc=4, argv=0xffffff6ef8, envp=0xffffff6f20) at ../linux-user/main.c:1527
(gdb) x/22i $pc-44
...
=> 0xfff778e678 <__GI___memmem+296>:    ld.bu    $r13,$r23,-1(0xfff)
...
(gdb) i r $r23
r23            0x5508048003        365206732803
(gdb) info proc
process 21731
cmdline = '/home/zhaixiang/repo/lat/build64-dbg/latx-x86_64 -L /mnt/home/zhaixiang/tmp/target/target-gcc_13.2.0-glibc_2.42/usr /home/zhaixiang/repo/box64/tests/test01'
cwd = '/home/zhaixiang/repo/lat'
exe = '/home/zhaixiang/repo/lat/build64-dbg/latx-x86_64'
```

根因0x5508048000 ~ 0x55080ac000不可读：

```
00010000-5500000000 ---p 00000000 00:00 0 
5500000000-5500004000 rwxp 00000000 00:00 0 
5500004000-5500008000 rw-p 00000000 00:00 0 
5500008000-5501008000 ---p 00000000 00:00 0 
5501008000-550780c000 ---p 00000000 00:00 0 
550780c000-550800c000 rw-p 00000000 00:00 0 
550800c000-5508010000 r--p 00000000 00:00 0 
5508010000-5508040000 r--p 00004000 08:03 1574844                        /mnt/home/zhaixiang/tmp/target/target-gcc_13.2.0-glibc_2.42/usr/lib64/ld-linux-x86-64.so.2
5508040000-5508048000 rw-p 00000000 00:00 0 
=> 5508048000-55080ac000 ---p 00000000 00:00 0 
                         ^--- 不可读
55080ac000-55080b0000 r--p 00000000 00:00 0 
55080b0000-55080b8000 rw-p 00000000 00:00 0 
55080b8000-7000000000 ---p 00000000 00:00 0 
7f80000000-7f81230000 r-xp 00000000 08:07 3148091                        /home/zhaixiang/repo/lat/build64-dbg/latx-x86_64
7f81234000-7f81290000 r--p 01230000 08:07 3148091                        /home/zhaixiang/repo/lat/build64-dbg/latx-x86_64
7f81290000-7f812f4000 rw-p 0128c000 08:07 3148091                        /home/zhaixiang/repo/lat/build64-dbg/latx-x86_64
7f812f4000-7f83558000 rw-p 00000000 00:00 0                              [heap]
...
```

请review之。

Thanks,
Leslie Zhai