### PR TITLE
LATX, fix: remove unnecessary log about smc

### DIFF
--- a/accel/tcg/user-exec.c
+++ b/accel/tcg/user-exec.c
@@ -25,6 +25,7 @@
 #include "exec/cpu_ldst.h"
 #include "exec/translate-all.h"
 #include "exec/helper-proto.h"
+#include "exec/log.h"
 #include "qemu/atomic128.h"
 #include "trace/trace-root.h"
 #include "trace/mem.h"
@@ -242,12 +243,15 @@ static uint64_t parse_guest_store(siginfo_t *info, ucontext_t *uc, int *size)
     if (s == -2) unsup_sc += 1;
 
     if (unsup < 0x100) {
-        fprintf(stderr, "%s:%d SMC unsupport inst %08x count %lu %lu\n",
+        qemu_log_mask(LAT_LOG_SMC,
+                "%s:%d SMC unsupport inst %08x count %lu %lu\n",
                 __func__, __LINE__, inst, unsup, unsup_sc);
     } else if (!(unsup & 0xfff)) {
-        fprintf(stderr, "%s:%d SMC unsupport inst %08x count %lu %lu\n",
+        qemu_log_mask(LAT_LOG_SMC,
+                "%s:%d SMC unsupport inst %08x count %lu %lu\n",
                 __func__, __LINE__, inst, unsup, unsup_sc);
-        fprintf(stderr, "%s:%d SMC unsupport too much !!! "
+        qemu_log_mask(LAT_LOG_SMC,
+                "%s:%d SMC unsupport too much !!! "
                 "Maybe try export LATX_SMC=0 and report this problem please.\n",
                 __func__, __LINE__);
     }

--- a/include/qemu/log.h
+++ b/include/qemu/log.h
@@ -82,6 +82,7 @@ static inline bool qemu_log_separate(void)
 #define LOG_STRACE_ERROR   (1 << 25)
 #define LAT_LOG_AOT        (1 << 26)
 #define LAT_IMM_REG        (1 << 27)
+#define LAT_LOG_SMC        (1 << 28)
 
 #define LAT_LOG_PROFILE    (1 << 31)
 /* Lock output for a series of related logs.  Since this is not needed

--- a/util/log.c
+++ b/util/log.c
@@ -392,6 +392,7 @@ const QEMULogItem qemu_log_items[] = {
     { LAT_LOG_EFLAGS, "lat_eflags", "latx tail eflags info debug" },
     { LAT_LOG_AOT, "lat_aot", "aot log info"},
     { LAT_IMM_REG, "lat_imm_reg","latx imm reg info debug"},
+    { LAT_LOG_SMC, "lat_log_smc","smc opt log"},
     { 0, NULL, NULL },
 };
 


### PR DESCRIPTION
Print these info use qemu_log_mask() instead.