### PR TITLE
LATX, fix: Fix segfault in tcg_tb_lookup_fast by validating buffer bo…

### DIFF
--- a/tcg/tcg.c
+++ b/tcg/tcg.c
@@ -699,6 +699,9 @@ static void *tcg_tb_lookup_fast(uintptr_t tc_ptr)
                 CODE_GEN_ALIGN));
     while (tbm->mtbp_struct.magic != TB_MAGIC) {
         tbm = (TBMini *)((uint64_t)tbm - CODE_GEN_ALIGN);
+        if (!in_code_gen_buffer((void *)tbm)) {
+            return NULL;
+        }
     }
     void *tb = (void *)(tbm->mtbp_uint64 &
                 MAKE_64BIT_MASK(0, HOST_VIRT_ADDR_SPACE_BITS));


### PR DESCRIPTION
…unds

When iterating backwards through the translation block mini structures, the pointer `tbm` could potentially step outside the code generation buffer region. This would lead to an out-of-bounds memory access and a segfault when `tcg_tb_lookup` was called.

Add a check using `in_code_gen_buffer()` to ensure `tbm` stays within the valid buffer range. If the pointer falls outside the buffer, return NULL immediately.