### PR TITLE
LATX, fix: tb reset offset when lazylink

### DIFF
--- a/target/i386/latx/include/latx-config.h
+++ b/target/i386/latx/include/latx-config.h
@@ -45,5 +45,9 @@ void target_disasm(struct TranslationBlock *tb, int max_insns);
 #define B_STUB_SIZE 4
 #endif
 
+#ifdef CONFIG_LATX_LAZYLINK
+#undef  B_STUB_SIZE
+#define B_STUB_SIZE 0
+#endif
 
 #endif /* _LATX_CONFIG_H_ */


### PR DESCRIPTION
In tblink optimization, the link stub (b + nop) is generated inside TB and will be rewrite to implement direct jmp from one TB to another.

There are two key variable of TB that are related to this tblink optimization.
- jmp_target_arg[n] points to the start of the link stub
- jmp_reset_offset[n] points to the end of the link stub, which is also the next inst after the link stub

These two variables are calcualted in the label_dispose(). And the size of the link stub is fixed (B_STUB_SIZE).

But in the lazylink optimization, the link stub is eliminated. The B_STUB_SIZE should be zero. Otherwise the jmp_reset_offset[n] might points to an address that locates outsize of this TB.