### PR TITLE
Revert "LATX, opt:  Reduce memory waste for tbmini"

### DIFF
--- a/tcg/tcg.c
+++ b/tcg/tcg.c
@@ -1283,11 +1283,7 @@ TranslationBlock *tcg_tb_alloc(TCGContext *s)
             goto retry;
         }
         qatomic_set(&s->tb_gen_ptr, next_tb);
-#if defined(CONFIG_LATX_TBMINI_ENABLE)
-        next = (void *)ROUND_UP((uintptr_t)s->code_gen_ptr, CODE_GEN_ALIGN);
-#else
         next = (void *)ROUND_UP((uintptr_t)s->code_gen_ptr, align);
-#endif
     } else {
         tb = (void *)ROUND_UP((uintptr_t)s->code_gen_ptr, align);
         next = (void *)ROUND_UP((uintptr_t)(tb + 1), align);
@@ -1322,11 +1318,7 @@ TranslationBlock *tcg_tb_alloc_full(TCGContext *s)
             goto retry;
         }
         qatomic_set(&s->tb_gen_ptr, next_tb);
-#if defined(CONFIG_LATX_TBMINI_ENABLE)
-        next = (void *)ROUND_UP((uintptr_t)s->code_gen_ptr, CODE_GEN_ALIGN);
-#else
         next = (void *)ROUND_UP((uintptr_t)s->code_gen_ptr, align);
-#endif
     } else {
         tb = (void *)ROUND_UP((uintptr_t)s->code_gen_ptr, align);
         new_s_data = (void *)ROUND_UP((uintptr_t)(tb + 1), align);


### PR DESCRIPTION
This reverts commit 364a3c519c41e11a58acb58f6548cb2b9c4ef22d.

This patch caused a large number of applications to fail to start