### PR TITLE
LATX, opt: classify AOT file types

### DIFF
--- a/accel/tcg/translate-all.c
+++ b/accel/tcg/translate-all.c
@@ -3583,9 +3583,6 @@ bool pageflags_set_clear(target_ulong start, target_ulong last,
     return inval_tb;
 }
 
-#ifdef CONFIG_LATX_AOT
-static seg_info *p_info;
-#endif
 /* Modify the flags of a page and invalidate the code if necessary.
    The flag PAGE_WRITE_ORG is positioned automatically depending
    on PAGE_WRITE.  The mmap_lock should already be held.  */
@@ -3636,27 +3633,18 @@ void page_set_flags(target_ulong start, target_ulong end, int flags)
     }
 
 #ifdef CONFIG_LATX_AOT
-    if (option_aot && (flags & PAGE_WRITE)) {
-        p_info = segment_tree_lookup2(start, end);
-
-    }
-#endif
-
-#ifdef CONFIG_LATX_AOT
     target_ulong addr, len;
     if (option_aot && (flags & PAGE_WRITE)) {
-        for (addr = start, len = end - start;
-             len != 0;
+        seg_info *seg_info = segment_tree_lookup2(start, end);
+        for (addr = start, len = end - start; len != 0;
              len -= TARGET_PAGE_SIZE, addr += TARGET_PAGE_SIZE) {
             PageFlagsNode *p = pageflags_find(addr, addr);
             if (p && !(p->flags & PAGE_WRITE)) {
                 if (foreach_tb_first(addr, addr + TARGET_PAGE_SIZE)) {
                     page_set_page_state(addr, PAGE_SMC);
-                } else if ((p->flags & PAGE_EXEC) && p_info) {
-                    aot_segment *p_segment = (aot_segment *)(p_info->p_segment);
-                    if ((p_segment && !(p_segment->is_pe))) {
-                        page_set_page_state(addr, PAGE_SMC);
-                    }
+                } else if ((p->flags & PAGE_EXEC) && seg_info &&
+                        (seg_info->seg_flag & IS_ELF_SEG)) {
+                    page_set_page_state(addr, PAGE_SMC);
                 }
             }
         }

--- a/target/i386/latx/include/aot.h
+++ b/target/i386/latx/include/aot.h
@@ -46,7 +46,11 @@ typedef struct aot_header {
     uint32_t rel_entry_num; /* relocation entries num. */
     uint32_t parallel_tb_num;
     uint32_t unparallel_tb_num;
-    uint8_t is_pe;
+#define ELF_AOT_FILE        1
+#define PE_AOT_FILE         2
+#define CACHE_AOT_FILE      4
+#define HASH_AOT_FILE       8
+    uint8_t aot_file_type;
 } aot_header;
 
 typedef struct aot_file_info {
@@ -79,7 +83,7 @@ typedef struct aot_segment {
     uint32_t segment_tbs_num;
     /* Offset of page_table in AOT. */
     uint32_t page_table_offset;
-    bool is_pe;
+    uint8_t aot_file_type;
 } aot_segment;
 
 typedef struct aot_tb {
@@ -315,7 +319,6 @@ void fix_rel_entry(int fix_id, uint32_t tc_offset);
             (tb)->s_data->rel_end = rel_index;              \
         }                                           \
     } while (0)
-
 
 extern void *aot_buffer;
 extern char *aot_file_path;

--- a/target/i386/latx/include/aot_page.h
+++ b/target/i386/latx/include/aot_page.h
@@ -11,10 +11,12 @@
 typedef enum page_state_type{
     PAGE_UNLOAD = 0,
     PAGE_FLUSH,
+    PAGE_SMC,
     PAGE_LOADED,
     CANNOT_OVERLOAD,
-    PAGE_SMC,
-    PAGE_NOINFO
+    PAGE_NOINFO,
+    HASH_PAGE_LOADED,
+    HASH_PAGE_NOINFO,
 }page_state_type;
 
 typedef struct PageDesc {
@@ -43,7 +45,6 @@ typedef struct page_info {
     void *buffer;
     aot_segment *p_segment;
     char *seg_name;
-    bool is_pe;
     bool is_running;
 } page_info;
 

--- a/target/i386/latx/include/segment.h
+++ b/target/i386/latx/include/segment.h
@@ -19,7 +19,9 @@ typedef struct seg_info {
         uint64_t last_tb_id;
         void *p_segment;
     };
-    bool is_running;
+#define SEG_RUNNING     0x1
+#define IS_ELF_SEG      0x2
+    uint8_t seg_flag;
 } seg_info;
 
 typedef struct wine_sec_info {

--- a/target/i386/latx/include/ts.h
+++ b/target/i386/latx/include/ts.h
@@ -22,8 +22,10 @@ target_ulong get_curr_seg_end(target_ulong curr_pc);
 void get_dynamic_message(TranslationBlock **tb_list, int tb_num,
         seg_info **seg_info_vector, int *seg_info_num);
 char is_pe(char *file_name);
-int is_pe_file(const char *filename);
-int is_elf_file(const char *filename);
+uint8_t is_pe_file(const char *filename);
+uint8_t is_elf_file(const char *filename);
+uint8_t is_deepinwine_cache(const char *file_name);
+uint8_t get_file_type(const char *file_name);
 void ts_push_back(TranslationBlock *tb);
 void pop_back(void);
 char is_bad_tb(TranslationBlock *tb);

--- a/target/i386/latx/optimization/ts.c
+++ b/target/i386/latx/optimization/ts.c
@@ -177,7 +177,7 @@ char is_pe(char *file_name)
 }
 
 #define SIGNATURE_LENGTH 4
-int is_pe_file(const char *filename) {
+uint8_t is_pe_file(const char *filename) {
     FILE *file = fopen(filename, "rb");
     if (!file) {
         perror("Error opening file");
@@ -193,11 +193,10 @@ int is_pe_file(const char *filename) {
 }
 
 #define ELF_MAGIC 0x464C457F  // "\x7FELF"
-int is_elf_file(const char *filename)
+uint8_t is_elf_file(const char *filename)
 {
     FILE *file = fopen(filename, "rb");
     if (!file) {
-        perror("Error opening file");
         return 0;
     }
     uint32_t magic;
@@ -207,6 +206,45 @@ int is_elf_file(const char *filename)
         return 0;
     }
     return (magic == ELF_MAGIC);
+}
+
+#include <libgen.h>
+uint8_t is_deepinwine_cache(const char *file_name)
+{
+    if (!file_name) {
+        return false;
+    }
+    static char *deepinwine_cache_path = NULL;
+    if (deepinwine_cache_path == NULL) {
+        deepinwine_cache_path = (char *)malloc(PATH_MAX);
+        assert(deepinwine_cache_path);
+        char *home = getenv("HOME");
+        if (likely(home)) {
+            snprintf(deepinwine_cache_path, PATH_MAX,
+                    "%s%s", home, "/.deepinwine");
+        } else {
+            snprintf(deepinwine_cache_path, PATH_MAX,
+                    "%s", "/.deepinwine");
+        }
+    }
+    int deepinwine_path_len = strlen(deepinwine_cache_path);
+    if (strncmp(file_name, deepinwine_cache_path, deepinwine_path_len) == 0) {
+        return true;
+    }
+    return false;
+}
+
+uint8_t get_file_type(const char *file_name)
+{
+    if (is_elf_file(file_name)) {
+        return ELF_AOT_FILE;
+    } else if (is_pe_file(file_name)) {
+        return PE_AOT_FILE;
+    } else {
+        /* WARNING: Not only deepinwine cache return CACHE_AOT_FILE. */
+        return CACHE_AOT_FILE;
+    }
+    return 0;
 }
 
 void ts_push_back(TranslationBlock *tb)

--- a/target/i386/latx/sbt/aot.c
+++ b/target/i386/latx/sbt/aot.c
@@ -221,8 +221,7 @@ static struct aot_header *get_aot_buffer(int first_seg_in_lib,
 static void fill_seg_table(int seg_info_begin, int seg_info_end,
         struct aot_header *p_header, struct aot_segment *p_segments)
 {
-    bool is_pe = !is_elf_file(curr_lib_name);
-    p_header->is_pe |= is_pe;
+    uint8_t aot_file_type = p_header->aot_file_type;
     int seg_num_in_file = seg_info_end - seg_info_begin;
     p_header->segments_num = seg_num_in_file;
     p_header->segment_table_offset =
@@ -257,7 +256,7 @@ static void fill_seg_table(int seg_info_begin, int seg_info_end,
             curr_name += strlen(curr_seg_info->file_name) + 1;
         }
 
-        p_segments[seg_id_in_lib].is_pe = is_pe;
+        p_segments[seg_id_in_lib].aot_file_type = aot_file_type;
         p_segments[seg_id_in_lib].lib_name_offset =
             (uintptr_t)last_name - (uintptr_t)p_header;
         p_segments[seg_id_in_lib].segment_tbs_num = 0;
@@ -722,21 +721,27 @@ void do_generate_aot(int first_seg_in_lib, int end_seg_in_lib)
             curr_lib_name);
         return;
     }
-    struct stat statbuf;
-    if (stat(curr_lib_name, &statbuf)) {
-        qemu_log_mask(LAT_LOG_AOT, "ERROT stat %s failed\n", curr_lib_name);
-        return;
-    }
-    for (int i = first_seg_in_lib; i < end_seg_in_lib; i++) {
-        seg_info *seg = seg_info_vector[i];
-        if (seg->lib_size != statbuf.st_size ||
-                seg->tv_sec != statbuf.st_mtim.tv_sec) {
-            fprintf(stderr, "error, orignal lib changed %s\n", curr_lib_name);
+
+    p_header->aot_file_type = get_file_type(curr_lib_name);
+
+    if (p_header->aot_file_type & (ELF_AOT_FILE | PE_AOT_FILE)) {
+        struct stat statbuf;
+        if (stat(curr_lib_name, &statbuf)) {
+            qemu_log_mask(LAT_LOG_AOT, "ERROR stat %s failed\n", curr_lib_name);
             return;
         }
+        for (int i = first_seg_in_lib; i < end_seg_in_lib; i++) {
+            seg_info *seg = seg_info_vector[i];
+            if (seg->lib_size != statbuf.st_size ||
+                    seg->tv_sec != statbuf.st_mtim.tv_sec) {
+                fprintf(stderr, "error, orignal lib changed %s\n", curr_lib_name);
+                return;
+            }
+        }
+        p_header->lib_size = statbuf.st_size;
+        p_header->last_modify_time = statbuf.st_mtim;
     }
-    p_header->lib_size = statbuf.st_size;
-    p_header->last_modify_time = statbuf.st_mtim;
+
     struct aot_segment *p_segments;
     p_segments =
         (struct aot_segment *)ROUND_UP((uintptr_t)(p_header + 1), 8);
@@ -849,10 +854,11 @@ static int get_tb_num(char *lib_name, CPUState *cpu) {
     aot_header *p_header = (aot_header *)buffer;
     /* dump_aot_buffer(p_header); */
     struct stat statbuf;
-    if (stat(lib_name, &statbuf)
+    if ((p_header->aot_file_type & (ELF_AOT_FILE | PE_AOT_FILE))
+            && (stat(lib_name, &statbuf)
             || p_header->lib_size != statbuf.st_size
             || p_header->last_modify_time.tv_sec != statbuf.st_mtim.tv_sec
-            || p_header->last_modify_time.tv_nsec != statbuf.st_mtim.tv_nsec) {
+            || p_header->last_modify_time.tv_nsec != statbuf.st_mtim.tv_nsec)) {
         qemu_log_mask(LAT_LOG_AOT, "need remove old aot file. %s lib_size %d %ld\n",
                 aot_file_path, p_header->lib_size, statbuf.st_size);
         remove(aot_file_path);
@@ -1178,14 +1184,16 @@ lib_info *aot_load(char *lib_name, void **curr_aot_buffer)
     aot_header *p_header = (aot_header *)buffer;
 
     /* Test original file state. */
-    if (stat(lib_name, &statbuf)
-            || p_header->lib_size != statbuf.st_size
-            || p_header->last_modify_time.tv_sec != statbuf.st_mtim.tv_sec
-            || p_header->last_modify_time.tv_nsec != statbuf.st_mtim.tv_nsec) {
-        qemu_log_mask(LAT_LOG_AOT, "need remove old aot file. %s lib_size %d %ld\n",
-                aot_file_path, p_header->lib_size, statbuf.st_size);
-        remove_curr_aot_file();
-        goto exit_aot_load;
+    if (p_header->aot_file_type & (ELF_AOT_FILE | PE_AOT_FILE)) {
+        if (stat(lib_name, &statbuf)
+                || p_header->lib_size != statbuf.st_size
+                || p_header->last_modify_time.tv_sec != statbuf.st_mtim.tv_sec
+                || p_header->last_modify_time.tv_nsec != statbuf.st_mtim.tv_nsec) {
+            qemu_log_mask(LAT_LOG_AOT, "need remove old aot file. %s lib_size %d %ld\n",
+                    aot_file_path, p_header->lib_size, statbuf.st_size);
+            remove_curr_aot_file();
+            goto exit_aot_load;
+        }
     }
 
     /* dump_aot_buffer(p_header); */
@@ -1496,15 +1504,10 @@ static aot_segment *get_segment(char *lib_name, uint64_t aot_offset,
     if (p_segment == NULL) {
         return NULL;
     }
-    if (p_segment->is_pe) {
-        if (p_segment->details.seg_begin == start) {
-            if (lib->is_unmapped) {
-                return NULL;
-            }
-        } else {
-            /* assert(lib); */
-            /* lib->is_unmapped = 1; */
-            /* return NULL; */
+    if (p_segment->aot_file_type & PE_AOT_FILE) {
+        if (p_segment->details.seg_begin != start) {
+            lib->is_unmapped = 1;
+            return NULL;
         }
     }
     if ((p_segment->details.seg_begin >> 31 == 0)
@@ -1590,7 +1593,7 @@ void recover_aot_tb(char *lib_name, uint64_t aot_offset, abi_long start,
         seg->buffer = curr_aot_buffer;
         seg->p_segment = p_segment;
     }
-    if (!p_segment->is_pe) {
+    if (p_segment->aot_file_type & ELF_AOT_FILE) {
         aot_guest_code_protect(start, start + len, p_segment, curr_aot_buffer);
     }
 }

--- a/target/i386/latx/sbt/aot_merge.c
+++ b/target/i386/latx/sbt/aot_merge.c
@@ -449,8 +449,8 @@ static void merge_aot_generate(void)
     char *aot_x86_lib_names = (char *)(aot_page_table + page_count);
     char *last_name = aot_x86_lib_names;
     char *curr_name = aot_x86_lib_names;
-    bool is_pe = !is_elf_file(merge_seg_info_vector[0]->file_name);
-    p_header->is_pe |= is_pe;
+    uint8_t aot_file_type = get_file_type(merge_seg_info_vector[0]->file_name);
+    p_header->aot_file_type = aot_file_type;
     int page_index = 0;
     for (int i = 0; i < seg_info_num; i++) {
         seg_info *curr_seg_info = merge_seg_info_vector[i]->s_info;
@@ -473,7 +473,7 @@ static void merge_aot_generate(void)
             curr_name += strlen(file_name) + 1;
         }
 
-        p_segments[i].is_pe = is_pe;
+        p_segments[i].aot_file_type = aot_file_type;
         p_segments[i].lib_name_offset =
             (uintptr_t)last_name - (uintptr_t)p_header;
         p_segments[i].segment_tbs_num = 0;

--- a/target/i386/latx/sbt/aot_page.c
+++ b/target/i386/latx/sbt/aot_page.c
@@ -69,7 +69,6 @@ void page_tree_insert(target_ulong start, target_ulong end,
     page->buffer = buffer;
     page->p_segment = p_segment;
     page->is_running = false;
-    page->is_pe = p_segment->is_pe;
     g_tree_replace(page_tree, page, page);
 }
 

--- a/target/i386/latx/sbt/aot_recover_tb.c
+++ b/target/i386/latx/sbt/aot_recover_tb.c
@@ -332,7 +332,7 @@ inline int load_page(target_ulong pc, uint32_t cflags, seg_info *info)
 
     target_ulong p1 = pc & TARGET_PAGE_MASK;
 
-    if (p_segment->is_pe) {
+    if (p_segment->aot_file_type & (PE_AOT_FILE | CACHE_AOT_FILE)) {
         if (!check_ir1(info->seg_begin, p_aot_tbs, tb_num_in_page, aot_buffer)) {
             page_set_page_state(pc, PAGE_SMC);
             return 0;
@@ -368,20 +368,22 @@ int load_aot(target_ulong pc, uint32_t cflags)
         return 0;
     }
 
-    int page_state = page_get_page_state(pc);
-    if (page_state >= PAGE_LOADED) {
-        return 0;
-    }
-
     seg_info *info = segment_tree_lookup(pc);
     if (info == NULL || info->buffer == NULL) {
         page_set_page_state(pc, PAGE_NOINFO);
         return 0;
     }
 
+    int page_state = page_get_page_state(pc);
+
+    if (page_state >= PAGE_LOADED || ((page_state == PAGE_SMC)
+                && (((aot_header *)info->buffer)->aot_file_type == ELF_AOT_FILE))) {
+        return 0;
+    }
+
     if (option_aot == 2 &&
-            (info->is_running == false || page_state == PAGE_FLUSH)) {
-        info->is_running = true;
+            (!(info->seg_flag & SEG_RUNNING) || page_state == PAGE_FLUSH)) {
+        info->seg_flag |= SEG_RUNNING;
         page_set_page_state_range(info->seg_begin & TARGET_PAGE_MASK,
                 info->seg_end & TARGET_PAGE_MASK, PAGE_LOADED);
         for (target_ulong addr = info->seg_begin; addr < info->seg_end;

--- a/target/i386/latx/sbt/segment.c
+++ b/target/i386/latx/sbt/segment.c
@@ -148,7 +148,10 @@ void segment_tree_insert(char *name, target_ulong offset, target_ulong begin,
     seg->lib_size = statbuf.st_size;
     seg->buffer = NULL;
     seg->p_segment = NULL;
-    seg->is_running = false;
+    seg->seg_flag = 0;
+    if (is_elf_file(name)) {
+       seg->seg_flag = IS_ELF_SEG;
+    }
     seg_info * old_seg_info = segment_tree_lookup2(begin, end);
     while(old_seg_info) {
        segment_tree_remove(old_seg_info);


### PR DESCRIPTION
ELF_AOT_FILE: AOT files corresponding to ELF binaries
PE_AOT_FILE: AOT files corresponding to PE binaries
CACHE_AOT_FILE: AOT files from cache directories
HASH_AOT_FILE: AOT files generated from hash

Only track SMC pages for ELF files in page_set_flags. PE_AOT_FILE and CACHE_AOT_FILE need check ir1.
CACHE_AOT_FILE do not check origin file change time.