### PR TITLE
LATX, fix: Fix compatibility issue with fingerprint input devices 

### DIFF
--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -8153,7 +8153,7 @@ static abi_long do_ioctl(int fd, int cmd, abi_ulong arg)
 #endif
     /* slow path to iterate the ioctl_entries */
     if (ie->target_cmd != cmd) {
-        if (TARGET_IOC_TYPE(cmd) == 'H') {
+        if (TARGET_IOC_TYPE(cmd) == 'H' || TARGET_IOC_TYPE(cmd) == 'U') {
             switch(TARGET_IOC_NR(cmd)) {
                 case TARGET_IOC_NR(TARGET_HIDIOCSFEATURE(0)):
                 case TARGET_IOC_NR(TARGET_HIDIOCGFEATURE(0)):


### PR DESCRIPTION
LATX, fix: Fix compatibility issue with fingerprint input devices HID ioctl handling

The HID ioctl handling code had overly strict type checking, causing incompatibility with fingerprint input devices. This change extends the HID-specific switch statement to also process ioctl commands of type 'U' (0x55), thereby enabling compatibility with these devices.