### PR TITLE
LATX, fix: Remove unused variable in aot_do_tb_reloc

### DIFF
--- a/target/i386/latx/sbt/aot.c
+++ b/target/i386/latx/sbt/aot.c
@@ -1224,8 +1224,6 @@ void aot_do_tb_reloc(TranslationBlock *tb, struct aot_tb *stb,
     uint64_t offset;
     uintptr_t helper_address;
     int lib_method_index;
-    CPUArchState* env = (CPUArchState*)(lsenv->cpu_state);
-    target_ulong base = env->segs[R_CS].base;
     ADDR loacl_indirect_jmp_glue = indirect_jmp_glue;
 
     aot_rel_table = aot_buffer +


### PR DESCRIPTION
Fixes compilation error with -Werror=unused-variable flag enabled.

The variable 'base' defined at target/i386/latx/sbt/aot.c:1228 is assigned but never used, causing the following compilation error:
  ../target/i386/latx/sbt/aot.c:1228:18: error: unused variable 'base'

Remove the unused variable to resolve the build failure.