### PR TITLE
LATX, opt: SMC TB reload

### DIFF
--- a/accel/tcg/internal.h
+++ b/accel/tcg/internal.h
@@ -20,4 +20,6 @@ void QEMU_NORETURN cpu_io_recompile(CPUState *cpu, uintptr_t retaddr);
 TranslationBlock *tb_link_page(TranslationBlock *tb, tb_page_addr_t phys_pc,
     tb_page_addr_t phys_page2);
 
+void tb_flush_remove_all(void);
+
 #endif /* ACCEL_TCG_INTERNAL_H */

--- a/accel/tcg/meson.build
+++ b/accel/tcg/meson.build
@@ -5,6 +5,7 @@ tcg_ss.add(files(
   'cpu-exec.c',
   'tcg-runtime-gvec.c',
   'tcg-runtime.c',
+  'tb-flush.c',
   'tb-jump.c',
   'translate-all.c',
   'translator.c',

--- a/accel/tcg/meson.build
+++ b/accel/tcg/meson.build
@@ -5,6 +5,7 @@ tcg_ss.add(files(
   'cpu-exec.c',
   'tcg-runtime-gvec.c',
   'tcg-runtime.c',
+  'tb-jump.c',
   'translate-all.c',
   'translator.c',
 ))

--- a/accel/tcg/tb-flush.c
+++ b/accel/tcg/tb-flush.c
@@ -50,14 +50,14 @@ static gboolean tb_host_size_iter(gpointer key, gpointer value, gpointer data)
 /* flush all the translation blocks */
 void do_tb_flush(CPUState *cpu, run_on_cpu_data tb_flush_count)
 {
+    bool did_flush = false;
+
 #ifdef CONFIG_LATX_AOT
     if (option_aot && in_pre_translate) {
         qemu_log_mask(LAT_LOG_AOT, "FIXME: tb flush in pre translate\n");
         _exit(0);
     }
 #endif
-
-    bool did_flush = false;
 
     mmap_lock();
     /*

--- a/accel/tcg/tb-flush.c
+++ b/accel/tcg/tb-flush.c
@@ -1,0 +1,136 @@
+/*
+ * Translation block flush coordination.
+ *
+ * Copyright (c) 2003 Fabrice Bellard
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or (at
+ * your option) any later version.
+ */
+
+#include "qemu/osdep.h"
+#include "qemu/plugin.h"
+#include "exec/exec-all.h"
+#include "tcg/tcg.h"
+#include "sysemu/tcg.h"
+#include "accel/tcg/internal.h"
+
+#ifdef CONFIG_USER_ONLY
+#include "qemu.h"
+#endif
+
+#ifdef CONFIG_LATX
+#include "latx-options.h"
+#include "smc_reload.h"
+#endif
+#ifdef CONFIG_LATX_AOT
+#include "aot.h"
+#include "ts.h"
+#endif
+#ifdef CONFIG_LATX_FAST_JMPCACHE
+#include "exec/fasttb.h"
+#endif
+
+#ifdef DEBUG_TB_FLUSH
+#define DEBUG_TB_FLUSH_GATE 1
+#else
+#define DEBUG_TB_FLUSH_GATE 0
+#endif
+
+static gboolean tb_host_size_iter(gpointer key, gpointer value, gpointer data)
+{
+    const TranslationBlock *tb = value;
+    size_t *size = data;
+
+    *size += tb->tc.size;
+    return false;
+}
+
+/* flush all the translation blocks */
+void do_tb_flush(CPUState *cpu, run_on_cpu_data tb_flush_count)
+{
+#ifdef CONFIG_LATX_AOT
+    if (option_aot && in_pre_translate) {
+        qemu_log_mask(LAT_LOG_AOT, "FIXME: tb flush in pre translate\n");
+        _exit(0);
+    }
+#endif
+
+    bool did_flush = false;
+
+    mmap_lock();
+    /*
+     * If it is already been done on request of another CPU, just retry.
+     */
+    if (tb_ctx.tb_flush_count != tb_flush_count.host_int) {
+        goto done;
+    }
+    did_flush = true;
+
+#ifdef CONFIG_LATX
+    if (option_smc_reload) {
+        smc_reload_tree_clear();
+    }
+#endif
+
+    if (DEBUG_TB_FLUSH_GATE) {
+        size_t nb_tbs = tcg_nb_tbs();
+        size_t host_size = 0;
+
+        tcg_tb_foreach(tb_host_size_iter, &host_size);
+        printf("qemu: flush code_size=%zu nb_tbs=%zu avg_tb_size=%zu\n",
+               tcg_code_size(), nb_tbs, nb_tbs > 0 ? host_size / nb_tbs : 0);
+    }
+
+    CPU_FOREACH(cpu) {
+#ifdef CONFIG_LATX_FAST_JMPCACHE
+        latx_fast_jmp_cache_clear_all(cpu);
+#endif
+        cpu_tb_jmp_cache_clear(cpu);
+    }
+
+    qht_reset_size(&tb_ctx.htable, CODE_GEN_HTABLE_SIZE);
+    tb_flush_remove_all();
+
+    tcg_region_reset_all();
+    /*
+     * XXX: flush processor icache at this point if cache flush is expensive.
+     */
+    qatomic_mb_set(&tb_ctx.tb_flush_count, tb_ctx.tb_flush_count + 1);
+
+done:
+    mmap_unlock();
+    if (did_flush) {
+        qemu_plugin_flush_cb();
+    }
+#if defined(CONFIG_LATX_KZT)
+    CPU_FOREACH(cpu) {
+        if (cpu && option_kzt) {
+            init_tb_callback_bridge(cpu, &info1);
+        }
+    }
+#endif
+}
+
+static void gen_aot_and_flush(CPUState *cpu, run_on_cpu_data tb_flush_count)
+{
+#ifdef CONFIG_LATX_AOT
+    aot_exit_entry(cpu, false);
+#endif
+    do_tb_flush(cpu, tb_flush_count);
+}
+
+void tb_flush(CPUState *cpu)
+{
+    if (tcg_enabled()) {
+        unsigned tb_flush_count = qatomic_mb_read(&tb_ctx.tb_flush_count);
+
+        if (cpu_in_exclusive_context(cpu)) {
+            gen_aot_and_flush(cpu, RUN_ON_CPU_HOST_INT(tb_flush_count));
+        } else {
+            async_safe_run_on_cpu(cpu, gen_aot_and_flush,
+                                  RUN_ON_CPU_HOST_INT(tb_flush_count));
+        }
+    }
+}

--- a/accel/tcg/tb-jump.c
+++ b/accel/tcg/tb-jump.c
@@ -1,0 +1,31 @@
+/*
+ * Translation block jump reset.
+ */
+#include "qemu/osdep.h"
+
+#include "exec/exec-all.h"
+#include "tcg/tcg.h"
+
+/*
+ * Reset the jump entry 'n' of a TB so that it is not chained to another TB.
+ */
+void tb_reset_jump(TranslationBlock *tb, int n)
+{
+    assert(!use_tu_jmp(tb));
+    uintptr_t addr = (uintptr_t)(tb->tc.ptr + tb->jmp_reset_offset[n]);
+    tb_set_jmp_target(tb, n, addr);
+#ifdef CONFIG_LATX_INSTS_PATTERN
+    if (tb->eflags_target_arg[n] != TB_JMP_RESET_OFFSET_INVALID) {
+        tb_eflag_recover(tb, n);
+    }
+#endif
+#ifdef CONFIG_LATX_XCOMISX_OPT
+    if (tb->jmp_stub_reset_offset[n] != TB_JMP_RESET_OFFSET_INVALID) {
+        uintptr_t offset = tb->jmp_stub_target_arg[n];
+        uintptr_t tc_ptr = (uintptr_t)tb->tc.ptr;
+        uintptr_t jmp_rx = tc_ptr + offset;
+        uintptr_t jmp_rw = jmp_rx - tcg_splitwx_diff;
+        tb_target_set_nop(tc_ptr, jmp_rx, jmp_rw, addr);
+    }
+#endif
+}

--- a/accel/tcg/tb-jump.c
+++ b/accel/tcg/tb-jump.c
@@ -1,5 +1,20 @@
 /*
  * Translation block jump reset.
+ *
+ * Copyright (c) 2003 Fabrice Bellard
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
  */
 #include "qemu/osdep.h"
 
@@ -11,8 +26,10 @@
  */
 void tb_reset_jump(TranslationBlock *tb, int n)
 {
+    uintptr_t addr;
+
     assert(!use_tu_jmp(tb));
-    uintptr_t addr = (uintptr_t)(tb->tc.ptr + tb->jmp_reset_offset[n]);
+    addr = (uintptr_t)(tb->tc.ptr + tb->jmp_reset_offset[n]);
     tb_set_jmp_target(tb, n, addr);
 #ifdef CONFIG_LATX_INSTS_PATTERN
     if (tb->eflags_target_arg[n] != TB_JMP_RESET_OFFSET_INVALID) {

--- a/accel/tcg/translate-all.c
+++ b/accel/tcg/translate-all.c
@@ -80,6 +80,7 @@
 #include "accel/tcg/internal.h"
 #include "ts.h"
 #include "latx-smc.h"
+#include "smc_reload.h"
 #endif
 #ifdef CONFIG_LATX_FAST_JMPCACHE
 #include "exec/fasttb.h"
@@ -564,7 +565,7 @@ static bool is_shadow_page_shmm(target_ulong address)
     return spd && spd->is_shmm;
 }
 
-static bool is_shadow_page_not_shmm(target_ulong address)
+bool is_shadow_page_not_shmm(target_ulong address)
 {
     ShadowPageDesc *spd = page_get_target_data(address);
     return spd && !(spd->is_shmm);
@@ -1682,6 +1683,10 @@ static void gen_aot_and_flush(CPUState *cpu, run_on_cpu_data tb_flush_count)
 
 void tb_flush(CPUState *cpu)
 {
+    if (option_smc_reload) {
+        reload_tree_clear();
+    }
+
     if (tcg_enabled()) {
         unsigned tb_flush_count = qatomic_mb_read(&tb_ctx.tb_flush_count);
 
@@ -3583,10 +3588,60 @@ bool pageflags_set_clear(target_ulong start, target_ulong last,
     return inval_tb;
 }
 
+static void add_smc_node(tb_page_addr_t start, tb_page_addr_t end)
+{
+    if (!option_smc_reload || !option_aot) {
+        return;
+    }
+    if (segment_tree_lookup2(start, end)) {
+        return;
+    }
+
+    TranslationBlock *tb;
+    PageForEachNext next_tb;
+    int ir1_size;
+    int curr_page_tb_num;
+
+    for (target_ulong curr_page = start; curr_page < end; curr_page += TARGET_PAGE_SIZE) {
+        curr_page_tb_num = 0;
+        ir1_size = 0;
+        PAGE_FOR_EACH_TB(curr_page, curr_page + TARGET_PAGE_SIZE, unused, tb, next_tb) {
+            if ((tb->pc & TARGET_PAGE_MASK) == curr_page) {
+                curr_page_tb_num++;
+                ir1_size += tb->size;
+            }
+        }
+        if (curr_page_tb_num) {
+            reload_info *reload_node = (reload_info *)malloc(sizeof(reload_info));
+            reload_node->tb_num = curr_page_tb_num;
+            reload_node->page_addr = curr_page;
+            assert(reload_node);
+            reload_node->tb_vector =
+                (TranslationBlock **)malloc(curr_page_tb_num * sizeof(TranslationBlock *));
+            assert(reload_node->tb_vector);
+            reload_node->ir1_code_buffer = malloc(ir1_size);
+            assert(reload_node->ir1_code_buffer);
+            int tb_id = 0;
+            ir1_size = 0;
+            PAGE_FOR_EACH_TB(curr_page, curr_page + TARGET_PAGE_SIZE, unused, tb, next_tb) {
+                if ((tb->pc & TARGET_PAGE_MASK) == curr_page) {
+                    memcpy(reload_node->ir1_code_buffer + ir1_size,
+                            (void *)(uintptr_t)tb->pc, tb->size);
+                    reload_node->tb_vector[tb_id++] = tb;
+                    ir1_size += tb->size;
+                }
+            }
+            reload_tree_insert(reload_node);
+        }
+    }
+}
+
 /* Modify the flags of a page and invalidate the code if necessary.
+   Save SMC TB to reload_tree if necessary.
    The flag PAGE_WRITE_ORG is positioned automatically depending
    on PAGE_WRITE.  The mmap_lock should already be held.  */
-void page_set_flags(target_ulong start, target_ulong end, int flags)
+void page_set_flags_tb_reload(target_ulong start, target_ulong end,
+        int flags, bool tb_reload)
 {
 #ifdef CONFIG_LATX_PERF
     latx_timer_start(TIMER_PAGE_FLAGS);
@@ -3657,11 +3712,22 @@ void page_set_flags(target_ulong start, target_ulong end, int flags)
     }
 
     if (inval_tb) {
+        if (tb_reload) {
+            add_smc_node(start, end);
+        }
         tb_invalidate_phys_range(start, end);
     }
 #ifdef CONFIG_LATX_PERF
     latx_timer_stop(TIMER_PAGE_FLAGS);
 #endif
+}
+
+/* Modify the flags of a page and invalidate the code if necessary.
+   The flag PAGE_WRITE_ORG is positioned automatically depending
+   on PAGE_WRITE.  The mmap_lock should already be held.  */
+void page_set_flags(target_ulong start, target_ulong end, int flags)
+{
+    page_set_flags_tb_reload(start, end, flags, false);
 }
 
 typedef struct TargetPageDataNode {

--- a/accel/tcg/translate-all.c
+++ b/accel/tcg/translate-all.c
@@ -1782,30 +1782,6 @@ static inline void tb_remove_from_jmp_list(TranslationBlock *orig, int n_orig)
     g_assert_not_reached();
 }
 
-/* reset the jump entry 'n' of a TB so that it is not chained to
-   another TB */
-void tb_reset_jump(TranslationBlock *tb, int n)
-{
-    assert(!use_tu_jmp(tb));
-    uintptr_t addr = (uintptr_t)(tb->tc.ptr + tb->jmp_reset_offset[n]);
-    tb_set_jmp_target(tb, n, addr);
-#ifdef CONFIG_LATX_INSTS_PATTERN
-    if (tb->eflags_target_arg[n] !=
-        TB_JMP_RESET_OFFSET_INVALID) {
-        tb_eflag_recover(tb, n);
-    }
-#endif
-#ifdef CONFIG_LATX_XCOMISX_OPT
-    if (tb->jmp_stub_reset_offset[n] != TB_JMP_RESET_OFFSET_INVALID) {
-        uintptr_t offset = tb->jmp_stub_target_arg[n];
-        uintptr_t tc_ptr = (uintptr_t)tb->tc.ptr;
-        uintptr_t jmp_rx = tc_ptr + offset;
-        uintptr_t jmp_rw = jmp_rx - tcg_splitwx_diff;
-        tb_target_set_nop(tc_ptr, jmp_rx, jmp_rw, addr);
-    }
-#endif
-}
-
 /* remove any jumps to the TB */
 static inline void tb_jmp_unlink(TranslationBlock *dest)
 {

--- a/accel/tcg/translate-all.c
+++ b/accel/tcg/translate-all.c
@@ -1424,7 +1424,7 @@ static inline void invalidate_page_bitmap(PageDesc *p)
  */
 static IntervalTreeRoot tb_root;
 
-static void tb_remove_all(void)
+void tb_flush_remove_all(void)
 {
     assert_memory_lock();
     memset(&tb_root, 0, sizeof(tb_root));
@@ -1526,7 +1526,7 @@ static void tb_remove_all_1(int level, void **lp)
     }
 }
 
-static void tb_remove_all(void)
+void tb_flush_remove_all(void)
 {
     int i, l1_sz = v_l1_size;
 
@@ -1604,103 +1604,6 @@ static void tb_remove(TranslationBlock *tb)
     }
 }
 #endif /* CONFIG_USER_ONLY */
-
-static gboolean tb_host_size_iter(gpointer key, gpointer value, gpointer data)
-{
-    const TranslationBlock *tb = value;
-    size_t *size = data;
-
-    *size += tb->tc.size;
-    return false;
-}
-
-/* flush all the translation blocks */
-void do_tb_flush(CPUState *cpu, run_on_cpu_data tb_flush_count)
-{
-#ifdef CONFIG_LATX_AOT
-    if (option_aot && in_pre_translate) {
-	qemu_log_mask(LAT_LOG_AOT, "FIXME: tb flush in pre translate\n");
-	_exit(0);
-    }
-#endif
-
-    bool did_flush = false;
-
-    mmap_lock();
-    /* If it is already been done on request of another CPU,
-     * just retry.
-     */
-    if (tb_ctx.tb_flush_count != tb_flush_count.host_int) {
-        goto done;
-    }
-    did_flush = true;
-
-    if (DEBUG_TB_FLUSH_GATE) {
-        size_t nb_tbs = tcg_nb_tbs();
-        size_t host_size = 0;
-
-        tcg_tb_foreach(tb_host_size_iter, &host_size);
-        printf("qemu: flush code_size=%zu nb_tbs=%zu avg_tb_size=%zu\n",
-               tcg_code_size(), nb_tbs, nb_tbs > 0 ? host_size / nb_tbs : 0);
-    }
-
-    CPU_FOREACH(cpu) {
-#ifdef CONFIG_LATX_FAST_JMPCACHE
-        latx_fast_jmp_cache_clear_all(cpu);
-#endif
-        cpu_tb_jmp_cache_clear(cpu);
-    }
-
-    qht_reset_size(&tb_ctx.htable, CODE_GEN_HTABLE_SIZE);
-    tb_remove_all();
-
-    tcg_region_reset_all();
-    /* XXX: flush processor icache at this point if cache flush is
-       expensive */
-    qatomic_mb_set(&tb_ctx.tb_flush_count, tb_ctx.tb_flush_count + 1);
-
-done:
-    mmap_unlock();
-    if (did_flush) {
-        qemu_plugin_flush_cb();
-    }
-#if defined(CONFIG_LATX_KZT)
-    CPU_FOREACH(cpu) {
-        if (cpu && option_kzt) {
-            init_tb_callback_bridge(cpu, &info1);
-        }
-    }
-#endif
-}
-
-static void gen_aot_and_flush(CPUState *cpu, run_on_cpu_data tb_flush_count)
-{
-#ifdef CONFIG_LATX_AOT
-    aot_exit_entry(cpu, false);
-#endif
-    do_tb_flush(cpu, tb_flush_count);
-}
-
-void tb_flush(CPUState *cpu)
-{
-    if (option_smc_reload) {
-        smc_reload_tree_clear();
-    }
-
-    if (tcg_enabled()) {
-        unsigned tb_flush_count = qatomic_mb_read(&tb_ctx.tb_flush_count);
-
-        if (cpu_in_exclusive_context(cpu)) {
-            /* do_tb_flush(cpu, RUN_ON_CPU_HOST_INT(tb_flush_count)); */
-            gen_aot_and_flush(cpu, RUN_ON_CPU_HOST_INT(tb_flush_count));
-        } else {
-            /* async_safe_run_on_cpu(cpu, do_tb_flush, */
-            /*                       RUN_ON_CPU_HOST_INT(tb_flush_count)); */
-            async_safe_run_on_cpu(cpu, gen_aot_and_flush,
-                                   RUN_ON_CPU_HOST_INT(tb_flush_count));
-        }
-    }
-}
 
 /*
  * Formerly ifdef DEBUG_TB_CHECK. These debug functions are user-mode-only,

--- a/accel/tcg/translate-all.c
+++ b/accel/tcg/translate-all.c
@@ -3509,8 +3509,9 @@ static void add_smc_node(tb_page_addr_t start, tb_page_addr_t end)
             PAGE_FOR_EACH_TB(curr_page, curr_page + TARGET_PAGE_SIZE,
                              unused, tb, next_tb) {
                 if ((tb->pc & TARGET_PAGE_MASK) == curr_page) {
-                    memcpy(reload_node->ir1_code_buffer + ir1_size,
-                           g2h_untagged(tb->pc), tb->size);
+                    smc_reload_save_tb_code(
+                        reload_node->ir1_code_buffer + ir1_size,
+                        tb->pc, tb->size);
                     reload_node->tb_vector[tb_id++] = tb;
                     ir1_size += tb->size;
                 }

--- a/accel/tcg/translate-all.c
+++ b/accel/tcg/translate-all.c
@@ -3478,7 +3478,8 @@ static void add_smc_node(tb_page_addr_t start, tb_page_addr_t end)
     if (!option_smc_reload || !option_aot) {
         return;
     }
-    if (segment_tree_lookup2(start, end)) {
+    if (!smc_reload_segment_is_candidate(
+            segment_tree_lookup2(start, end))) {
         return;
     }
 

--- a/accel/tcg/translate-all.c
+++ b/accel/tcg/translate-all.c
@@ -3606,7 +3606,7 @@ static void add_smc_node(tb_page_addr_t start, tb_page_addr_t end)
                              unused, tb, next_tb) {
                 if ((tb->pc & TARGET_PAGE_MASK) == curr_page) {
                     memcpy(reload_node->ir1_code_buffer + ir1_size,
-                           (const void *)(uintptr_t)tb->pc, tb->size);
+                           g2h_untagged(tb->pc), tb->size);
                     reload_node->tb_vector[tb_id++] = tb;
                     ir1_size += tb->size;
                 }

--- a/accel/tcg/translate-all.c
+++ b/accel/tcg/translate-all.c
@@ -565,7 +565,7 @@ static bool is_shadow_page_shmm(target_ulong address)
     return spd && spd->is_shmm;
 }
 
-bool is_shadow_page_not_shmm(target_ulong address)
+bool page_is_shadow_not_shmm(target_ulong address)
 {
     ShadowPageDesc *spd = page_get_target_data(address);
     return spd && !(spd->is_shmm);
@@ -1684,7 +1684,7 @@ static void gen_aot_and_flush(CPUState *cpu, run_on_cpu_data tb_flush_count)
 void tb_flush(CPUState *cpu)
 {
     if (option_smc_reload) {
-        reload_tree_clear();
+        smc_reload_tree_clear();
     }
 
     if (tcg_enabled()) {
@@ -2301,7 +2301,7 @@ TranslationBlock *tb_gen_code(CPUState *cpu,
      * but the paired page cross 16K boundary is still not protected.
      */
     int p_flags = page_get_flags(pc);
-    if ((p_flags & PAGE_WRITE) && !is_shadow_page_not_shmm(pc)) {
+    if ((p_flags & PAGE_WRITE) && !page_is_shadow_not_shmm(pc)) {
         mprotect((void*)(pc & qemu_host_page_mask), qemu_host_page_size, PROT_READ);
     }
 
@@ -3590,6 +3590,12 @@ bool pageflags_set_clear(target_ulong start, target_ulong last,
 
 static void add_smc_node(tb_page_addr_t start, tb_page_addr_t end)
 {
+    TranslationBlock *tb;
+    PageForEachNext next_tb;
+    target_ulong curr_page;
+    size_t ir1_size;
+    unsigned int curr_page_tb_count;
+
     if (!option_smc_reload || !option_aot) {
         return;
     }
@@ -3597,49 +3603,49 @@ static void add_smc_node(tb_page_addr_t start, tb_page_addr_t end)
         return;
     }
 
-    TranslationBlock *tb;
-    PageForEachNext next_tb;
-    int ir1_size;
-    int curr_page_tb_num;
-
-    for (target_ulong curr_page = start; curr_page < end; curr_page += TARGET_PAGE_SIZE) {
-        curr_page_tb_num = 0;
+    for (curr_page = start; curr_page < end;
+         curr_page += TARGET_PAGE_SIZE) {
+        curr_page_tb_count = 0;
         ir1_size = 0;
-        PAGE_FOR_EACH_TB(curr_page, curr_page + TARGET_PAGE_SIZE, unused, tb, next_tb) {
+        PAGE_FOR_EACH_TB(curr_page, curr_page + TARGET_PAGE_SIZE,
+                         unused, tb, next_tb) {
             if ((tb->pc & TARGET_PAGE_MASK) == curr_page) {
-                curr_page_tb_num++;
+                curr_page_tb_count++;
                 ir1_size += tb->size;
             }
         }
-        if (curr_page_tb_num) {
-            reload_info *reload_node = (reload_info *)malloc(sizeof(reload_info));
-            reload_node->tb_num = curr_page_tb_num;
+        if (curr_page_tb_count) {
+            SMCReloadInfo *reload_node;
+            unsigned int tb_id;
+
+            reload_node = g_new(SMCReloadInfo, 1);
+            reload_node->tb_count = curr_page_tb_count;
             reload_node->page_addr = curr_page;
-            assert(reload_node);
             reload_node->tb_vector =
-                (TranslationBlock **)malloc(curr_page_tb_num * sizeof(TranslationBlock *));
-            assert(reload_node->tb_vector);
-            reload_node->ir1_code_buffer = malloc(ir1_size);
-            assert(reload_node->ir1_code_buffer);
-            int tb_id = 0;
+                g_new(TranslationBlock *, curr_page_tb_count);
+            reload_node->ir1_code_buffer = g_malloc(ir1_size);
+            tb_id = 0;
             ir1_size = 0;
-            PAGE_FOR_EACH_TB(curr_page, curr_page + TARGET_PAGE_SIZE, unused, tb, next_tb) {
+            PAGE_FOR_EACH_TB(curr_page, curr_page + TARGET_PAGE_SIZE,
+                             unused, tb, next_tb) {
                 if ((tb->pc & TARGET_PAGE_MASK) == curr_page) {
                     memcpy(reload_node->ir1_code_buffer + ir1_size,
-                            (void *)(uintptr_t)tb->pc, tb->size);
+                           (const void *)(uintptr_t)tb->pc, tb->size);
                     reload_node->tb_vector[tb_id++] = tb;
                     ir1_size += tb->size;
                 }
             }
-            reload_tree_insert(reload_node);
+            smc_reload_tree_insert(reload_node);
         }
     }
 }
 
-/* Modify the flags of a page and invalidate the code if necessary.
-   Save SMC TB to reload_tree if necessary.
-   The flag PAGE_WRITE_ORG is positioned automatically depending
-   on PAGE_WRITE.  The mmap_lock should already be held.  */
+/*
+ * Modify the flags of a page and invalidate the code if necessary.
+ * Save SMC TBs to the SMC reload tree if necessary.
+ * The flag PAGE_WRITE_ORG is positioned automatically depending
+ * on PAGE_WRITE.  The mmap_lock should already be held.
+ */
 void page_set_flags_tb_reload(target_ulong start, target_ulong end,
         int flags, bool tb_reload)
 {
@@ -3722,9 +3728,11 @@ void page_set_flags_tb_reload(target_ulong start, target_ulong end,
 #endif
 }
 
-/* Modify the flags of a page and invalidate the code if necessary.
-   The flag PAGE_WRITE_ORG is positioned automatically depending
-   on PAGE_WRITE.  The mmap_lock should already be held.  */
+/*
+ * Modify the flags of a page and invalidate the code if necessary.
+ * The flag PAGE_WRITE_ORG is positioned automatically depending
+ * on PAGE_WRITE.  The mmap_lock should already be held.
+ */
 void page_set_flags(target_ulong start, target_ulong end, int flags)
 {
     page_set_flags_tb_reload(start, end, flags, false);
@@ -3999,7 +4007,7 @@ void page_protect(tb_page_addr_t address)
         }
 
         pageflags_set_clear(start, last, 0, PAGE_WRITE);
-        if (!is_shadow_page_not_shmm(address)) {
+        if (!page_is_shadow_not_shmm(address)) {
             mprotect(g2h_untagged(start), qemu_host_page_size,
                     (prot & PAGE_BITS) & ~PAGE_WRITE);
         }
@@ -4699,7 +4707,7 @@ no_pageflags_cache:
             if (prot & PAGE_EXEC) {
                 prot = (prot & ~PAGE_EXEC) | PAGE_READ;
             }
-            if (!is_shadow_page_not_shmm(address)) {
+            if (!page_is_shadow_not_shmm(address)) {
                 mprotect((void *)g2h_untagged(start), len, prot & PAGE_BITS);
             }
         }

--- a/include/exec/cpu-all.h
+++ b/include/exec/cpu-all.h
@@ -291,6 +291,8 @@ target_ulong get_first_page(target_ulong start, target_ulong end);
 int page_get_flags(target_ulong address);
 void page_clear_overflow(target_ulong start, target_ulong end);
 void page_set_flags(target_ulong start, target_ulong end, int flags);
+void page_set_flags_tb_reload(target_ulong start, target_ulong end,
+        int flags, bool tb_reload);
 bool pageflags_set_clear(target_ulong start, target_ulong last,
                                 int set_flags, int clear_flags);
 int page_get_page_state(target_ulong address);

--- a/include/exec/cpu-all.h
+++ b/include/exec/cpu-all.h
@@ -292,7 +292,7 @@ int page_get_flags(target_ulong address);
 void page_clear_overflow(target_ulong start, target_ulong end);
 void page_set_flags(target_ulong start, target_ulong end, int flags);
 void page_set_flags_tb_reload(target_ulong start, target_ulong end,
-        int flags, bool tb_reload);
+                              int flags, bool tb_reload);
 bool pageflags_set_clear(target_ulong start, target_ulong last,
                                 int set_flags, int clear_flags);
 int page_get_page_state(target_ulong address);

--- a/include/exec/translate-all.h
+++ b/include/exec/translate-all.h
@@ -23,7 +23,7 @@
 extern void *l1_map[];
 extern IntervalTreeRoot pageflags_root;
 /* translate-all.c */
-bool is_shadow_page_not_shmm(target_ulong address);
+bool page_is_shadow_not_shmm(target_ulong address);
 struct page_collection *page_collection_lock(tb_page_addr_t start,
                                              tb_page_addr_t end);
 void page_collection_unlock(struct page_collection *set);

--- a/include/exec/translate-all.h
+++ b/include/exec/translate-all.h
@@ -23,6 +23,7 @@
 extern void *l1_map[];
 extern IntervalTreeRoot pageflags_root;
 /* translate-all.c */
+bool is_shadow_page_not_shmm(target_ulong address);
 struct page_collection *page_collection_lock(tb_page_addr_t start,
                                              tb_page_addr_t end);
 void page_collection_unlock(struct page_collection *set);

--- a/linux-user/main.c
+++ b/linux-user/main.c
@@ -728,7 +728,10 @@ static void handle_arg_latx_monitor_shared_mem(const char *arg)
 
 static void handle_arg_smc_reload(const char *arg)
 {
-    option_smc_reload = strtol(arg, NULL, 0);
+    long value = 0;
+
+    qemu_strtol(arg, NULL, 0, &value);
+    option_smc_reload = value;
     if (option_smc_reload) {
         option_jr_ra = 0;
     }

--- a/linux-user/main.c
+++ b/linux-user/main.c
@@ -726,6 +726,14 @@ static void handle_arg_latx_monitor_shared_mem(const char *arg)
     option_monitor_shared_mem = strtol(arg, NULL, 0);
 }
 
+static void handle_arg_smc_reload(const char *arg)
+{
+    option_smc_reload = strtol(arg, NULL, 0);
+    if (option_smc_reload) {
+        option_jr_ra = 0;
+    }
+}
+
 #ifdef CONFIG_LATX_AOT
 static void handle_arg_latx_aot(const char *arg)
 {
@@ -833,6 +841,8 @@ static const struct qemu_argument arg_table[] = {
     "",           "enable get real self maps"},
     {"latx-monitor-shared-mem",    "LATX_MONITOR_SHARED_MEM",     true,  handle_arg_latx_monitor_shared_mem,
     "",           "monitor shared memory, retranslate self modifying page"},
+    {"smc_reload",    "LATX_SMC_RELOAD",     true,  handle_arg_smc_reload,
+    "",           "reload SMC TB"},
 #ifdef CONFIG_LATX_AOT
     {"latx-aot",    "LATX_AOT",     true,  handle_arg_latx_aot,
     "",           "enable aot"},

--- a/linux-user/mmap.c
+++ b/linux-user/mmap.c
@@ -174,7 +174,7 @@ int target_mprotect(abi_ulong start, abi_ulong len, int target_prot)
             if ((prot_tmp & PAGE_EXEC) && !(prot_tmp & PAGE_WRITE) &&
                 (prot_tmp & PAGE_WRITE_ORG) && (target_prot & PAGE_WRITE)) {
                 page_set_flags_tb_reload(addr, addr + TARGET_PAGE_SIZE,
-                                prot_tmp | PAGE_WRITE, true);
+                                         prot_tmp | PAGE_WRITE, true);
             }
             prot1 |= prot_tmp;
         }
@@ -185,7 +185,7 @@ int target_mprotect(abi_ulong start, abi_ulong len, int target_prot)
                 if ((prot_tmp & PAGE_EXEC) && !(prot_tmp & PAGE_WRITE) &&
                     (prot_tmp & PAGE_WRITE_ORG) && (target_prot & PAGE_WRITE)) {
                     page_set_flags_tb_reload(addr, addr + TARGET_PAGE_SIZE,
-                                    prot_tmp | PAGE_WRITE, true);
+                                             prot_tmp | PAGE_WRITE, true);
                 }
                 prot1 |= prot_tmp;
             }
@@ -223,7 +223,7 @@ int target_mprotect(abi_ulong start, abi_ulong len, int target_prot)
             if ((prot_tmp & PAGE_EXEC) && !(prot_tmp & PAGE_WRITE) &&
                 (prot_tmp & PAGE_WRITE_ORG) && (target_prot & PAGE_WRITE)) {
                 page_set_flags_tb_reload(addr, addr + TARGET_PAGE_SIZE,
-                                prot_tmp | PAGE_WRITE, true);
+                                         prot_tmp | PAGE_WRITE, true);
             }
             prot1 |= prot_tmp;
         }
@@ -260,7 +260,7 @@ int target_mprotect(abi_ulong start, abi_ulong len, int target_prot)
 
     page_set_flags_tb_reload(start, start + len, page_flags, true);
 
-    if(target_prot == PROT_NONE) {
+    if (target_prot == PROT_NONE) {
 #ifdef CONFIG_LATX_AOT
         if (option_aot && segment_tree_lookup2(start, start + len)) {
             page_set_page_state_range(start, start + len, PAGE_SMC);

--- a/linux-user/mmap.c
+++ b/linux-user/mmap.c
@@ -173,8 +173,8 @@ int target_mprotect(abi_ulong start, abi_ulong len, int target_prot)
             prot_tmp = page_get_flags(addr);
             if ((prot_tmp & PAGE_EXEC) && !(prot_tmp & PAGE_WRITE) &&
                 (prot_tmp & PAGE_WRITE_ORG) && (target_prot & PAGE_WRITE)) {
-                page_set_flags(addr, addr + TARGET_PAGE_SIZE,
-                                prot_tmp | PAGE_WRITE);
+                page_set_flags_tb_reload(addr, addr + TARGET_PAGE_SIZE,
+                                prot_tmp | PAGE_WRITE, true);
             }
             prot1 |= prot_tmp;
         }
@@ -184,8 +184,8 @@ int target_mprotect(abi_ulong start, abi_ulong len, int target_prot)
                 prot_tmp = page_get_flags(addr);
                 if ((prot_tmp & PAGE_EXEC) && !(prot_tmp & PAGE_WRITE) &&
                     (prot_tmp & PAGE_WRITE_ORG) && (target_prot & PAGE_WRITE)) {
-                    page_set_flags(addr, addr + TARGET_PAGE_SIZE,
-                                    prot_tmp | PAGE_WRITE);
+                    page_set_flags_tb_reload(addr, addr + TARGET_PAGE_SIZE,
+                                    prot_tmp | PAGE_WRITE, true);
                 }
                 prot1 |= prot_tmp;
             }
@@ -222,8 +222,8 @@ int target_mprotect(abi_ulong start, abi_ulong len, int target_prot)
             prot_tmp = page_get_flags(addr);
             if ((prot_tmp & PAGE_EXEC) && !(prot_tmp & PAGE_WRITE) &&
                 (prot_tmp & PAGE_WRITE_ORG) && (target_prot & PAGE_WRITE)) {
-                page_set_flags(addr, addr + TARGET_PAGE_SIZE,
-                                prot_tmp | PAGE_WRITE);
+                page_set_flags_tb_reload(addr, addr + TARGET_PAGE_SIZE,
+                                prot_tmp | PAGE_WRITE, true);
             }
             prot1 |= prot_tmp;
         }
@@ -258,7 +258,8 @@ int target_mprotect(abi_ulong start, abi_ulong len, int target_prot)
         }
     }
 
-    page_set_flags(start, start + len, page_flags);
+    page_set_flags_tb_reload(start, start + len, page_flags, true);
+
     if(target_prot == PROT_NONE) {
 #ifdef CONFIG_LATX_AOT
         if (option_aot && segment_tree_lookup2(start, start + len)) {

--- a/meson.build
+++ b/meson.build
@@ -607,6 +607,7 @@ foreach target : target_dirs
                                             dependencies: [glib],
                                             include_directories: target_inc,
                                             link_args: ['-Wl,--gc-sections',
+                                                '-Wl,--wrap=mprotect',
                                                 '-Wl,--no-export-dynamic'])
     test('latx-smc-reload-guest-base', smc_reload_guest_base_test)
 

--- a/meson.build
+++ b/meson.build
@@ -593,6 +593,22 @@ foreach target : target_dirs
                                     link_args: ['-Wl,--gc-sections',
                                         '-Wl,--no-export-dynamic'])
     test('latx-smc-reload-tu', smc_reload_tu_test)
+
+    smc_reload_guest_base_test = executable('test-latx-smc-reload-guest-base',
+                                            files('target/i386/latx/sbt/tests/smc-reload-guest-base-test.c',
+                                                  'target/i386/latx/sbt/smc_reload.c',
+                                                  'target/i386/latx/sbt/aot_smc_reload.c',
+                                                  'accel/tcg/tb-jump.c',
+                                                  'util/pagesize.c'),
+                                            c_args: c_args + ['-ffunction-sections',
+                                                '-fvisibility=hidden',
+                                                '-I' + (meson.current_build_dir() /
+                                                ('libqemu-' + target + '.fa.p'))],
+                                            dependencies: [glib],
+                                            include_directories: target_inc,
+                                            link_args: ['-Wl,--gc-sections',
+                                                '-Wl,--no-export-dynamic'])
+    test('latx-smc-reload-guest-base', smc_reload_guest_base_test)
   endif
 
     execs = [{

--- a/meson.build
+++ b/meson.build
@@ -609,6 +609,20 @@ foreach target : target_dirs
                                             link_args: ['-Wl,--gc-sections',
                                                 '-Wl,--no-export-dynamic'])
     test('latx-smc-reload-guest-base', smc_reload_guest_base_test)
+
+    smc_reload_async_flush_test = executable('test-latx-tb-flush-smc-reload-async',
+                                             files('target/i386/latx/sbt/tests/tb-flush-smc-reload-async-test.c',
+                                                   'target/i386/latx/sbt/smc_reload.c',
+                                                   'accel/tcg/tb-flush.c'),
+                                             c_args: c_args + ['-ffunction-sections',
+                                                 '-fvisibility=hidden',
+                                                 '-I' + (meson.current_build_dir() /
+                                                 ('libqemu-' + target + '.fa.p'))],
+                                             dependencies: [glib],
+                                             include_directories: target_inc,
+                                             link_args: ['-Wl,--gc-sections',
+                                                 '-Wl,--no-export-dynamic'])
+    test('latx-tb-flush-smc-reload-async', smc_reload_async_flush_test)
   endif
 
     execs = [{

--- a/meson.build
+++ b/meson.build
@@ -579,50 +579,60 @@ foreach target : target_dirs
                  name_suffix: 'fa')
 
   if target == 'x86_64-linux-user' and 'CONFIG_LATX_O1' in config_host
-    smc_reload_tu_test = executable('test-latx-smc-reload-tu',
-                                    files('target/i386/latx/sbt/tests/smc-reload-tu-test.c',
-                                          'target/i386/latx/sbt/smc_reload.c',
-                                          'target/i386/latx/sbt/aot_smc_reload.c',
-                                          'accel/tcg/tb-jump.c'),
-                                    c_args: c_args + ['-ffunction-sections',
-                                        '-fvisibility=hidden',
-                                        '-I' + (meson.current_build_dir() /
-                                        ('libqemu-' + target + '.fa.p'))],
-                                    dependencies: [glib],
-                                    include_directories: target_inc,
-                                    link_args: ['-Wl,--gc-sections',
-                                        '-Wl,--no-export-dynamic'])
+    smc_reload_test_c_args = c_args + [
+      '-ffunction-sections',
+      '-fvisibility=hidden',
+      '-I' + (meson.current_build_dir() /
+              ('libqemu-' + target + '.fa.p'))
+    ]
+    smc_reload_test_link_args = [
+      '-Wl,--gc-sections',
+      '-Wl,--no-export-dynamic'
+    ]
+
+    smc_reload_tu_test = executable(
+      'test-latx-smc-reload-tu',
+      files(
+        'target/i386/latx/sbt/tests/smc-reload-tu-test.c',
+        'target/i386/latx/sbt/smc_reload.c',
+        'target/i386/latx/sbt/aot_smc_reload.c',
+        'accel/tcg/tb-jump.c'
+      ),
+      c_args: smc_reload_test_c_args,
+      dependencies: [glib],
+      include_directories: target_inc,
+      link_args: smc_reload_test_link_args
+    )
     test('latx-smc-reload-tu', smc_reload_tu_test)
 
-    smc_reload_guest_base_test = executable('test-latx-smc-reload-guest-base',
-                                            files('target/i386/latx/sbt/tests/smc-reload-guest-base-test.c',
-                                                  'target/i386/latx/sbt/smc_reload.c',
-                                                  'target/i386/latx/sbt/aot_smc_reload.c',
-                                                  'accel/tcg/tb-jump.c',
-                                                  'util/pagesize.c'),
-                                            c_args: c_args + ['-ffunction-sections',
-                                                '-fvisibility=hidden',
-                                                '-I' + (meson.current_build_dir() /
-                                                ('libqemu-' + target + '.fa.p'))],
-                                            dependencies: [glib],
-                                            include_directories: target_inc,
-                                            link_args: ['-Wl,--gc-sections',
-                                                '-Wl,--wrap=mprotect',
-                                                '-Wl,--no-export-dynamic'])
+    smc_reload_guest_base_test = executable(
+      'test-latx-smc-reload-guest-base',
+      files(
+        'target/i386/latx/sbt/tests/smc-reload-guest-base-test.c',
+        'target/i386/latx/sbt/smc_reload.c',
+        'target/i386/latx/sbt/aot_smc_reload.c',
+        'accel/tcg/tb-jump.c',
+        'util/pagesize.c'
+      ),
+      c_args: smc_reload_test_c_args,
+      dependencies: [glib],
+      include_directories: target_inc,
+      link_args: smc_reload_test_link_args + ['-Wl,--wrap=mprotect']
+    )
     test('latx-smc-reload-guest-base', smc_reload_guest_base_test)
 
-    smc_reload_async_flush_test = executable('test-latx-tb-flush-smc-reload-async',
-                                             files('target/i386/latx/sbt/tests/tb-flush-smc-reload-async-test.c',
-                                                   'target/i386/latx/sbt/smc_reload.c',
-                                                   'accel/tcg/tb-flush.c'),
-                                             c_args: c_args + ['-ffunction-sections',
-                                                 '-fvisibility=hidden',
-                                                 '-I' + (meson.current_build_dir() /
-                                                 ('libqemu-' + target + '.fa.p'))],
-                                             dependencies: [glib],
-                                             include_directories: target_inc,
-                                             link_args: ['-Wl,--gc-sections',
-                                                 '-Wl,--no-export-dynamic'])
+    smc_reload_async_flush_test = executable(
+      'test-latx-tb-flush-smc-reload-async',
+      files(
+        'target/i386/latx/sbt/tests/tb-flush-smc-reload-async-test.c',
+        'target/i386/latx/sbt/smc_reload.c',
+        'accel/tcg/tb-flush.c'
+      ),
+      c_args: smc_reload_test_c_args,
+      dependencies: [glib],
+      include_directories: target_inc,
+      link_args: smc_reload_test_link_args
+    )
     test('latx-tb-flush-smc-reload-async', smc_reload_async_flush_test)
   endif
 

--- a/meson.build
+++ b/meson.build
@@ -578,6 +578,23 @@ foreach target : target_dirs
                  build_by_default: false,
                  name_suffix: 'fa')
 
+  if target == 'x86_64-linux-user' and 'CONFIG_LATX_O1' in config_host
+    smc_reload_tu_test = executable('test-latx-smc-reload-tu',
+                                    files('target/i386/latx/sbt/tests/smc-reload-tu-test.c',
+                                          'target/i386/latx/sbt/smc_reload.c',
+                                          'target/i386/latx/sbt/aot_smc_reload.c',
+                                          'accel/tcg/tb-jump.c'),
+                                    c_args: c_args + ['-ffunction-sections',
+                                        '-fvisibility=hidden',
+                                        '-I' + (meson.current_build_dir() /
+                                        ('libqemu-' + target + '.fa.p'))],
+                                    dependencies: [glib],
+                                    include_directories: target_inc,
+                                    link_args: ['-Wl,--gc-sections',
+                                        '-Wl,--no-export-dynamic'])
+    test('latx-smc-reload-tu', smc_reload_tu_test)
+  endif
+
     execs = [{
       'name': 'latx-' + target_name,
       'gui': false,

--- a/target/i386/latx/include/aot_recover_tb.h
+++ b/target/i386/latx/include/aot_recover_tb.h
@@ -11,6 +11,9 @@ void do_recover_segment(aot_segment *p_segment, abi_long start,
 int load_page(target_ulong pc, uint32_t cflags, seg_info *info);
 int load_page_4(target_ulong pc, uint32_t cflags, seg_info *info);
 int load_aot(target_ulong pc, uint32_t cflags);
+#ifdef CONFIG_LATX_AOT
+int smc_page_reload(target_ulong page_addr, uint32_t cflags);
+#endif
 /* void print_tb(TranslationBlock *tb); */
 
 #endif

--- a/target/i386/latx/include/latx-options.h
+++ b/target/i386/latx/include/latx-options.h
@@ -44,6 +44,7 @@ extern int option_tunnel_lib;
 extern uint64_t option_end_trace_addr;
 extern uint64_t option_begin_trace_addr;
 extern int option_aot;
+extern int option_smc_reload;
 extern int option_aot_wine;
 extern int option_load_aot;
 extern int option_debug_aot;

--- a/target/i386/latx/include/smc_reload.h
+++ b/target/i386/latx/include/smc_reload.h
@@ -1,0 +1,21 @@
+#ifndef __SMC_RELOAD_H_
+#define __SMC_RELOAD_H_
+
+#include "qemu-def.h"
+
+typedef struct reoload_info {
+    int tb_num;
+    target_ulong page_addr;
+    TranslationBlock **tb_vector;
+    void *ir1_code_buffer;
+} reload_info;
+
+void reload_tree_init(void);
+void reload_tree_insert(reload_info *reload_node);
+reload_info *reload_tree_lookup(target_ulong page_addr);
+void reload_tree_remove(reload_info *reload_node);
+gint get_reload_node_num(void);
+void reload_tree_foreach(void);
+void reload_tree_clear(void);
+
+#endif

--- a/target/i386/latx/include/smc_reload.h
+++ b/target/i386/latx/include/smc_reload.h
@@ -3,6 +3,8 @@
 
 #include "qemu-def.h"
 
+struct seg_info;
+
 typedef struct SMCReloadInfo {
     unsigned int tb_count;
     target_ulong page_addr;
@@ -17,5 +19,6 @@ void smc_reload_tree_remove(SMCReloadInfo *reload_node);
 unsigned int smc_reload_tree_get_node_count(void);
 void smc_reload_tree_foreach(void);
 void smc_reload_tree_clear(void);
+bool smc_reload_segment_is_candidate(const struct seg_info *segment);
 
 #endif

--- a/target/i386/latx/include/smc_reload.h
+++ b/target/i386/latx/include/smc_reload.h
@@ -20,5 +20,7 @@ unsigned int smc_reload_tree_get_node_count(void);
 void smc_reload_tree_foreach(void);
 void smc_reload_tree_clear(void);
 bool smc_reload_segment_is_candidate(const struct seg_info *segment);
+void smc_reload_save_tb_code(uint8_t *dest, target_ulong guest_pc,
+                             size_t size);
 
 #endif

--- a/target/i386/latx/include/smc_reload.h
+++ b/target/i386/latx/include/smc_reload.h
@@ -1,21 +1,21 @@
-#ifndef __SMC_RELOAD_H_
-#define __SMC_RELOAD_H_
+#ifndef LATX_SMC_RELOAD_H
+#define LATX_SMC_RELOAD_H
 
 #include "qemu-def.h"
 
-typedef struct reoload_info {
-    int tb_num;
+typedef struct SMCReloadInfo {
+    unsigned int tb_count;
     target_ulong page_addr;
     TranslationBlock **tb_vector;
-    void *ir1_code_buffer;
-} reload_info;
+    uint8_t *ir1_code_buffer;
+} SMCReloadInfo;
 
-void reload_tree_init(void);
-void reload_tree_insert(reload_info *reload_node);
-reload_info *reload_tree_lookup(target_ulong page_addr);
-void reload_tree_remove(reload_info *reload_node);
-gint get_reload_node_num(void);
-void reload_tree_foreach(void);
-void reload_tree_clear(void);
+void smc_reload_tree_init(void);
+void smc_reload_tree_insert(SMCReloadInfo *reload_node);
+SMCReloadInfo *smc_reload_tree_lookup(target_ulong page_addr);
+void smc_reload_tree_remove(SMCReloadInfo *reload_node);
+unsigned int smc_reload_tree_get_node_count(void);
+void smc_reload_tree_foreach(void);
+void smc_reload_tree_clear(void);
 
 #endif

--- a/target/i386/latx/latx-options.c
+++ b/target/i386/latx/latx-options.c
@@ -62,6 +62,7 @@ int option_debug_lative;
 int option_aot;
 int option_load_aot;
 int option_aot_wine;
+int option_smc_reload;
 int option_debug_aot;
 int option_imm_reg;
 int option_imm_rip;
@@ -238,6 +239,7 @@ void options_init(void)
     option_aot_wine = 0;
     option_debug_aot = 0;
 #endif
+    option_smc_reload = 0;
 #ifdef CONFIG_LATX_IMM_REG
     option_imm_reg = 0;
     option_imm_rip = 0;

--- a/target/i386/latx/sbt/aot_recover_tb.c
+++ b/target/i386/latx/sbt/aot_recover_tb.c
@@ -8,8 +8,10 @@
 #include "lsenv.h"
 #include "accel/tcg/internal.h"
 #include "include/exec/cpu-all.h"
+#include "include/exec/translate-all.h"
 #include "aot_page.h"
 #include "aot_smc.h"
+#include "smc_reload.h"
 #ifdef CONFIG_LATX_TU
 #include "tu.h"
 #endif
@@ -383,6 +385,55 @@ inline int load_page(target_ulong pc, uint32_t cflags, seg_info *info)
     return 1;
 }
 
+static int smc_page_reload(target_ulong page_addr, uint32_t cflags)
+{
+    if (!option_smc_reload) {
+        return 0;
+    }
+    reload_info *reload_node = reload_tree_lookup(page_addr);
+    if (!reload_node) {
+        return 0;
+    }
+
+    int p_flags = page_get_flags(page_addr);
+    if (!(p_flags & PAGE_READ)) {
+        return 0;
+    }
+    /*
+     * remove write prot of the page in case of paralell code modification,
+     * but the paired page cross 16K boundary is still not protected.
+     */
+    if ((p_flags & PAGE_WRITE) && !is_shadow_page_not_shmm(page_addr)) {
+        mprotect((void*)(page_addr & qemu_host_page_mask), qemu_host_page_size, PROT_READ);
+    }
+
+    tcg_ctx->tb_cflags = cflags;
+
+    int ir1_offset = 0;
+    for (int tb_id = 0; tb_id < reload_node->tb_num; tb_id++) {
+        TranslationBlock *tb = reload_node->tb_vector[tb_id];
+        if (!memcmp((void *)(uintptr_t)tb->pc,
+                    reload_node->ir1_code_buffer + ir1_offset, tb->size)) {
+            tb->cflags = tb->cflags & ~CF_INVALID;
+            if (tb->jmp_reset_offset[0] != TB_JMP_RESET_OFFSET_INVALID) {
+                tb_reset_jump(tb, 0);
+            }
+            if (tb->jmp_reset_offset[1] != TB_JMP_RESET_OFFSET_INVALID) {
+                tb_reset_jump(tb, 1);
+            }
+            tb->jmp_list_head = (uintptr_t)NULL;
+            tb->jmp_list_next[0] = (uintptr_t)NULL;
+            tb->jmp_list_next[1] = (uintptr_t)NULL;
+            tb->jmp_dest[0] = (uintptr_t)NULL;
+            tb->jmp_dest[1] = (uintptr_t)NULL;
+            aot_tb_register(tb);
+        }
+        ir1_offset += tb->size;
+    }
+    reload_tree_remove(reload_node);
+    return 1;
+}
+
 int load_aot(target_ulong pc, uint32_t cflags)
 {
     if (in_pre_translate) {
@@ -391,6 +442,9 @@ int load_aot(target_ulong pc, uint32_t cflags)
 
     seg_info *info = segment_tree_lookup(pc);
     if (info == NULL || info->buffer == NULL) {
+        if (smc_page_reload(pc & TARGET_PAGE_MASK, cflags)) {
+            return 1;
+        }
         page_set_page_state(pc, PAGE_NOINFO);
         return 0;
     }

--- a/target/i386/latx/sbt/aot_recover_tb.c
+++ b/target/i386/latx/sbt/aot_recover_tb.c
@@ -3,12 +3,14 @@
  * @author wwq <weiwenqiang@mail.ustc.edu.cn>
  * @brief AOT optimization
  */
+#include "qemu/osdep.h"
+
 #include "aot_recover_tb.h"
 #include "latx-options.h"
 #include "lsenv.h"
 #include "accel/tcg/internal.h"
-#include "include/exec/cpu-all.h"
-#include "include/exec/translate-all.h"
+#include "exec/cpu-all.h"
+#include "exec/translate-all.h"
 #include "aot_page.h"
 #include "aot_smc.h"
 #include "smc_reload.h"
@@ -387,15 +389,21 @@ inline int load_page(target_ulong pc, uint32_t cflags, seg_info *info)
 
 static int smc_page_reload(target_ulong page_addr, uint32_t cflags)
 {
+    SMCReloadInfo *reload_node;
+    TranslationBlock *tb;
+    size_t ir1_offset;
+    unsigned int tb_id;
+    int p_flags;
+
     if (!option_smc_reload) {
         return 0;
     }
-    reload_info *reload_node = reload_tree_lookup(page_addr);
+    reload_node = smc_reload_tree_lookup(page_addr);
     if (!reload_node) {
         return 0;
     }
 
-    int p_flags = page_get_flags(page_addr);
+    p_flags = page_get_flags(page_addr);
     if (!(p_flags & PAGE_READ)) {
         return 0;
     }
@@ -403,34 +411,35 @@ static int smc_page_reload(target_ulong page_addr, uint32_t cflags)
      * remove write prot of the page in case of paralell code modification,
      * but the paired page cross 16K boundary is still not protected.
      */
-    if ((p_flags & PAGE_WRITE) && !is_shadow_page_not_shmm(page_addr)) {
-        mprotect((void*)(page_addr & qemu_host_page_mask), qemu_host_page_size, PROT_READ);
+    if ((p_flags & PAGE_WRITE) && !page_is_shadow_not_shmm(page_addr)) {
+        mprotect((void *)(page_addr & qemu_host_page_mask),
+                 qemu_host_page_size, PROT_READ);
     }
 
     tcg_ctx->tb_cflags = cflags;
 
-    int ir1_offset = 0;
-    for (int tb_id = 0; tb_id < reload_node->tb_num; tb_id++) {
-        TranslationBlock *tb = reload_node->tb_vector[tb_id];
-        if (!memcmp((void *)(uintptr_t)tb->pc,
+    ir1_offset = 0;
+    for (tb_id = 0; tb_id < reload_node->tb_count; tb_id++) {
+        tb = reload_node->tb_vector[tb_id];
+        if (!memcmp((const void *)(uintptr_t)tb->pc,
                     reload_node->ir1_code_buffer + ir1_offset, tb->size)) {
-            tb->cflags = tb->cflags & ~CF_INVALID;
+            tb->cflags &= ~CF_INVALID;
             if (tb->jmp_reset_offset[0] != TB_JMP_RESET_OFFSET_INVALID) {
                 tb_reset_jump(tb, 0);
             }
             if (tb->jmp_reset_offset[1] != TB_JMP_RESET_OFFSET_INVALID) {
                 tb_reset_jump(tb, 1);
             }
-            tb->jmp_list_head = (uintptr_t)NULL;
-            tb->jmp_list_next[0] = (uintptr_t)NULL;
-            tb->jmp_list_next[1] = (uintptr_t)NULL;
-            tb->jmp_dest[0] = (uintptr_t)NULL;
-            tb->jmp_dest[1] = (uintptr_t)NULL;
+            tb->jmp_list_head = 0;
+            tb->jmp_list_next[0] = 0;
+            tb->jmp_list_next[1] = 0;
+            tb->jmp_dest[0] = 0;
+            tb->jmp_dest[1] = 0;
             aot_tb_register(tb);
         }
         ir1_offset += tb->size;
     }
-    reload_tree_remove(reload_node);
+    smc_reload_tree_remove(reload_node);
     return 1;
 }
 

--- a/target/i386/latx/sbt/aot_recover_tb.c
+++ b/target/i386/latx/sbt/aot_recover_tb.c
@@ -387,62 +387,6 @@ inline int load_page(target_ulong pc, uint32_t cflags, seg_info *info)
     return 1;
 }
 
-static int smc_page_reload(target_ulong page_addr, uint32_t cflags)
-{
-    SMCReloadInfo *reload_node;
-    TranslationBlock *tb;
-    size_t ir1_offset;
-    unsigned int tb_id;
-    int p_flags;
-
-    if (!option_smc_reload) {
-        return 0;
-    }
-    reload_node = smc_reload_tree_lookup(page_addr);
-    if (!reload_node) {
-        return 0;
-    }
-
-    p_flags = page_get_flags(page_addr);
-    if (!(p_flags & PAGE_READ)) {
-        return 0;
-    }
-    /*
-     * remove write prot of the page in case of paralell code modification,
-     * but the paired page cross 16K boundary is still not protected.
-     */
-    if ((p_flags & PAGE_WRITE) && !page_is_shadow_not_shmm(page_addr)) {
-        mprotect((void *)(page_addr & qemu_host_page_mask),
-                 qemu_host_page_size, PROT_READ);
-    }
-
-    tcg_ctx->tb_cflags = cflags;
-
-    ir1_offset = 0;
-    for (tb_id = 0; tb_id < reload_node->tb_count; tb_id++) {
-        tb = reload_node->tb_vector[tb_id];
-        if (!memcmp((const void *)(uintptr_t)tb->pc,
-                    reload_node->ir1_code_buffer + ir1_offset, tb->size)) {
-            tb->cflags &= ~CF_INVALID;
-            if (tb->jmp_reset_offset[0] != TB_JMP_RESET_OFFSET_INVALID) {
-                tb_reset_jump(tb, 0);
-            }
-            if (tb->jmp_reset_offset[1] != TB_JMP_RESET_OFFSET_INVALID) {
-                tb_reset_jump(tb, 1);
-            }
-            tb->jmp_list_head = 0;
-            tb->jmp_list_next[0] = 0;
-            tb->jmp_list_next[1] = 0;
-            tb->jmp_dest[0] = 0;
-            tb->jmp_dest[1] = 0;
-            aot_tb_register(tb);
-        }
-        ir1_offset += tb->size;
-    }
-    smc_reload_tree_remove(reload_node);
-    return 1;
-}
-
 int load_aot(target_ulong pc, uint32_t cflags)
 {
     if (in_pre_translate) {

--- a/target/i386/latx/sbt/aot_smc_reload.c
+++ b/target/i386/latx/sbt/aot_smc_reload.c
@@ -27,7 +27,7 @@ int smc_page_reload(target_ulong page_addr, uint32_t cflags)
     }
 
     p_flags = page_get_flags(page_addr);
-    if (!(p_flags & PAGE_READ)) {
+    if (!(p_flags & PAGE_EXEC)) {
         return 0;
     }
     if ((p_flags & PAGE_WRITE) && !page_is_shadow_not_shmm(page_addr)) {

--- a/target/i386/latx/sbt/aot_smc_reload.c
+++ b/target/i386/latx/sbt/aot_smc_reload.c
@@ -1,0 +1,66 @@
+#include "qemu/osdep.h"
+
+#include "aot_recover_tb.h"
+#include "latx-options.h"
+#include "accel/tcg/internal.h"
+#include "exec/cpu-all.h"
+#include "exec/translate-all.h"
+#include "aot.h"
+#include "smc_reload.h"
+
+#ifdef CONFIG_LATX_AOT
+int smc_page_reload(target_ulong page_addr, uint32_t cflags)
+{
+    SMCReloadInfo *reload_node;
+    TranslationBlock *tb;
+    size_t ir1_offset;
+    unsigned int tb_id;
+    int p_flags;
+
+    if (!option_smc_reload) {
+        return 0;
+    }
+    reload_node = smc_reload_tree_lookup(page_addr);
+    if (!reload_node) {
+        return 0;
+    }
+
+    p_flags = page_get_flags(page_addr);
+    if (!(p_flags & PAGE_READ)) {
+        return 0;
+    }
+    if ((p_flags & PAGE_WRITE) && !page_is_shadow_not_shmm(page_addr)) {
+        mprotect((void *)(page_addr & qemu_host_page_mask),
+                 qemu_host_page_size, PROT_READ);
+    }
+
+    tcg_ctx->tb_cflags = cflags;
+    ir1_offset = 0;
+    for (tb_id = 0; tb_id < reload_node->tb_count; tb_id++) {
+        tb = reload_node->tb_vector[tb_id];
+        if (!memcmp((const void *)(uintptr_t)tb->pc,
+                    reload_node->ir1_code_buffer + ir1_offset, tb->size)) {
+            tb->cflags &= ~CF_INVALID;
+            if (!use_tu_jmp(tb)) {
+                if (tb->jmp_reset_offset[0] !=
+                    TB_JMP_RESET_OFFSET_INVALID) {
+                    tb_reset_jump(tb, 0);
+                }
+                if (tb->jmp_reset_offset[1] !=
+                    TB_JMP_RESET_OFFSET_INVALID) {
+                    tb_reset_jump(tb, 1);
+                }
+            }
+            tb->jmp_list_head = 0;
+            tb->jmp_list_next[0] = 0;
+            tb->jmp_list_next[1] = 0;
+            tb->jmp_dest[0] = 0;
+            tb->jmp_dest[1] = 0;
+            aot_tb_register(tb);
+        }
+        ir1_offset += tb->size;
+    }
+    smc_reload_tree_remove(reload_node);
+    return 1;
+}
+#endif

--- a/target/i386/latx/sbt/aot_smc_reload.c
+++ b/target/i386/latx/sbt/aot_smc_reload.c
@@ -4,6 +4,7 @@
 #include "latx-options.h"
 #include "accel/tcg/internal.h"
 #include "exec/cpu-all.h"
+#include "exec/cpu_ldst.h"
 #include "exec/translate-all.h"
 #include "aot.h"
 #include "smc_reload.h"
@@ -30,7 +31,7 @@ int smc_page_reload(target_ulong page_addr, uint32_t cflags)
         return 0;
     }
     if ((p_flags & PAGE_WRITE) && !page_is_shadow_not_shmm(page_addr)) {
-        mprotect((void *)(page_addr & qemu_host_page_mask),
+        mprotect(g2h_untagged(page_addr & qemu_host_page_mask),
                  qemu_host_page_size, PROT_READ);
     }
 
@@ -38,7 +39,7 @@ int smc_page_reload(target_ulong page_addr, uint32_t cflags)
     ir1_offset = 0;
     for (tb_id = 0; tb_id < reload_node->tb_count; tb_id++) {
         tb = reload_node->tb_vector[tb_id];
-        if (!memcmp((const void *)(uintptr_t)tb->pc,
+        if (!memcmp(g2h_untagged(tb->pc),
                     reload_node->ir1_code_buffer + ir1_offset, tb->size)) {
             tb->cflags &= ~CF_INVALID;
             if (!use_tu_jmp(tb)) {

--- a/target/i386/latx/sbt/aot_smc_reload.c
+++ b/target/i386/latx/sbt/aot_smc_reload.c
@@ -15,6 +15,12 @@ bool smc_reload_segment_is_candidate(const struct seg_info *segment)
     return segment == NULL || segment->buffer == NULL;
 }
 
+void smc_reload_save_tb_code(uint8_t *dest, target_ulong guest_pc,
+                             size_t size)
+{
+    memcpy(dest, g2h_untagged(guest_pc), size);
+}
+
 int smc_page_reload(target_ulong page_addr, uint32_t cflags)
 {
     SMCReloadInfo *reload_node;

--- a/target/i386/latx/sbt/aot_smc_reload.c
+++ b/target/i386/latx/sbt/aot_smc_reload.c
@@ -46,7 +46,7 @@ int smc_page_reload(target_ulong page_addr, uint32_t cflags)
         tb = reload_node->tb_vector[tb_id];
         if (!memcmp(g2h_untagged(tb->pc),
                     reload_node->ir1_code_buffer + ir1_offset, tb->size)) {
-            tb->cflags &= ~CF_INVALID;
+            qemu_spin_lock(&tb->jmp_lock);
             if (!use_tu_jmp(tb)) {
                 if (tb->jmp_reset_offset[0] !=
                     TB_JMP_RESET_OFFSET_INVALID) {
@@ -62,6 +62,8 @@ int smc_page_reload(target_ulong page_addr, uint32_t cflags)
             tb->jmp_list_next[1] = 0;
             tb->jmp_dest[0] = 0;
             tb->jmp_dest[1] = 0;
+            qatomic_and(&tb->cflags, ~CF_INVALID);
+            qemu_spin_unlock(&tb->jmp_lock);
             aot_tb_register(tb);
         }
         ir1_offset += tb->size;

--- a/target/i386/latx/sbt/aot_smc_reload.c
+++ b/target/i386/latx/sbt/aot_smc_reload.c
@@ -10,6 +10,11 @@
 #include "smc_reload.h"
 
 #ifdef CONFIG_LATX_AOT
+bool smc_reload_segment_is_candidate(const struct seg_info *segment)
+{
+    return segment == NULL || segment->buffer == NULL;
+}
+
 int smc_page_reload(target_ulong page_addr, uint32_t cflags)
 {
     SMCReloadInfo *reload_node;

--- a/target/i386/latx/sbt/meson.build
+++ b/target/i386/latx/sbt/meson.build
@@ -5,6 +5,7 @@ i386_ss.add(when: 'CONFIG_LATX', if_true: files(
   'aot_link_seg.c',
   'aot_merge.c',
   'aot_recover_tb.c',
+  'aot_smc_reload.c',
   'aot_lib.c',
   'aot_page.c',
   'aot_smc.c',

--- a/target/i386/latx/sbt/meson.build
+++ b/target/i386/latx/sbt/meson.build
@@ -8,4 +8,5 @@ i386_ss.add(when: 'CONFIG_LATX', if_true: files(
   'aot_lib.c',
   'aot_page.c',
   'aot_smc.c',
+  'smc_reload.c',
 ))

--- a/target/i386/latx/sbt/smc_reload.c
+++ b/target/i386/latx/sbt/smc_reload.c
@@ -1,100 +1,109 @@
-#include "smc_reload.h"
+#include "qemu/osdep.h"
+
 #include "latx-options.h"
-#include <glib.h>
+#include "smc_reload.h"
 
-static GTree *reload_tree = NULL;
+static GTree *smc_reload_tree;
 
-static gint compare_page_addr(gconstpointer a, gconstpointer b, gpointer user_data)
+static gint compare_page_addr(gconstpointer a, gconstpointer b,
+                              gpointer user_data G_GNUC_UNUSED)
 {
-    target_ulong addr_a = *((target_ulong *)a);
-    target_ulong addr_b = *((target_ulong *)b);
+    const target_ulong *addr_a = a;
+    const target_ulong *addr_b = b;
 
-    if (addr_a < addr_b) return -1;
-    if (addr_a > addr_b) return 1;
+    if (*addr_a < *addr_b) {
+        return -1;
+    }
+    if (*addr_a > *addr_b) {
+        return 1;
+    }
     return 0;
 }
 
 static void free_reload_info(gpointer data)
 {
-    reload_info *info = (reload_info *)data;
+    SMCReloadInfo *info = data;
+
     if (info) {
-        if (info->tb_vector) {
-            g_free(info->tb_vector);
-        }
-        if (info->ir1_code_buffer) {
-            g_free(info->ir1_code_buffer);
-        }
-        g_free(info); }
-}
-
-void reload_tree_init(void)
-{
-    if (reload_tree != NULL) {
-        reload_tree_clear();
+        g_free(info->tb_vector);
+        g_free(info->ir1_code_buffer);
+        g_free(info);
     }
-    reload_tree = g_tree_new_full(compare_page_addr, NULL, NULL, free_reload_info);
 }
 
-void reload_tree_insert(reload_info *reload_node)
+void smc_reload_tree_init(void)
 {
-    if (reload_tree == NULL) {
-        reload_tree_init();
+    if (smc_reload_tree) {
+        smc_reload_tree_clear();
+    }
+    smc_reload_tree = g_tree_new_full(compare_page_addr, NULL, NULL,
+                                      free_reload_info);
+}
+
+void smc_reload_tree_insert(SMCReloadInfo *reload_node)
+{
+    if (smc_reload_tree == NULL) {
+        smc_reload_tree_init();
     }
 
     if (reload_node == NULL) {
         return;
     }
 
-    g_tree_insert(reload_tree, &reload_node->page_addr, reload_node);
+    g_tree_insert(smc_reload_tree, &reload_node->page_addr, reload_node);
 }
 
-reload_info *reload_tree_lookup(target_ulong page_addr)
+SMCReloadInfo *smc_reload_tree_lookup(target_ulong page_addr)
 {
-    if (reload_tree == NULL) {
+    if (smc_reload_tree == NULL) {
         return NULL;
     }
 
-    return (reload_info *)g_tree_lookup(reload_tree, &page_addr);
+    return g_tree_lookup(smc_reload_tree, &page_addr);
 }
 
-void reload_tree_remove(reload_info *reload_node)
+void smc_reload_tree_remove(SMCReloadInfo *reload_node)
 {
-    if (reload_tree == NULL || reload_node == NULL) {
+    if (smc_reload_tree == NULL || reload_node == NULL) {
         return;
     }
 
-    g_tree_remove(reload_tree, &reload_node->page_addr);
+    g_tree_remove(smc_reload_tree, &reload_node->page_addr);
 }
 
-gint get_reload_node_num(void)
+unsigned int smc_reload_tree_get_node_count(void)
 {
-    if (reload_tree == NULL) {
+    if (smc_reload_tree == NULL) {
         return 0;
     }
 
-    return g_tree_nnodes(reload_tree);
+    return g_tree_nnodes(smc_reload_tree);
 }
 
-static gboolean foreach_print_callback(gpointer key, gpointer value, gpointer data)
+static gboolean smc_reload_tree_print(gpointer key G_GNUC_UNUSED,
+                                      gpointer value,
+                                      gpointer data G_GNUC_UNUSED)
 {
-    reload_info *info = (reload_info *)value;
-    fprintf(stderr, "Page addr: 0x%lx, TB num: %d\n", (uint64_t)info->page_addr, info->tb_num);
+    const SMCReloadInfo *info = value;
+
+    g_printerr("Page addr: 0x%" PRIx64 ", TB num: %u\n",
+               (uint64_t)info->page_addr, info->tb_count);
     return false;
 }
 
-void reload_tree_foreach(void)
+void smc_reload_tree_foreach(void)
 {
-    if (reload_tree == NULL) {
+    if (smc_reload_tree == NULL) {
         return;
     }
 
-    g_tree_foreach(reload_tree, foreach_print_callback, NULL);
+    g_tree_foreach(smc_reload_tree, smc_reload_tree_print, NULL);
 }
 
-void reload_tree_clear(void)
+void smc_reload_tree_clear(void)
 {
-    if (reload_tree != NULL) {
-        g_tree_destroy(reload_tree);
-        reload_tree = NULL;
+    if (smc_reload_tree) {
+        g_tree_destroy(smc_reload_tree);
+        smc_reload_tree = NULL;
     }
 }

--- a/target/i386/latx/sbt/smc_reload.c
+++ b/target/i386/latx/sbt/smc_reload.c
@@ -1,0 +1,100 @@
+#include "smc_reload.h"
+#include "latx-options.h"
+#include <glib.h>
+
+static GTree *reload_tree = NULL;
+
+static gint compare_page_addr(gconstpointer a, gconstpointer b, gpointer user_data)
+{
+    target_ulong addr_a = *((target_ulong *)a);
+    target_ulong addr_b = *((target_ulong *)b);
+
+    if (addr_a < addr_b) return -1;
+    if (addr_a > addr_b) return 1;
+    return 0;
+}
+
+static void free_reload_info(gpointer data)
+{
+    reload_info *info = (reload_info *)data;
+    if (info) {
+        if (info->tb_vector) {
+            g_free(info->tb_vector);
+        }
+        if (info->ir1_code_buffer) {
+            g_free(info->ir1_code_buffer);
+        }
+        g_free(info); }
+}
+
+void reload_tree_init(void)
+{
+    if (reload_tree != NULL) {
+        reload_tree_clear();
+    }
+    reload_tree = g_tree_new_full(compare_page_addr, NULL, NULL, free_reload_info);
+}
+
+void reload_tree_insert(reload_info *reload_node)
+{
+    if (reload_tree == NULL) {
+        reload_tree_init();
+    }
+
+    if (reload_node == NULL) {
+        return;
+    }
+
+    g_tree_insert(reload_tree, &reload_node->page_addr, reload_node);
+}
+
+reload_info *reload_tree_lookup(target_ulong page_addr)
+{
+    if (reload_tree == NULL) {
+        return NULL;
+    }
+
+    return (reload_info *)g_tree_lookup(reload_tree, &page_addr);
+}
+
+void reload_tree_remove(reload_info *reload_node)
+{
+    if (reload_tree == NULL || reload_node == NULL) {
+        return;
+    }
+
+    g_tree_remove(reload_tree, &reload_node->page_addr);
+}
+
+gint get_reload_node_num(void)
+{
+    if (reload_tree == NULL) {
+        return 0;
+    }
+
+    return g_tree_nnodes(reload_tree);
+}
+
+static gboolean foreach_print_callback(gpointer key, gpointer value, gpointer data)
+{
+    reload_info *info = (reload_info *)value;
+    fprintf(stderr, "Page addr: 0x%lx, TB num: %d\n", (uint64_t)info->page_addr, info->tb_num);
+    return false;
+}
+
+void reload_tree_foreach(void)
+{
+    if (reload_tree == NULL) {
+        return;
+    }
+
+    g_tree_foreach(reload_tree, foreach_print_callback, NULL);
+}
+
+void reload_tree_clear(void)
+{
+    if (reload_tree != NULL) {
+        g_tree_destroy(reload_tree);
+        reload_tree = NULL;
+    }
+}

--- a/target/i386/latx/sbt/tests/smc-reload-guest-base-test.c
+++ b/target/i386/latx/sbt/tests/smc-reload-guest-base-test.c
@@ -5,8 +5,12 @@
 #include "latx-options.h"
 #include "smc_reload.h"
 #include "exec/translate-all.h"
+#include "smc-reload-guest-base-test.h"
 
 static unsigned int aot_register_count;
+static void *reload_mprotect_addr;
+static int reload_mprotect_prot;
+static bool capture_reload_mprotect;
 
 __thread TCGContext *tcg_ctx;
 int option_smc_reload;
@@ -15,6 +19,14 @@ uintptr_t qemu_host_page_size;
 intptr_t qemu_host_page_mask;
 uintptr_t guest_base;
 bool have_guest_base;
+
+int __wrap_mprotect(void *addr, size_t len G_GNUC_UNUSED, int prot)
+{
+    g_assert(capture_reload_mprotect);
+    reload_mprotect_addr = addr;
+    reload_mprotect_prot = prot;
+    return 0;
+}
 
 bool use_tu_jmp(TranslationBlock *tb)
 {
@@ -81,7 +93,6 @@ int main(void)
     guest_base = qemu_host_page_size;
     mapping[0] = 0xcc;
     host_page[0] = 0x90;
-    g_assert(mprotect(mapping, qemu_host_page_size, PROT_NONE) == 0);
 
     tcg_ctx = &test_tcg_ctx;
     option_smc_reload = 1;
@@ -96,10 +107,15 @@ int main(void)
     reload->tb_vector = g_new(TranslationBlock *, 1);
     reload->tb_vector[0] = &tb;
     reload->ir1_code_buffer = g_malloc(code_size);
-    memcpy(reload->ir1_code_buffer, host_page, code_size);
+    smc_reload_save_tb_code(reload->ir1_code_buffer, guest_page, code_size);
+    g_assert(reload->ir1_code_buffer[0] == host_page[0]);
 
     smc_reload_tree_insert(reload);
+    capture_reload_mprotect = true;
     g_assert(smc_page_reload(reload->page_addr, 0) == 1);
+    capture_reload_mprotect = false;
+    g_assert(reload_mprotect_addr == host_page);
+    g_assert(reload_mprotect_prot == PROT_READ);
     g_assert(aot_register_count == 1);
     g_assert(smc_reload_tree_get_node_count() == 0);
     qemu_spin_destroy(&tb.jmp_lock);

--- a/target/i386/latx/sbt/tests/smc-reload-guest-base-test.c
+++ b/target/i386/latx/sbt/tests/smc-reload-guest-base-test.c
@@ -49,7 +49,7 @@ void aot_tb_register(TranslationBlock *tb)
 
 int page_get_flags(target_ulong address G_GNUC_UNUSED)
 {
-    return PAGE_READ;
+    return PAGE_VALID | PAGE_READ | PAGE_WRITE | PAGE_EXEC;
 }
 
 bool page_is_shadow_not_shmm(target_ulong address G_GNUC_UNUSED)
@@ -60,29 +60,45 @@ bool page_is_shadow_not_shmm(target_ulong address G_GNUC_UNUSED)
 int main(void)
 {
     static TCGContext test_tcg_ctx;
-    static uint8_t guest_code[] = { 0x90 };
+    const size_t code_size = 1;
+    const size_t mapping_size = 2 * qemu_real_host_page_size;
+    uint8_t *mapping;
+    target_ulong guest_page;
+    uint8_t *host_page;
     TranslationBlock tb = { 0 };
     SMCReloadInfo *reload = g_new0(SMCReloadInfo, 1);
 
+    qemu_host_page_size = qemu_real_host_page_size;
+    qemu_host_page_mask = -qemu_host_page_size;
+    mapping = mmap(NULL, mapping_size, PROT_READ | PROT_WRITE,
+                   MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    g_assert(mapping != MAP_FAILED);
+    guest_page = (target_ulong)(uintptr_t)mapping;
+    host_page = mapping + qemu_host_page_size;
+    guest_base = qemu_host_page_size;
+    mapping[0] = 0xcc;
+    host_page[0] = 0x90;
+    g_assert(mprotect(mapping, qemu_host_page_size, PROT_NONE) == 0);
+
     tcg_ctx = &test_tcg_ctx;
     option_smc_reload = 1;
-    tb.pc = (uintptr_t)guest_code;
-    tb.size = sizeof(guest_code);
+    tb.pc = guest_page;
+    tb.size = code_size;
     tb.bool_flags = IS_TU_JMP;
-    tb.tu_jmp[TU_TB_INDEX_NEXT] = 4;
-    tb.tu_jmp[TU_TB_INDEX_TARGET] = TB_JMP_RESET_OFFSET_INVALID;
+    qemu_spin_init(&tb.jmp_lock);
 
     reload->tb_count = 1;
-    reload->page_addr = (uintptr_t)guest_code & TARGET_PAGE_MASK;
+    reload->page_addr = guest_page;
     reload->tb_vector = g_new(TranslationBlock *, 1);
     reload->tb_vector[0] = &tb;
-    reload->ir1_code_buffer = g_malloc(sizeof(guest_code));
-    memcpy(reload->ir1_code_buffer, guest_code, sizeof(guest_code));
+    reload->ir1_code_buffer = g_malloc(code_size);
+    memcpy(reload->ir1_code_buffer, host_page, code_size);
 
     smc_reload_tree_insert(reload);
     g_assert(smc_page_reload(reload->page_addr, 0) == 1);
     g_assert(aot_register_count == 1);
-    g_assert(tb.tu_jmp[TU_TB_INDEX_NEXT] == 4);
     g_assert(smc_reload_tree_get_node_count() == 0);
+    qemu_spin_destroy(&tb.jmp_lock);
+    g_assert(munmap(mapping, mapping_size) == 0);
     return 0;
 }

--- a/target/i386/latx/sbt/tests/smc-reload-guest-base-test.c
+++ b/target/i386/latx/sbt/tests/smc-reload-guest-base-test.c
@@ -18,6 +18,7 @@ bool have_guest_base;
 
 bool use_tu_jmp(TranslationBlock *tb)
 {
+    g_assert(qemu_spin_locked(&tb->jmp_lock));
     return tb->bool_flags & IS_TU_JMP;
 }
 
@@ -44,6 +45,8 @@ void tb_target_set_nop(uintptr_t tc_ptr G_GNUC_UNUSED,
 void aot_tb_register(TranslationBlock *tb)
 {
     assert(tb != NULL);
+    g_assert(!qemu_spin_locked(&tb->jmp_lock));
+    g_assert(!(tb->cflags & CF_INVALID));
     aot_register_count++;
 }
 
@@ -85,6 +88,7 @@ int main(void)
     tb.pc = guest_page;
     tb.size = code_size;
     tb.bool_flags = IS_TU_JMP;
+    tb.cflags = CF_INVALID;
     qemu_spin_init(&tb.jmp_lock);
 
     reload->tb_count = 1;

--- a/target/i386/latx/sbt/tests/smc-reload-guest-base-test.h
+++ b/target/i386/latx/sbt/tests/smc-reload-guest-base-test.h
@@ -1,0 +1,6 @@
+#ifndef LATX_SMC_RELOAD_GUEST_BASE_TEST_H
+#define LATX_SMC_RELOAD_GUEST_BASE_TEST_H
+
+int __wrap_mprotect(void *addr, size_t len, int prot);
+
+#endif

--- a/target/i386/latx/sbt/tests/smc-reload-tu-test.c
+++ b/target/i386/latx/sbt/tests/smc-reload-tu-test.c
@@ -49,7 +49,7 @@ void aot_tb_register(TranslationBlock *tb)
 
 int page_get_flags(target_ulong address G_GNUC_UNUSED)
 {
-    return PAGE_READ;
+    return PAGE_VALID | PAGE_EXEC;
 }
 
 bool page_is_shadow_not_shmm(target_ulong address G_GNUC_UNUSED)

--- a/target/i386/latx/sbt/tests/smc-reload-tu-test.c
+++ b/target/i386/latx/sbt/tests/smc-reload-tu-test.c
@@ -57,6 +57,17 @@ bool page_is_shadow_not_shmm(target_ulong address G_GNUC_UNUSED)
     return false;
 }
 
+static void test_smc_reload_segment_candidate(void)
+{
+    static uint8_t aot_buffer;
+    seg_info segment = { 0 };
+
+    g_assert(smc_reload_segment_is_candidate(NULL));
+    g_assert(smc_reload_segment_is_candidate(&segment));
+    segment.buffer = &aot_buffer;
+    g_assert(!smc_reload_segment_is_candidate(&segment));
+}
+
 int main(void)
 {
     static TCGContext test_tcg_ctx;
@@ -64,6 +75,7 @@ int main(void)
     TranslationBlock tb = { 0 };
     SMCReloadInfo *reload = g_new0(SMCReloadInfo, 1);
 
+    test_smc_reload_segment_candidate();
     tcg_ctx = &test_tcg_ctx;
     option_smc_reload = 1;
     tb.pc = (uintptr_t)guest_code;

--- a/target/i386/latx/sbt/tests/smc-reload-tu-test.c
+++ b/target/i386/latx/sbt/tests/smc-reload-tu-test.c
@@ -18,6 +18,7 @@ bool have_guest_base;
 
 bool use_tu_jmp(TranslationBlock *tb)
 {
+    g_assert(qemu_spin_locked(&tb->jmp_lock));
     return tb->bool_flags & IS_TU_JMP;
 }
 
@@ -44,6 +45,8 @@ void tb_target_set_nop(uintptr_t tc_ptr G_GNUC_UNUSED,
 void aot_tb_register(TranslationBlock *tb)
 {
     assert(tb != NULL);
+    g_assert(!qemu_spin_locked(&tb->jmp_lock));
+    g_assert(!(tb->cflags & CF_INVALID));
     aot_register_count++;
 }
 
@@ -81,6 +84,8 @@ int main(void)
     tb.pc = (uintptr_t)guest_code;
     tb.size = sizeof(guest_code);
     tb.bool_flags = IS_TU_JMP;
+    tb.cflags = CF_INVALID;
+    qemu_spin_init(&tb.jmp_lock);
     tb.tu_jmp[TU_TB_INDEX_NEXT] = 4;
     tb.tu_jmp[TU_TB_INDEX_TARGET] = TB_JMP_RESET_OFFSET_INVALID;
 
@@ -96,5 +101,6 @@ int main(void)
     g_assert(aot_register_count == 1);
     g_assert(tb.tu_jmp[TU_TB_INDEX_NEXT] == 4);
     g_assert(smc_reload_tree_get_node_count() == 0);
+    qemu_spin_destroy(&tb.jmp_lock);
     return 0;
 }

--- a/target/i386/latx/sbt/tests/smc-reload-tu-test.c
+++ b/target/i386/latx/sbt/tests/smc-reload-tu-test.c
@@ -1,0 +1,86 @@
+#include "qemu/osdep.h"
+
+#include "optimize-config.h"
+#include "aot_recover_tb.h"
+#include "latx-options.h"
+#include "smc_reload.h"
+#include "exec/translate-all.h"
+
+static unsigned int aot_register_count;
+
+__thread TCGContext *tcg_ctx;
+int option_smc_reload;
+uintptr_t tcg_splitwx_diff;
+uintptr_t qemu_host_page_size;
+intptr_t qemu_host_page_mask;
+
+bool use_tu_jmp(TranslationBlock *tb)
+{
+    return tb->bool_flags & IS_TU_JMP;
+}
+
+void tb_set_jmp_target(TranslationBlock *tb G_GNUC_UNUSED,
+                       int n G_GNUC_UNUSED, uintptr_t addr G_GNUC_UNUSED)
+{
+    g_assert_not_reached();
+}
+
+void tb_eflag_recover(TranslationBlock *tb G_GNUC_UNUSED,
+                      int n G_GNUC_UNUSED)
+{
+    g_assert_not_reached();
+}
+
+void tb_target_set_nop(uintptr_t tc_ptr G_GNUC_UNUSED,
+                       uintptr_t jmp_rx G_GNUC_UNUSED,
+                       uintptr_t jmp_rw G_GNUC_UNUSED,
+                       uintptr_t addr G_GNUC_UNUSED)
+{
+    g_assert_not_reached();
+}
+
+void aot_tb_register(TranslationBlock *tb)
+{
+    assert(tb != NULL);
+    aot_register_count++;
+}
+
+int page_get_flags(target_ulong address G_GNUC_UNUSED)
+{
+    return PAGE_READ;
+}
+
+bool page_is_shadow_not_shmm(target_ulong address G_GNUC_UNUSED)
+{
+    return false;
+}
+
+int main(void)
+{
+    static TCGContext test_tcg_ctx;
+    static uint8_t guest_code[] = { 0x90 };
+    TranslationBlock tb = { 0 };
+    SMCReloadInfo *reload = g_new0(SMCReloadInfo, 1);
+
+    tcg_ctx = &test_tcg_ctx;
+    option_smc_reload = 1;
+    tb.pc = (uintptr_t)guest_code;
+    tb.size = sizeof(guest_code);
+    tb.bool_flags = IS_TU_JMP;
+    tb.tu_jmp[TU_TB_INDEX_NEXT] = 4;
+    tb.tu_jmp[TU_TB_INDEX_TARGET] = TB_JMP_RESET_OFFSET_INVALID;
+
+    reload->tb_count = 1;
+    reload->page_addr = (uintptr_t)guest_code & TARGET_PAGE_MASK;
+    reload->tb_vector = g_new(TranslationBlock *, 1);
+    reload->tb_vector[0] = &tb;
+    reload->ir1_code_buffer = g_malloc(sizeof(guest_code));
+    memcpy(reload->ir1_code_buffer, guest_code, sizeof(guest_code));
+
+    smc_reload_tree_insert(reload);
+    g_assert(smc_page_reload(reload->page_addr, 0) == 1);
+    g_assert(aot_register_count == 1);
+    g_assert(tb.tu_jmp[TU_TB_INDEX_NEXT] == 4);
+    g_assert(smc_reload_tree_get_node_count() == 0);
+    return 0;
+}

--- a/target/i386/latx/sbt/tests/tb-flush-smc-reload-async-test.c
+++ b/target/i386/latx/sbt/tests/tb-flush-smc-reload-async-test.c
@@ -1,0 +1,137 @@
+#include "qemu/osdep.h"
+#include "qemu/log.h"
+
+#if defined(CONFIG_LATX_KZT)
+#include "qemu.h"
+#endif
+
+#include "accel/tcg/internal.h"
+#include "aot.h"
+#include "exec/fasttb.h"
+#include "latx-options.h"
+#include "smc_reload.h"
+#include "sysemu/tcg.h"
+#include "ts.h"
+
+static run_on_cpu_func queued_func;
+static run_on_cpu_data queued_data;
+static bool mmap_locked;
+
+TBContext tb_ctx;
+CPUTailQ cpus = QTAILQ_HEAD_INITIALIZER(cpus);
+bool tcg_allowed = true;
+int option_smc_reload;
+int option_aot;
+int qemu_loglevel;
+__thread int in_pre_translate;
+#if defined(CONFIG_LATX_KZT)
+int option_kzt;
+struct image_info info1;
+#endif
+
+int qemu_log(const char *fmt G_GNUC_UNUSED, ...)
+{
+    return 0;
+}
+
+void aot_exit_entry(CPUState *cpu G_GNUC_UNUSED, int is_end G_GNUC_UNUSED)
+{
+}
+
+#ifdef CONFIG_PLUGIN
+void qemu_plugin_flush_cb(void)
+{
+}
+#endif
+
+#if defined(CONFIG_LATX_KZT)
+void init_tb_callback_bridge(CPUState *cpu G_GNUC_UNUSED,
+                             void *opaque G_GNUC_UNUSED)
+{
+}
+#endif
+
+void async_safe_run_on_cpu(CPUState *cpu G_GNUC_UNUSED,
+                           run_on_cpu_func func, run_on_cpu_data data)
+{
+    g_assert(queued_func == NULL);
+    queued_func = func;
+    queued_data = data;
+}
+
+void mmap_lock(void)
+{
+    g_assert(!mmap_locked);
+    mmap_locked = true;
+}
+
+void mmap_unlock(void)
+{
+    g_assert(mmap_locked);
+    mmap_locked = false;
+}
+
+bool have_mmap_lock(void)
+{
+    return mmap_locked;
+}
+
+bool qht_reset_size(struct qht *ht G_GNUC_UNUSED,
+                    size_t n_elems G_GNUC_UNUSED)
+{
+    return false;
+}
+
+void tb_flush_remove_all(void)
+{
+    g_assert(mmap_locked);
+}
+
+void tcg_region_reset_all(void)
+{
+    g_assert(mmap_locked);
+}
+
+void latx_fast_jmp_cache_clear_all(CPUState *cpu G_GNUC_UNUSED)
+{
+}
+
+static SMCReloadInfo *new_reload_node(target_ulong page_addr)
+{
+    SMCReloadInfo *node = g_new0(SMCReloadInfo, 1);
+
+    node->page_addr = page_addr;
+    return node;
+}
+
+static void run_queued_flush(CPUState *cpu)
+{
+    run_on_cpu_func func = queued_func;
+
+    g_assert(func != NULL);
+    queued_func = NULL;
+    func(cpu, queued_data);
+}
+
+int main(void)
+{
+    CPUState cpu = { 0 };
+
+    option_smc_reload = true;
+    tb_ctx.tb_flush_count = 1;
+
+    tb_flush(&cpu);
+    g_assert(queued_func != NULL);
+    smc_reload_tree_insert(new_reload_node(0x1000));
+    run_queued_flush(&cpu);
+    g_assert(smc_reload_tree_get_node_count() == 0);
+
+    smc_reload_tree_insert(new_reload_node(0x2000));
+    tb_flush(&cpu);
+    g_assert(queued_func != NULL);
+    tb_ctx.tb_flush_count++;
+    run_queued_flush(&cpu);
+    g_assert(smc_reload_tree_get_node_count() == 1);
+    smc_reload_tree_clear();
+    return 0;
+}


### PR DESCRIPTION
Track TBs invalidated by `target_mprotect()` and reload unchanged TBs when their pages become executable again, reducing redundant translation work.

## Summary

- Record invalidated TB code and restore TBs whose guest instructions have not changed.
- Preserve TU jump metadata and synchronize reload updates with the TB `jmp_lock`.
- Translate guest addresses through `guest_base` for code copies, comparisons, and page protection.
- Keep the reload tree consistent with asynchronous TB flushes and unloaded AOT segments.
- Add focused regression tests for TU reload, `guest_base`, and asynchronous flush ordering.

## Patch details

### `c0077a0` — Align SMC reload code with QEMU conventions

- **Issue:** the SMC reload implementation had inconsistent naming, include paths, allocation helpers, declaration placement, comments, formatting, and integer parsing.
- **Reproduction:** strict checkpatch identifies the style and API inconsistencies.
- **Resolution:** use consistent `smc_reload_*` names and types, GLib allocation helpers, QEMU includes and integer parsing, and QEMU-compliant declarations and formatting.
- **Verification:** strict checkpatch reports **0 errors and 0 warnings** for this patch.

### `54aac8e` — Preserve TU jump state during SMC TB reload

- **Issue:** TU jump metadata aliases generic jump-reset fields. Calling `tb_reset_jump()` for a TU TB violates the `!use_tu_jmp(tb)` contract and can corrupt TU state.
- **Reproduction:** `target/i386/latx/sbt/tests/smc-reload-tu-test.c` invokes the production `smc_page_reload()` and `tb_reset_jump()` paths. Without the TU guard, it aborts at `assert(!use_tu_jmp(tb))` with exit code 134.
- **Resolution:** reset generic jump state only for non-TU TBs.
- **Verification:** `latx-smc-reload-tu` passes and confirms that the TU target remains unchanged.

### `a515969` — Honor `guest_base` in SMC reload memory access

- **Issue:** the save and reload paths used guest virtual addresses as host pointers during code copy, protection, and comparison.
- **Reproduction:** `target/i386/latx/sbt/tests/smc-reload-guest-base-test.c` maps raw guest and translated host pages with different contents. Without the reload-side address conversion, it aborts at `aot_register_count == 1` with exit code 134 because the wrong page is compared.
- **Resolution:** translate save-side copies, reload-side `mprotect()`, and reload-side `memcmp()` addresses with `g2h_untagged()`.
- **Verification:** the guest-base and TU regression tests pass.

### `1a49965` — Flush the SMC reload tree with an accepted TB reset

- **Issue:** asynchronous `tb_flush()` cleared the reload tree before confirming that the captured flush count was still current, allowing nodes inserted after queueing to survive an accepted flush.
- **Reproduction:** `target/i386/latx/sbt/tests/tb-flush-smc-reload-async-test.c` exercises accepted and stale `tb_flush()` / `do_tb_flush()` callbacks. With the previous ordering, the accepted callback leaves one node and aborts at `smc_reload_tree_get_node_count() == 0` with exit code 134.
- **Resolution:** after accepting the flush count, clear the reload tree while holding `mmap_lock()` and before resetting TB and TCG regions. Stale callbacks leave the tree unchanged.
- **Verification:** the test confirms that accepted flushes clear the tree and stale flushes preserve it.

### `1097ac8` — Reload execute-only SMC pages

- **Issue:** reload eligibility required `PAGE_READ`, although the address is used for instruction fetch and execute-only pages are valid.
- **Reproduction:** `smc-reload-tu-test.c` exposes only `PAGE_VALID | PAGE_EXEC`. Requiring `PAGE_READ` makes `smc_page_reload()` return zero and aborts at `smc_page_reload(...) == 1` with exit code 134.
- **Resolution:** gate reload eligibility on `PAGE_EXEC`.
- **Verification:** `latx-smc-reload-tu` passes for an execute-only page.

### `f61c679` — Keep candidates for unloaded AOT segments

- **Issue:** a segment-tree hit does not imply that AOT code is loaded; a newly created segment has a NULL buffer and still requires SMC reload candidates.
- **Reproduction:** `smc-reload-tu-test.c` checks the production candidate predicate for a missing segment, an unloaded segment, and a loaded segment. Requiring `segment == NULL` fails the unloaded-segment assertion.
- **Resolution:** retain candidates when the segment is absent or its buffer is NULL, and reject only loaded segments.
- **Verification:** the three-state predicate table and TU reload path pass.

### `ef6a256` — Lock SMC reload TB state

- **Issue:** reload updated jump state and cleared `CF_INVALID` without holding the TB `jmp_lock` used by execution and chaining paths.
- **Reproduction:** the TU and guest-base fixtures require `use_tu_jmp()` to run with the lock held and require registration to occur after unlock. Without the lock, the TU test aborts at `qemu_spin_locked(&tb->jmp_lock)` with exit code 134.
- **Resolution:** lock the matched TB before inspecting or resetting jump state, clear jump-list and destination fields, atomically clear `CF_INVALID` last, unlock, and then register the TB.
- **Verification:** the TU and guest-base regression tests pass.

### `679b3a0` — Cover guest-base save and protection addresses

- **Issue:** guest-base correctness requires the save-side copy and page-protection call to use translated host addresses as well as the comparison path.
- **Reproduction:** the guest-base test calls the production save helper and wraps `mprotect()` at link time. A raw guest PC fails `reload->ir1_code_buffer[0] == host_page[0]`; a raw guest page passed to `mprotect()` fails `reload_mprotect_addr == host_page`.
- **Resolution:** route `add_smc_node()` through `smc_reload_save_tb_code()` and use translated host addresses in both paths.
- **Verification:** `latx-smc-reload-guest-base` passes.

### `f63623e` — Complete SMC reload style cleanup

- **Issue:** the changed code contained two mixed declarations, overlong Meson definitions, and no LGPL notice in code extracted from `translate-all.c`.
- **Reproduction:** `docs/devel/style.rst` and strict checkpatch identify the declaration and formatting requirements; source-license comparison identifies the missing notice.
- **Resolution:** move declarations to block starts, share and reflow the Meson test definitions, and retain the source license notice in `tb-jump.c`.
- **Verification:** strict checkpatch reports **0 errors and 0 warnings** for this patch, and all three focused regression tests pass.

## Regression tests

| Meson test | Source | Coverage |
|---|---|---|
| `latx-smc-reload-tu` | `target/i386/latx/sbt/tests/smc-reload-tu-test.c` | TU jump state, execute-only pages, unloaded AOT segments, and `jmp_lock` |
| `latx-smc-reload-guest-base` | `target/i386/latx/sbt/tests/smc-reload-guest-base-test.c` | guest-base save, comparison, page protection, and `jmp_lock` |
| `latx-tb-flush-smc-reload-async` | `target/i386/latx/sbt/tests/tb-flush-smc-reload-async-test.c` | accepted and stale asynchronous TB flushes |

## Validation

- `latx-x86_64` builds successfully.
- Focused Meson regression suite: **3/3 passed**.
- GitHub Actions build matrix: **10/10 jobs passed**.
- `git diff --check`: clean.
- Whole-PR strict checkpatch: **0 errors**. The remaining generic new-file/MAINTAINERS warning is covered by the existing `F: target/i386/` and `F: accel/tcg/` entries.