### PR TITLE
LATX, fix: avoid tblink stub cross cacheline

### DIFF
--- a/target/i386/latx/convert.py
+++ b/target/i386/latx/convert.py
@@ -322,7 +322,7 @@ def convertToConstructorForPseudo(name = str, header_list = list):
 def main():
     # pseudo insts which also not generate function like 'la_xxx()'
     pseudoinstruction_nofunction_list = [
-        "align", "code", "far_jump", "data_li", "data_add", "inst_diff",
+        "accl", "align", "code", "far_jump", "data_li", "data_add", "inst_diff",
         "data_st", "data_st_rel_table", "profile", "pcaddi_relocate", "pseudo_end"]
     pseudoinstruction_list = ["label", "x86_inst",
                               "mov64", "mov32_sx", "mov32_zx", "add", "sub",

--- a/target/i386/latx/include/ir2-relocate.h
+++ b/target/i386/latx/include/ir2-relocate.h
@@ -6,6 +6,19 @@
 #include "qemu-def.h"
 
 /**
+ * @brief Avoid IR2 cross cacheline
+ * @details
+ * This function is used to generate some filling instruciton to avoid
+ * the following @ninst instructions spans two cacheline.
+ * The icacheline size is obtained by qemu in util/cacheinfo.c
+ * and is usually 64 bytes in most cases.
+ * @param data_base base of translation block
+ * @param ninst number of inst to be keep inside one cacheline
+ * @param filling filling data/code
+ */
+IR2_INST *la_code_accl(IR2_OPND data_base, int ninst, uint32_t filling);
+
+/**
  * @brief Add pseudo inst to hint align
  *
  * @param align align size (byte), recommend {2^n}

--- a/target/i386/latx/inst_template.json
+++ b/target/i386/latx/inst_template.json
@@ -19,6 +19,13 @@
         ],
         "note": "divide each x86 insts"
     },
+    "accl": {
+        "opcode": "0x0",
+        "opnd": [
+            "opd_invalid"
+        ],
+        "note": "ir2 avoid cross cacheline"
+    },
     "align": {
         "opcode": "0x0",
         "opnd": [

--- a/target/i386/latx/translator/translate.c
+++ b/target/i386/latx/translator/translate.c
@@ -2631,7 +2631,8 @@ direct_jmp:
             la_label(label_first_jmp_align);
             tb->first_jmp_align = ir2_opnd_label_id(&label_first_jmp_align);
         }
-        la_code_align(2, 0x03400000);
+        la_code_accl(base, 2, 0x03400000);
+        /*la_code_align(2, 0x03400000);*/
 
         if (!use_tu_jmp(tb)) {
 #ifndef CONFIG_LATX_XCOMISX_OPT
@@ -2658,7 +2659,8 @@ direct_jmp:
 
             }
 
-            la_code_align(2, 0x03400000);
+            la_code_accl(base, 2, 0x03400000);
+            /*la_code_align(2, 0x03400000);*/
 
             la_label(goto_label_opnd);
             tb->jmp_reset_offset[succ_id] = ir2_opnd_label_id(&goto_label_opnd);

--- a/util/cacheinfo.c
+++ b/util/cacheinfo.c
@@ -9,6 +9,7 @@
 #include "qemu/osdep.h"
 #include "qemu/host-utils.h"
 #include "qemu/atomic.h"
+#include "larchintrin.h"
 
 int qemu_icache_linesize = 0;
 int qemu_icache_linesize_log;
@@ -143,6 +144,16 @@ static void arch_cache_info(int *isize, int *dsize)
     if (*dsize == 0) {
         *dsize = qemu_getauxval(AT_DCACHEBSIZE);
     }
+}
+
+#elif defined(__loongarch__)
+
+static void arch_cache_info(int *isize, int *dsize)
+{
+    uint64_t i = __cpucfg(0x11);
+    uint64_t d = __cpucfg(0x12);
+    *isize = 0x1 << ((i >> 24) & 0x7f);
+    *dsize = 0x1 << ((d >> 24) & 0x7f);
 }
 
 #else


### PR DESCRIPTION
The tblink stub contains two instructions. To apply tblink, this stub will be rewriten by one store inst st.d and becomes a direct jump to another tb.

If the stub spans two cacheline, the st.d may not be atomic.

The original LISA_ALIGN force this stub to be aligned by 2 inst. But it will lead to a lot of unnecessary nop if this stub is inside one cacheline.

This patch introduce a new psudo instruction LISA_ACCL, which stands for Avoid-Cross-CacheLine.  The icacheline size is obtained with cpucfg and is usually 64 bytes.