### PR TITLE
LATX, fix: Fix incorrect TB lookup when TBMini is enabled

### DIFF
--- a/tcg/tcg.c
+++ b/tcg/tcg.c
@@ -692,7 +692,7 @@ static void *tcg_tb_lookup_fast(uintptr_t tc_ptr)
     if (!in_code_gen_buffer((void *)tc_ptr)) {
         return NULL;
     }
-    TBMini *tbm = (TBMini *)(ROUND_DOWN((uintptr_t)tc_ptr,
+    TBMini *tbm = (TBMini *)(ROUND_DOWN((uintptr_t)tc_ptr - 4,
                 CODE_GEN_ALIGN));
     while (tbm->mtbp_struct.magic != TB_MAGIC) {
         tbm = (TBMini *)((uint64_t)tbm - CODE_GEN_ALIGN);


### PR DESCRIPTION
When TBMini is enabled, the tcg_tb_lookup() function could mistakenly identify a code address as a valid TBMini under a specific alignment condition.

This occurred when the last instruction address of a TB was exactly aligned to CODE_GEN_ALIGN. In this case, this address would be used as the starting point for searching the TBMini. If the subsequent memory matched the TB_MAGIC value, it would be incorrectly recognized as a valid TBM structure, leading to lookup errors.

The fix adjusts the search starting point by subtracting 4 from the incoming tc_ptr before rounding down to CODE_GEN_ALIGN.