### PR TITLE
LATX, fix: AOT use waitpid instead of wait for first fork

### DIFF
--- a/target/i386/latx/sbt/aot.c
+++ b/target/i386/latx/sbt/aot.c
@@ -1606,7 +1606,7 @@ void aot_exit_entry(CPUState *cpu, int is_end)
     pid_t pid = fork();
     if (pid) {
         if (pid > 0) {
-            wait(NULL);
+            waitpid(pid, NULL, 0);
             if (old_sa.sa_handler != SIG_DFL) {
                 sigaction(signum, &old_sa, NULL);
             }


### PR DESCRIPTION
Replace wait() with waitpid() in the first fork to prevent accidental reaping of guest program's child processes.