### PR TITLE
LATX, fix:Prevent HID ioctl handling from interfering with v4l2 ioctls

### DIFF
--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -8172,18 +8172,20 @@ static abi_long do_ioctl(int fd, int cmd, abi_ulong arg)
 #endif
     /* slow path to iterate the ioctl_entries */
     if (ie->target_cmd != cmd) {
-        switch(TARGET_IOC_NR(cmd)) {
-            case TARGET_IOC_NR(TARGET_HIDIOCSFEATURE(0)):
-            case TARGET_IOC_NR(TARGET_HIDIOCGFEATURE(0)):
-            case TARGET_IOC_NR(TARGET_HIDIOCGRAWNAME(0)):
-            case TARGET_IOC_NR(TARGET_HIDIOCGRAWPHYS(0)):
-            case TARGET_IOC_NR(TARGET_HIDIOCGRAWUNIQ(0)):
-            case TARGET_IOC_NR(TARGET_HIDIOCSINPUT(0)):
-            case TARGET_IOC_NR(TARGET_HIDIOCGINPUT(0)):
-            case TARGET_IOC_NR(TARGET_HIDIOCSOUTPUT(0)):
-            case TARGET_IOC_NR(TARGET_HIDIOCGOUTPUT(0)):
-            case TARGET_IOC_NR(TARGET_HIDIOCREVOKE):
-                return handle_hidfeature(fd, cmd, arg, TARGET_IOC_SIZE(cmd), 1);
+        if (TARGET_IOC_TYPE(cmd) == 'H') {
+            switch(TARGET_IOC_NR(cmd)) {
+                case TARGET_IOC_NR(TARGET_HIDIOCSFEATURE(0)):
+                case TARGET_IOC_NR(TARGET_HIDIOCGFEATURE(0)):
+                case TARGET_IOC_NR(TARGET_HIDIOCGRAWNAME(0)):
+                case TARGET_IOC_NR(TARGET_HIDIOCGRAWPHYS(0)):
+                case TARGET_IOC_NR(TARGET_HIDIOCGRAWUNIQ(0)):
+                case TARGET_IOC_NR(TARGET_HIDIOCSINPUT(0)):
+                case TARGET_IOC_NR(TARGET_HIDIOCGINPUT(0)):
+                case TARGET_IOC_NR(TARGET_HIDIOCSOUTPUT(0)):
+                case TARGET_IOC_NR(TARGET_HIDIOCGOUTPUT(0)):
+                case TARGET_IOC_NR(TARGET_HIDIOCREVOKE):
+                    return handle_hidfeature(fd, cmd, arg, TARGET_IOC_SIZE(cmd), 1);
+            }
         }
         ie = ioctl_entries;
         for (i = 0; ; i++) {

--- a/linux-user/syscall_defs.h
+++ b/linux-user/syscall_defs.h
@@ -132,6 +132,7 @@
 
 #define TARGET_IOC_NR(nr)		(((nr) >> TARGET_IOC_NRSHIFT) & TARGET_IOC_NRMASK)
 #define TARGET_IOC_SIZE(nr)		(((nr) >> TARGET_IOC_SIZESHIFT) & TARGET_IOC_SIZEMASK)
+#define TARGET_IOC_TYPE(nr)		(((nr) >> TARGET_IOC_TYPESHIFT) & TARGET_IOC_TYPEMASK)
 
 /* used to create numbers */
 #define TARGET_IO(type,nr)		TARGET_IOC(TARGET_IOC_NONE,(type),(nr),0)
@@ -2296,7 +2297,7 @@ struct target_stat {
 	abi_long	st_blocks;	/* Number 512-byte blocks allocated. */
 
 	abi_ulong	target_st_atime;
-	abi_ulong 	target_st_atime_nsec; 
+	abi_ulong 	target_st_atime_nsec;
 	abi_ulong	target_st_mtime;
 	abi_ulong	target_st_mtime_nsec;
 	abi_ulong	target_st_ctime;


### PR DESCRIPTION
The HID ioctl handling code was incorrectly intercepting v4l2 ioctl commands
due to overlapping ioctl number (nr) values. Specifically, v4l2 commands with
nr=4 were matching HIDIOCGRAWNAME(0) which also has nr=4.

Changes:
1. Added type checking before processing HID ioctls using TARGET_IOC_TYPE()
2. Only process ioctls with type 'H' (0x48) in the HID-specific switch statement
3. Non-HID ioctls now continue to the standard ioctl handling path

This ensures v4l2 ioctls (type='V'/0x56) are not incorrectly processed as HID
ioctls, fixing v4l2 device opening failures.