### PR TITLE
Revert "Build: Fixed debian ports repo"

### DIFF
--- a/.github/.ci/debian/Dockerfile
+++ b/.github/.ci/debian/Dockerfile
@@ -19,15 +19,6 @@ ARG DEPENDENCIES="         \
         python3-setuptools \
         xz-utils"
 
-RUN echo "deb http://snapshot.debian.org/archive/debian-ports/20250801T194242Z/ sid main"  > /etc/apt/sources.list && \
-    ( echo 'quiet "true";'; \
-      echo 'APT::Get::Assume-Yes "true";'; \
-      echo 'APT::Install-Recommends "false";'; \
-      echo 'Acquire::Check-Valid-Until "false";'; \
-      echo 'Acquire::Retries "5";'; \
-    ) > /etc/apt/apt.conf.d/99cpython-portable && \
-    rm -f /etc/apt/sources.list.d/*
-
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt-get update \


### PR DESCRIPTION
This reverts commit 0e25c5d28289d9395d75a80fd061dc1725da17c3.

移除 snapshot repo 定义，不再需要。
如果必须使用 snapshot repo 可以使用 `ghcr.io/loong64/debian:sid` 或者 sha256 固定