### PR TITLE
Latx fix config edge cases

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -584,6 +584,22 @@ foreach target : target_dirs
   if get_option('tests').enabled() and \
      target == 'x86_64-linux-user' and \
      'CONFIG_LATX_O1' in config_host
+    latx_config_regression_test = executable(
+      'test-latx-config-regression',
+      files('tests/latx-x86_64/latx-config-regression.c'),
+      objects: lib.extract_objects(latx_string_utils),
+      c_args: c_args,
+      dependencies: [glib],
+      include_directories: target_inc,
+    )
+    test(
+      'latx-config-regression',
+      latx_config_regression_test,
+      suite: 'lat-pr-fast',
+      env: ['ASAN_OPTIONS=detect_leaks=0'],
+      timeout: 30,
+    )
+
     smc_reload_test_c_args = c_args + [
       '-ffunction-sections',
       '-fvisibility=hidden',

--- a/target/i386/latx/include/latx-options.h
+++ b/target/i386/latx/include/latx-options.h
@@ -228,6 +228,4 @@ void conf_init(char **target_argv);
 char* guest_program(char **argv);
 void load_conf_file(const char *file, char* program);
 void find_option(const char *name, const char *val);
-int option_line_init(char *line, char **name, char **value);
-char* trim(char *s);
 #endif

--- a/target/i386/latx/include/latx-string-utils.h
+++ b/target/i386/latx/include/latx-string-utils.h
@@ -1,0 +1,18 @@
+/*
+ * SPDX-FileCopyrightText: 2021-2026 LAT Project Authors
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#ifndef _LATX_STRING_UTILS_H_
+#define _LATX_STRING_UTILS_H_
+
+#include <stddef.h>
+
+char *latx_trim(char *s);
+int latx_option_line_init(char *line, char **name, char **value);
+/* filename and buffer must be non-NULL, and buffer_size must be positive. */
+void latx_extract_filename(const char *filename, char *buffer,
+                           size_t buffer_size);
+
+#endif /* _LATX_STRING_UTILS_H_ */

--- a/target/i386/latx/latx-options.c
+++ b/target/i386/latx/latx-options.c
@@ -9,6 +9,7 @@
 #include "qemu/cutils.h"
 #include "reg-alloc.h"
 #include "latx-debug.h"
+#include "latx-string-utils.h"
 #include "translate.h"
 
 #if defined(CONFIG_LATX_KZT)
@@ -110,28 +111,6 @@ unsigned long long counter_tb_tr;
 unsigned long long counter_ir1_tr;
 unsigned long long counter_mips_tr;
 
-char* trim(char *s)
-{
-    while (isspace((unsigned char)*s)) s++;
-    char *end = s + strlen(s) - 1;
-    while (isspace((unsigned char)*end)) end--;
-    end[1] = '\0';
-    return s;
-}
-
-// find env var and value
-int option_line_init(char *line, char **name, char **value)
-{
-    while (isspace((unsigned char)*line)) line++;
-    if (*line == '#' || *line == '\0') { return false; }
-    char *eq = strchr(line, '=');
-    if (eq == NULL) { return false; }
-    *eq = '\0';
-    *name = trim(line);
-    *value = trim(eq + 1);
-    return true;
-}
-
 void load_conf_file(const char *file, char *program)
 {
     FILE *fp = fopen(file, "r");
@@ -145,7 +124,8 @@ void load_conf_file(const char *file, char *program)
     while(getline(&line, &len, fp) != -1) {
         char *option_name, *option_value;
         // env var
-        if(flag != 1 && option_line_init(line, &option_name, &option_value)) {
+        if (flag != 1 &&
+            latx_option_line_init(line, &option_name, &option_value)) {
             find_option(option_name, option_value);
         }
         // guest name

--- a/target/i386/latx/latx-special-args.c
+++ b/target/i386/latx/latx-special-args.c
@@ -6,6 +6,7 @@
 
 #include "latx-config.h"
 #include "latx-options.h"
+#include "latx-string-utils.h"
 
 typedef struct {
     const char* filename;
@@ -22,28 +23,11 @@ FileFunMap filefunmap[] = {
    {"program", lative_func},                        // lative
 };
 
-static void extract_filename(char* filename, char* buffer,
-                            size_t buffer_size)
-{
-    char* last_slash = strrchr(filename, '/');
-    char* filename_only;
-    if (last_slash != NULL) {
-        filename_only = last_slash + 1;
-    } else {
-        filename_only = filename;
-    }
-    strncpy(buffer, filename_only, buffer_size - 1);
-    char* extension = strchr(buffer, '.');
-    if (extension != NULL) {
-        *extension = '\0';
-    }
-}
-
 void latx_handle_args(char *filename)
 {
     int i;
     char buffer[256];
-    extract_filename(filename, buffer, sizeof(buffer));
+    latx_extract_filename(filename, buffer, sizeof(buffer));
 
     for (i = 0; i < sizeof(filefunmap) / sizeof(FileFunMap); i++) {
         if (strcmp(buffer, filefunmap[i].filename) == 0) {

--- a/target/i386/latx/latx-string-utils.c
+++ b/target/i386/latx/latx-string-utils.c
@@ -9,9 +9,19 @@
 
 char *latx_trim(char *s)
 {
-    while (isspace((unsigned char)*s)) s++;
-    char *end = s + strlen(s) - 1;
-    while (isspace((unsigned char)*end)) end--;
+    char *end;
+
+    while (isspace((unsigned char)*s)) {
+        s++;
+    }
+    if (*s == '\0') {
+        return s;
+    }
+
+    end = s + strlen(s) - 1;
+    while (end > s && isspace((unsigned char)*end)) {
+        end--;
+    }
     end[1] = '\0';
     return s;
 }

--- a/target/i386/latx/latx-string-utils.c
+++ b/target/i386/latx/latx-string-utils.c
@@ -1,0 +1,61 @@
+/*
+ * SPDX-FileCopyrightText: 2021-2026 LAT Project Authors
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#include "qemu/osdep.h"
+#include "latx-string-utils.h"
+
+char *latx_trim(char *s)
+{
+    while (isspace((unsigned char)*s)) s++;
+    char *end = s + strlen(s) - 1;
+    while (isspace((unsigned char)*end)) end--;
+    end[1] = '\0';
+    return s;
+}
+
+int latx_option_line_init(char *line, char **name, char **value)
+{
+    char *eq;
+
+    while (isspace((unsigned char)*line)) {
+        line++;
+    }
+    if (*line == '#' || *line == '\0') {
+        return false;
+    }
+
+    eq = strchr(line, '=');
+    if (eq == NULL) {
+        return false;
+    }
+
+    *eq = '\0';
+    *name = latx_trim(line);
+    *value = latx_trim(eq + 1);
+    return true;
+}
+
+void latx_extract_filename(const char *filename, char *buffer,
+                           size_t buffer_size)
+{
+    const char *filename_only;
+    const char *last_slash;
+    char *extension;
+
+    last_slash = strrchr(filename, '/');
+    if (last_slash != NULL) {
+        filename_only = last_slash + 1;
+    } else {
+        filename_only = filename;
+    }
+
+    strncpy(buffer, filename_only, buffer_size - 1);
+
+    extension = strchr(buffer, '.');
+    if (extension != NULL) {
+        *extension = '\0';
+    }
+}

--- a/target/i386/latx/latx-string-utils.c
+++ b/target/i386/latx/latx-string-utils.c
@@ -63,6 +63,7 @@ void latx_extract_filename(const char *filename, char *buffer,
     }
 
     strncpy(buffer, filename_only, buffer_size - 1);
+    buffer[buffer_size - 1] = '\0';
 
     extension = strchr(buffer, '.');
     if (extension != NULL) {

--- a/target/i386/latx/meson.build
+++ b/target/i386/latx/meson.build
@@ -61,6 +61,8 @@ if cs_latx_debug or cs_git
                                   include_directories: capstone_git_incdir_dependency)
 endif
 
+latx_string_utils = files('latx-string-utils.c')
+
 i386_ss.add(when: 'CONFIG_LATX', if_true: files(
   'error.c',
   'mem.c',
@@ -70,7 +72,7 @@ i386_ss.add(when: 'CONFIG_LATX', if_true: files(
   'latx-name-demangling.cpp',
   'latx-special-args.c',
   'latx-signal.c',
-))
+) + latx_string_utils)
 
 lazydis_lib = static_library('lazydis',
                          build_by_default: false,

--- a/tests/latx-x86_64/latx-config-regression.c
+++ b/tests/latx-x86_64/latx-config-regression.c
@@ -1,0 +1,41 @@
+/*
+ * SPDX-FileCopyrightText: 2021-2026 LAT Project Authors
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#include "qemu/osdep.h"
+#include <glib.h>
+
+#include "latx-string-utils.h"
+
+static void test_empty_config_value(void)
+{
+    char line[] = "LATX_CLOSE_PARALLEL=   \n";
+    char *name = NULL;
+    char *value = NULL;
+
+    g_assert_true(latx_option_line_init(line, &name, &value));
+    g_assert_cmpstr(name, ==, "LATX_CLOSE_PARALLEL");
+    g_assert_cmpstr(value, ==, "");
+}
+
+static void test_trim_empty_and_whitespace(void)
+{
+    char empty[] = "";
+    char whitespace[] = " \t \n";
+
+    g_assert_cmpstr(latx_trim(empty), ==, "");
+    g_assert_cmpstr(latx_trim(whitespace), ==, "");
+}
+
+int main(int argc, char **argv)
+{
+    g_test_init(&argc, &argv, NULL);
+
+    g_test_add_func("/latx/config/empty-value", test_empty_config_value);
+    g_test_add_func("/latx/config/trim-empty-and-whitespace",
+                    test_trim_empty_and_whitespace);
+
+    return g_test_run();
+}

--- a/tests/latx-x86_64/latx-config-regression.c
+++ b/tests/latx-x86_64/latx-config-regression.c
@@ -29,6 +29,44 @@ static void test_trim_empty_and_whitespace(void)
     g_assert_cmpstr(latx_trim(whitespace), ==, "");
 }
 
+static void test_long_filename_is_terminated(void)
+{
+    char filename[512];
+    char buffer[8];
+
+    filename[0] = '/';
+    filename[1] = 't';
+    filename[2] = 'm';
+    filename[3] = 'p';
+    filename[4] = '/';
+    memset(filename + 5, 'b', sizeof(filename) - 6);
+    filename[sizeof(filename) - 1] = '\0';
+
+    memset(buffer, 'x', sizeof(buffer));
+    latx_extract_filename(filename, buffer, sizeof(buffer));
+
+    g_assert_cmpint(buffer[sizeof(buffer) - 1], ==, '\0');
+    g_assert_cmpstr(buffer, ==, "bbbbbbb");
+}
+
+static void test_single_byte_filename_buffer(void)
+{
+    char buffer[1] = { 'x' };
+
+    latx_extract_filename("program", buffer, sizeof(buffer));
+
+    g_assert_cmpint(buffer[0], ==, '\0');
+}
+
+static void test_filename_path_and_extension(void)
+{
+    char buffer[32];
+
+    latx_extract_filename("/usr/bin/program.exe", buffer, sizeof(buffer));
+
+    g_assert_cmpstr(buffer, ==, "program");
+}
+
 int main(int argc, char **argv)
 {
     g_test_init(&argc, &argv, NULL);
@@ -36,6 +74,12 @@ int main(int argc, char **argv)
     g_test_add_func("/latx/config/empty-value", test_empty_config_value);
     g_test_add_func("/latx/config/trim-empty-and-whitespace",
                     test_trim_empty_and_whitespace);
+    g_test_add_func("/latx/config/long-filename-terminated",
+                    test_long_filename_is_terminated);
+    g_test_add_func("/latx/config/single-byte-filename-buffer",
+                    test_single_byte_filename_buffer);
+    g_test_add_func("/latx/config/filename-path-and-extension",
+                    test_filename_path_and_extension);
 
     return g_test_run();
 }


### PR DESCRIPTION
## Summary / 变更说明

Fix two string-boundary bugs in the LATX runtime configuration path:

- Empty or all-whitespace configuration values could make `trim()` form and
  dereference a pointer before the input buffer.
- A truncated program name was not guaranteed to be NUL-terminated before
  `strchr()` scanned it for an extension.

The small string helpers are now isolated behind
`latx-string-utils.h`. Production sources retain their normal headers, and the
regression test links the exact helper object extracted from the production
library instead of including production `.c` files.

The regression is registered as the explicit Meson target
`test-latx-config-regression` in the `lat-pr-fast` suite. The repository's
shared `.github/workflows/tests.yml` workflow selects that suite; this PR does
not add a test-specific workflow. Ordinary builds with the default
`tests=auto` setting do not contain or build this test-only executable.

### Supported boundary contract

`latx_extract_filename()` is an internal helper. Its `filename` and `buffer`
arguments must be non-NULL, and `buffer_size` must be greater than zero. This
matches its production caller, which uses a fixed 256-byte buffer. The
regression covers the minimum supported buffer size of one byte; NULL and
zero-sized buffers are deliberately outside the helper contract.

## Validation / 验证

RED/GREEN and the affected product build were validated on the LoongArch `l1`
host before the final sync to the repository's shared CI infrastructure:

```console
../configure \
  --target-list=x86_64-linux-user \
  --enable-latx \
  --enable-kzt \
  --enable-debug \
  --enable-tests \
  --enable-sanitizers \
  --disable-werror \
  --optimize-O1 \
  --extra-ldflags=-ldl \
  --disable-docs
ASAN_OPTIONS=detect_leaks=0 \
  meson test latx-config-regression --print-errorlogs
ninja latx-x86_64
```

The current branch is based on `master` at `4641169bebc`; its final validation
is delegated to the shared GitHub `lat-pr-fast` workflow.

Results:

- Pre-fix empty-string behavior: deterministic AddressSanitizer
  `stack-buffer-underflow` in `latx_trim()`.
- Pre-fix long-name behavior: deterministic AddressSanitizer
  `stack-buffer-overflow` while `strchr()` scans the unterminated destination.
- Fixed regression target: 5/5 cases passed.
- Final `latx-x86_64` integration build passed.
- With `tests=auto`, `test-latx-config-regression` is absent from Ninja's
  targets and an ordinary dry-run does not reference it.
- With `tests=enabled`, the explicit target is present and the Meson test
  passes.

Covered cases:

1. Empty configuration value.
2. Empty and all-whitespace trimming.
3. NUL termination after long-name truncation.
4. One-byte destination buffer.
5. Normal path and extension handling.

## Checklist / 检查项

- [x] I have read `CONTRIBUTING.md`. / 我已阅读 `CONTRIBUTING.md`。
- [x] Every commit contains a DCO sign-off (`git commit -s`). /
      每个提交都包含 DCO 签署（`git commit -s`）。
- [x] I have included relevant build or test results, or explained why they
      are not applicable. /
      我已提供相关构建或测试结果，或说明了不适用的原因。
