### PR TITLE
linux-user: Avoid PT_LOAD overlap on 16K hosts

### DIFF
--- a/linux-user/elfload-pagesize.c
+++ b/linux-user/elfload-pagesize.c
@@ -1,0 +1,67 @@
+#include "qemu/osdep.h"
+#include "elf.h"
+#include "qemu/range.h"
+#include "linux-user/elfload-pagesize.h"
+
+uint64_t elf_load_page_start(uint64_t vaddr, uint64_t pagesize)
+{
+    return vaddr & ~(pagesize - 1);
+}
+
+uint64_t elf_load_page_offset(uint64_t vaddr, uint64_t pagesize)
+{
+    return vaddr & (pagesize - 1);
+}
+
+uint64_t elf_load_page_length(uint64_t len, uint64_t pagesize)
+{
+    return ROUND_UP(len, pagesize);
+}
+
+uint64_t elf_load_exec_pagesize(const ElfLoadMapRange *segments,
+                                int segment_count, int current,
+                                uint64_t load_bias,
+                                uint64_t host_page_size,
+                                uint64_t target_page_size)
+{
+    uint64_t elf_pagesize;
+    uint64_t host_page_start, guest_page_start;
+    int i;
+
+    g_assert(segments != NULL);
+    g_assert(current >= 0 && current < segment_count);
+    g_assert(host_page_size != 0);
+    g_assert(target_page_size != 0);
+
+    elf_pagesize = ((segments[current].align & (host_page_size - 1)) != 0) ?
+        target_page_size : MAX(host_page_size, target_page_size);
+
+    if (elf_pagesize <= target_page_size) {
+        return elf_pagesize;
+    }
+
+    host_page_start = elf_load_page_start(load_bias + segments[current].vaddr,
+                                          elf_pagesize);
+    guest_page_start = elf_load_page_start(load_bias + segments[current].vaddr,
+                                           target_page_size);
+    if (host_page_start >= guest_page_start) {
+        return elf_pagesize;
+    }
+
+    for (i = 0; i < segment_count; ++i) {
+        uint64_t other_start;
+
+        if (i == current || segments[i].p_type != PT_LOAD ||
+            segments[i].memsz == 0) {
+            continue;
+        }
+
+        other_start = load_bias + segments[i].vaddr;
+        if (ranges_overlap(host_page_start, guest_page_start - host_page_start,
+                           other_start, segments[i].memsz)) {
+            return target_page_size;
+        }
+    }
+
+    return elf_pagesize;
+}

--- a/linux-user/elfload-pagesize.h
+++ b/linux-user/elfload-pagesize.h
@@ -1,0 +1,22 @@
+#ifndef LINUX_USER_ELFLOAD_PAGESIZE_H
+#define LINUX_USER_ELFLOAD_PAGESIZE_H
+
+#include <stdint.h>
+
+typedef struct ElfLoadMapRange {
+    uint32_t p_type;
+    uint64_t vaddr;
+    uint64_t memsz;
+    uint64_t align;
+} ElfLoadMapRange;
+
+uint64_t elf_load_exec_pagesize(const ElfLoadMapRange *segments,
+                                int segment_count, int current,
+                                uint64_t load_bias,
+                                uint64_t host_page_size,
+                                uint64_t target_page_size);
+uint64_t elf_load_page_start(uint64_t vaddr, uint64_t pagesize);
+uint64_t elf_load_page_offset(uint64_t vaddr, uint64_t pagesize);
+uint64_t elf_load_page_length(uint64_t len, uint64_t pagesize);
+
+#endif

--- a/linux-user/elfload.c
+++ b/linux-user/elfload.c
@@ -14,6 +14,7 @@
 #include "qemu/units.h"
 #include "qemu/selfmap.h"
 #include "qapi/error.h"
+#include "linux-user/elfload-pagesize.h"
 #include "latx-options.h"
 #include "signal-common.h"
 #include "target_signal.h"
@@ -1636,14 +1637,6 @@ struct exec
 #define QMAGIC 0314
 
 /* Necessary parameters */
-#define TARGET_ELF_EXEC_PAGESIZE \
-        (((eppnt->p_align & ~qemu_host_page_mask) != 0) ? \
-         TARGET_PAGE_SIZE : MAX(qemu_host_page_size, TARGET_PAGE_SIZE))
-#define TARGET_ELF_PAGELENGTH(_v) ROUND_UP((_v), TARGET_ELF_EXEC_PAGESIZE)
-#define TARGET_ELF_PAGESTART(_v) ((_v) & \
-                                 ~(abi_ulong)(TARGET_ELF_EXEC_PAGESIZE-1))
-#define TARGET_ELF_PAGEOFFSET(_v) ((_v) & (TARGET_ELF_EXEC_PAGESIZE-1))
-
 #define DLINFO_ITEMS 16
 
 static inline void memcpy_fromfs(void * to, const void * from, unsigned long n)
@@ -2660,6 +2653,7 @@ static void load_elf_image(const char *image_name, const ImageSource *src,
                            char **pinterp_name)
 {
     g_autofree struct elf_phdr *phdr = NULL;
+    g_autofree ElfLoadMapRange *load_segments = NULL;
     abi_ulong load_addr, load_bias, loaddr, hiaddr, error, len;
     int i, prot_exec;
     Error *err = NULL;
@@ -2689,6 +2683,7 @@ static void load_elf_image(const char *image_name, const ImageSource *src,
         goto exit_errmsg;
     }
     bswap_phdr(phdr, ehdr->e_phnum);
+    load_segments = g_new0(ElfLoadMapRange, ehdr->e_phnum);
 
     info->nsegs = 0;
     info->pt_dynamic_addr = 0;
@@ -2715,6 +2710,10 @@ static void load_elf_image(const char *image_name, const ImageSource *src,
             len += b - a;
             ++info->nsegs;
             info->alignment |= eppnt->p_align;
+            load_segments[i].p_type = eppnt->p_type;
+            load_segments[i].vaddr = eppnt->p_vaddr;
+            load_segments[i].memsz = eppnt->p_memsz;
+            load_segments[i].align = eppnt->p_align;
         } else if (eppnt->p_type == PT_INTERP && pinterp_name) {
             g_autofree char *interp_name = NULL;
 
@@ -2850,6 +2849,7 @@ static void load_elf_image(const char *image_name, const ImageSource *src,
         struct elf_phdr *eppnt = phdr + i;
         if (eppnt->p_type == PT_LOAD) {
             abi_ulong vaddr, vaddr_po, vaddr_ps, vaddr_ef, vaddr_em, vaddr_len;
+            abi_ulong elf_pagesize;
             int elf_prot = 0;
 
             if (eppnt->p_flags & PF_R) {
@@ -2862,8 +2862,11 @@ static void load_elf_image(const char *image_name, const ImageSource *src,
                 elf_prot |= prot_exec;
             }
             vaddr = load_bias + eppnt->p_vaddr;
-            vaddr_po = TARGET_ELF_PAGEOFFSET(vaddr);
-            vaddr_ps = TARGET_ELF_PAGESTART(vaddr);
+            elf_pagesize = elf_load_exec_pagesize(load_segments, ehdr->e_phnum, i,
+                                                  load_bias, qemu_host_page_size,
+                                                  TARGET_PAGE_SIZE);
+            vaddr_po = elf_load_page_offset(vaddr, elf_pagesize);
+            vaddr_ps = elf_load_page_start(vaddr, elf_pagesize);
 
             vaddr_ef = vaddr + eppnt->p_filesz;
             vaddr_em = vaddr + eppnt->p_memsz;
@@ -2873,7 +2876,8 @@ static void load_elf_image(const char *image_name, const ImageSource *src,
              * but no backing file segment.
              */
             if (eppnt->p_filesz != 0) {
-                vaddr_len = TARGET_ELF_PAGELENGTH(eppnt->p_filesz + vaddr_po);
+                vaddr_len = elf_load_page_length(eppnt->p_filesz + vaddr_po,
+                                                 elf_pagesize);
                 error = imgsrc_mmap(vaddr_ps, eppnt->p_filesz + vaddr_po,
                                     elf_prot, MAP_PRIVATE | MAP_FIXED,
                                     src, eppnt->p_offset - vaddr_po);
@@ -2889,7 +2893,8 @@ static void load_elf_image(const char *image_name, const ImageSource *src,
                     zero_bss(vaddr_ef, vaddr_em, elf_prot);
                 }
             } else if (eppnt->p_memsz != 0) {
-                vaddr_len = TARGET_ELF_PAGELENGTH(eppnt->p_memsz + vaddr_po);
+                vaddr_len = elf_load_page_length(eppnt->p_memsz + vaddr_po,
+                                                 elf_pagesize);
                 error = target_mmap(vaddr_ps, vaddr_len, elf_prot,
                                     MAP_PRIVATE | MAP_FIXED | MAP_ANONYMOUS,
                                     -1, 0, 1);

--- a/linux-user/meson.build
+++ b/linux-user/meson.build
@@ -1,4 +1,5 @@
 linux_user_ss.add(files(
+  'elfload-pagesize.c',
   'elfload.c',
   'exit.c',
   'fd-trans.c',

--- a/meson.build
+++ b/meson.build
@@ -610,6 +610,7 @@ endif
 
 subdir('scripts')
 subdir('docs')
+subdir('tests')
 
 #########################
 # Configuration summary #

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,0 +1,5 @@
+if get_option('tests').disabled()
+  subdir_done()
+endif
+
+subdir('unit')

--- a/tests/unit/meson.build
+++ b/tests/unit/meson.build
@@ -1,0 +1,8 @@
+test_elfload_pagesize = executable(
+  'test-elfload-pagesize',
+  files('test-elfload-pagesize.c'),
+  '../../linux-user/elfload-pagesize.c',
+  dependencies: glib,
+)
+
+test('test-elfload-pagesize', test_elfload_pagesize)

--- a/tests/unit/test-elfload-pagesize.c
+++ b/tests/unit/test-elfload-pagesize.c
@@ -1,0 +1,52 @@
+#include "qemu/osdep.h"
+#include <glib.h>
+#include "elf.h"
+#include "linux-user/elfload-pagesize.h"
+
+static void test_overlap_falls_back_to_target_pagesize(void)
+{
+    const ElfLoadMapRange segments[] = {
+        { PT_LOAD, 0x24aa400, 0x3c41da0, 0x1000 },
+        { PT_LOAD, 0x60ed1a0, 0x8593e60, 0x4000 },
+    };
+
+    g_assert_cmphex(elf_load_exec_pagesize(segments, G_N_ELEMENTS(segments), 1,
+                                           0, 0x4000, 0x1000),
+                    ==, 0x1000);
+}
+
+static void test_aligned_segment_keeps_host_pagesize(void)
+{
+    const ElfLoadMapRange segments[] = {
+        { PT_LOAD, 0x20000, 0x1800, 0x4000 },
+    };
+
+    g_assert_cmphex(elf_load_exec_pagesize(segments, G_N_ELEMENTS(segments), 0,
+                                           0, 0x4000, 0x1000),
+                    ==, 0x4000);
+}
+
+static void test_small_align_uses_target_pagesize(void)
+{
+    const ElfLoadMapRange segments[] = {
+        { PT_LOAD, 0x20000, 0x1800, 0x1000 },
+    };
+
+    g_assert_cmphex(elf_load_exec_pagesize(segments, G_N_ELEMENTS(segments), 0,
+                                           0, 0x4000, 0x1000),
+                    ==, 0x1000);
+}
+
+int main(int argc, char **argv)
+{
+    g_test_init(&argc, &argv, NULL);
+
+    g_test_add_func("/elfload/pagesize/overlap-falls-back-to-target",
+                    test_overlap_falls_back_to_target_pagesize);
+    g_test_add_func("/elfload/pagesize/aligned-keeps-host",
+                    test_aligned_segment_keeps_host_pagesize);
+    g_test_add_func("/elfload/pagesize/small-align-uses-target",
+                    test_small_align_uses_target_pagesize);
+
+    return g_test_run();
+}


### PR DESCRIPTION
## Summary

  This PR fixes an ELF `PT_LOAD` loading bug on 16K-page LoongArch hosts
  running 4K-page x86_64 guests.

  The issue was reproduced with the official Claude Code Linux x64 release
  asset `claude-linux-x64.tar.gz` from:
  - `https://claude.ai/install.sh`
  - `https://github.com/anthropics/claude-code/releases`

  The root cause is not incorrect instruction translation. A later writable
  `PT_LOAD` could be widened backward to the host-page boundary and overlap
  the tail page of an earlier executable `PT_LOAD`, zeroing `.plt/.iplt`
  bytes before guest execution begins.

  This PR keeps host-page behavior for aligned non-overlapping segments,
  and falls back to guest-page granularity only when host-page widening
  would overlap another `PT_LOAD`.

  It also adds focused regression tests for:
  1. overlap must fall back to guest-page granularity;
  2. aligned non-overlapping segments must still keep host-page behavior;
  3. small `p_align` must still use `TARGET_PAGE_SIZE`.

  <details>
  <summary>English Details</summary>

  ## Problem

  The issue was reproduced with the official Claude Code x86_64 Linux
  native binary release asset `claude-linux-x64.tar.gz`.

  Source:
  - official installer entry point: `https://claude.ai/install.sh`
  - official releases page: `https://github.com/anthropics/claude-code/releases`

  On a 16K-page LoongArch kernel, the following minimal command crashed
  immediately:

  ```bash
  export LATX_AOT=0 LATX_KZT=0
  ./build64/latx-x86_64 /tmp/claude-code-test/claude --help
  ```

  Before this patch:
  - `SIGSEGV`
  - exit code `139`

  After this patch:
  - exits successfully
  - exit code `0`
  - prints the Claude Code help output

  ## Symptom

  At the crash site, execution reached guest bytes `00 00`, which decode as:

  ```asm
  add byte ptr [rax], al
  ```

  With `rax == 0`, the translated LoongArch memory access faulted on
  address `0`.

  That observation was correct, but it was only the symptom. The more
  important question was why the guest reached zero-filled bytes there
  at all.

  ## Root Cause

  The Claude binary contains two adjacent `PT_LOAD` segments:

  - an executable `PT_LOAD` (`R E`) ending at `0x60ec1a0`
  - a writable `PT_LOAD` (`RW`) starting at `0x60ed1a0`

  From the guest 4K-page point of view, these are distinct guest pages:

  ```text
  0x60ec000 - 0x60ecfff   RX page
  0x60ed000 - 0x60edfff   RW page
  ```

  On a 16K host, both guest pages fall into the same host page:

  ```text
  0x60ec000 - 0x60effff
  ```

  The old loader logic could choose host-page ELF loading granularity for
  a segment if its `p_align` matched the host page size. For the later
  writable `PT_LOAD`, `p_align = 0x4000`, so the loader considered it
  eligible for 16K widening and computed:

  ```text
  PAGESTART(0x60ed1a0) = 0x60ec000
  ```

  instead of the guest-page-granular:

  ```text
  PAGESTART(0x60ed1a0) = 0x60ed000
  ```

  That caused the later writable segment to be loaded starting from the
  same 16K host page that already contained the tail of the earlier
  executable segment.

  As a result, the earlier `.plt/.iplt` bytes were overwritten during ELF
  loading.

  This was verified at a breakpoint in `do_init_thread`, before guest
  execution began: the bytes at `0x60ec080` and `0x60ec120` were already
  all zeros before the guest ran, proving this was a loader bug rather
  than a runtime corruption bug.

  ## Why 4K Hosts Worked but 16K Hosts Failed

  On a 4K host, the two guest pages above are also different host pages,
  so they do not interfere.

  On a 16K host, they share one host page:

  ```text
  0x60ec000 - 0x60effff
  ```

  If the later writable segment is widened backward to `0x60ec000`, it
  overwrites the earlier executable tail page.

  So:
  - 4K host: works
  - 16K host: fails

  ## Design History / Risk Assessment

  This area already has a non-trivial history in upstream QEMU.

  - In 2014, `linux-user: Tell guest about big host page sizes`
    (`a70daba3771`) exposed larger host page granularity via `AT_PAGESZ`
    so the guest would not assume mappings smaller than the host can honor.

  - In 2018, `linux-user: fix ELF load alignment error`
    (`33143c446e`) added the fallback to `TARGET_PAGE_SIZE` when a
    `PT_LOAD`'s `p_align` is smaller than the host page size.

  - Later in 2018, `linux-user: elf: mmap all the target-pages of hostpage
    for data segment` (`94894ff2d13`) extended host-page behavior for
    aligned data segments so glibc could consume the remainder of the last
    host page.

  However, the current LATX tree no longer fully preserves those original
  upstream assumptions:

  1. `AT_PAGESZ` is forced back to `TARGET_PAGE_SIZE`, rather than exposing
     the larger host page size;
  2. file-backed `PT_LOAD`s are no longer mapped by rounding the mapping
     length up to the widened host-page length.

  So the current LATX tree is not implementing the full original
  2014/2018 upstream behavior anymore.

  To reduce risk, this patch does **not** globally force all
  `host > guest` cases back to guest-page granularity. Instead:

  - if widening a `PT_LOAD` down to the host-page boundary does **not**
    overlap another `PT_LOAD`, host-page behavior is preserved;
  - only if widening would overlap another `PT_LOAD`, we fall back to
    `TARGET_PAGE_SIZE` for that segment.

  ## Fix

  This patch extracts page-granularity selection into:

  - `linux-user/elfload-pagesize.h`
  - `linux-user/elfload-pagesize.c`

  The new logic is:

  1. Determine whether the current `PT_LOAD` is eligible for host-page
     alignment based on `p_align`.

  2. If it is eligible, check whether widening it downward to the host page
     start would overlap the memory range of any other `PT_LOAD`.

  3. If widening would overlap another `PT_LOAD`:
     - use `TARGET_PAGE_SIZE`
  4. Otherwise:
     - keep host-page ELF loading granularity

  This does not remove host-page behavior in general. It only prevents a
  later segment from extending into bytes that belong to an earlier one.

  ## 16K Host Page Layout

  Affected host page:

  ```text
  0x60ec000 - 0x60effff
  ```

  Before the fix:

  ```text
  16K host page: 0x60ec000 - 0x60effff

  [0x60ec000 ---------------- 0x60ecfff]   tail of earlier RX PT_LOAD
                                           contains .plt/.iplt
                                           but gets overwritten by widening
                                           the later RW PT_LOAD downward

  [0x60ed000 ---------------- 0x60edfff]   beginning of later RW PT_LOAD
  [0x60ee000 ---------------- 0x60eefff]   RW PT_LOAD
  [0x60ef000 ---------------- 0x60effff]   RW PT_LOAD
  ```

  Observed broken bytes before guest execution:

  ```text
  0x60ec080: 00 00 00 00 ...
  0x60ec120: 00 00 00 00 ...
  ```

  After the fix:

  ```text
  16K host page: 0x60ec000 - 0x60effff

  [0x60ec000 ---------------- 0x60ecfff]   preserved tail of earlier RX PT_LOAD
                                           .plt/.iplt bytes remain intact

  [0x60ed000 ---------------- 0x60edfff]   later RW PT_LOAD starts here
  [0x60ee000 ---------------- 0x60eefff]   RW PT_LOAD
  [0x60ef000 ---------------- 0x60effff]   RW PT_LOAD
  ```

  Observed correct bytes at `do_init_thread` after the fix:

  ```text
  0x60ec080:
  ff 25 f2 07 0e 00 68 dc 01 00 00 e9 20 e2 ff ff

  0x60ec120:
  ff 25 a2 07 0e 00 68 00 00 00 00 e9 80 e1 ff ff
  ```

  ## Tests

  The current LATX tree did not contain an existing automated regression
  test for this historical design area, so this PR adds a focused unit
  test:

  - `tests/unit/test-elfload-pagesize.c`

  It covers three cases:

  1. overlap must fall back to guest-page granularity;
  2. aligned non-overlapping segments must still keep host-page behavior;
  3. small `p_align` must still use `TARGET_PAGE_SIZE`.

  Test result:

  ```bash
  meson test -C build64 test-elfload-pagesize --print-errorlogs
  # 1/1 test-elfload-pagesize OK
  ```

  The original reproducer was also rerun successfully:

  ```bash
  export LATX_AOT=0 LATX_KZT=0
  ./build64/latx-x86_64 /tmp/claude-code-test/claude --help
  # exit code 0
  ```

  ## Result

  This PR fixes the Claude Code startup crash on 16K-page LoongArch hosts
  caused by overlapping `PT_LOAD` widening during ELF loading.

  After the fix:
  - `.plt/.iplt` is no longer zeroed during load;
  - execution no longer reaches `00 00 -> add [rax], al`;
  - `Claude --help` runs successfully;
  - focused regression tests are added to cover both the overlap case and
    the older non-overlapping host-page-aligned behavior.

  </details>

  <details>
  <summary>中文说明</summary>

  ## 问题概述

  这个 PR 修复了 LoongArch 16K 宿主页环境下，`linux-user` ELF 装载阶段
  对相邻 `PT_LOAD` 段处理不当的问题。

  问题最初是通过 Claude Code 官方发布的 x86_64 Linux 原生二进制复现的，
  对应发布资产名为：

  `claude-linux-x64.tar.gz`

  来源：
  - 官方安装入口：`https://claude.ai/install.sh`
  - 官方发布页：`https://github.com/anthropics/claude-code/releases`

  在 16K 页大小的 LoongArch Linux 内核上，运行下面的最小命令会直接段错误：

  ```bash
  export LATX_AOT=0 LATX_KZT=0
  ./build64/latx-x86_64 /tmp/claude-code-test/claude --help
  ```

  修复前：
  - 直接 `SIGSEGV`
  - 返回码 `139`

  修复后：
  - 正常退出
  - 返回码 `0`
  - 正常打印 Claude Code 的帮助信息

  ## 直接症状

  崩溃时执行到了 guest 字节 `00 00`，它会被解码为：

  ```asm
  add byte ptr [rax], al
  ```

  此时 `rax == 0`，翻译后的 LoongArch 访存在地址 `0` 触发异常。

  这个现象本身没有错，但它只是症状。真正的问题是：
  为什么 guest 会执行到一片本不该是 0 的区域。

  ## 根因分析

  Claude 二进制里有两个相邻的 `PT_LOAD`：

  - 一个可执行 `PT_LOAD`（`R E`），结束于 `0x60ec1a0`
  - 一个可写 `PT_LOAD`（`RW`），开始于 `0x60ed1a0`

  从 guest 4K 页视角看，它们分别是：

  ```text
  0x60ec000 - 0x60ecfff   RX 页
  0x60ed000 - 0x60edfff   RW 页
  ```

  这是合法布局。

  但在 16K host 上，这两个 guest 4K 页都落进同一个 host 页：

  ```text
  0x60ec000 - 0x60effff
  ```

  旧逻辑在 `p_align` 满足 host 页对齐时，会按 host 页粒度计算
  `PT_LOAD` 的 `PAGESTART`。对后一个 `RW PT_LOAD` 来说，
  `p_align = 0x4000`，于是会得到：

  ```text
  PAGESTART(0x60ed1a0) = 0x60ec000
  ```

  而不是 guest 4K 语义下更合理的：

  ```text
  PAGESTART(0x60ed1a0) = 0x60ed000
  ```

  这样后一个可写段在装载时就回踩到了前一个可执行段所在的
  同一 16K 页前半部分，把 `.plt/.iplt` 覆盖掉了。

  我在 `do_init_thread` 断点处检查过，确认在 guest 开始执行前：

  - `0x60ec080`
  - `0x60ec120`

  这些本应属于 `.plt/.iplt` 的位置，修复前已经全是 `0x00`。

  也就是说：
  - 不是运行过程中踩坏
  - 不是 translator 翻译错了指令
  - 而是 ELF 装载阶段就已经把这一页装坏了

  随后执行流进入这页零字节：

  ```text
  00 00
  ```

  按 x86_64 语义正常解码为：

  ```asm
  add byte ptr [rax], al
  ```

  最后在 `rax == 0` 时触发段错误。

  ## 为什么 4K 内核正常，16K 内核出错

  在 4K host 上：

  - `0x60ec000 - 0x60ecfff`
  - `0x60ed000 - 0x60edfff`

  本来就是两个不同的 host 页，所以不会互相覆盖。

  在 16K host 上：

  - 这两个 guest 页共处
    `0x60ec000 - 0x60effff`
    这个 host 页

  如果后一个 `PT_LOAD` 被错误地向下扩展到 `0x60ec000`，
  就会覆盖前一个段的尾页内容。

  因此：
  - 4K host：正常
  - 16K host：出错

  ## 历史设计背景 / 风险评估

  这个区域在 upstream QEMU 里本来就有一段比较复杂的历史。

  - 2014 年，`linux-user: Tell guest about big host page sizes`
    (`a70daba3771`) 通过 `AT_PAGESZ` 把更大的 host 页粒度告诉 guest。

  - 2018 年，`linux-user: fix ELF load alignment error`
    (`33143c446e`) 又补了当 `PT_LOAD` 的 `p_align` 小于 host 页大小时，
    退回 `TARGET_PAGE_SIZE` 的逻辑。

  - 2018 年稍后，`linux-user: elf: mmap all the target-pages of hostpage
    for data segment` (`94894ff2d13`) 又继续保住 aligned data segment
    的 host-page 行为，避免 glibc 消费最后一个 host 页时出错。

  但是当前 LATX 代码树已经不再完整保留 upstream 当年的那套前提：

  1. `AT_PAGESZ` 已经固定成 `TARGET_PAGE_SIZE`，
     不再把 host 大页告诉 guest；
  2. 文件型 `PT_LOAD` 的装载路径也不再按放大后的 host 页长度整体 mmap。

  所以当前 LATX 树并不是在完整沿用 2014/2018 upstream 那套
  “大 host 页语义”设计。

  为了降低风险，这个 PR **没有**简单粗暴地把所有
  `host > guest` 的场景都退回 guest 页，而是更窄地处理：

  - 如果某个 `PT_LOAD` 按 host 页向下扩展后**不会**与其它 `PT_LOAD` 重叠，
    就继续保留 host 页行为；
  - 只有当按 host 页向下扩展会**重叠到别的 `PT_LOAD`** 时，
    才退回 `TARGET_PAGE_SIZE`。

  ## 修复方案

  这次修复把页粒度判定逻辑抽成了独立 helper：

  - `linux-user/elfload-pagesize.h`
  - `linux-user/elfload-pagesize.c`

  新逻辑如下：

  1. 先按原有规则判断当前段是否有资格使用 host 大页：
     - `p_align` 是否满足 host 页对齐要求

  2. 如果有资格，再额外检查：
     - 当前段如果按 host 页向下扩展，
     - 扩展出来的前半段地址范围，
     - 是否会和其它 `PT_LOAD` 的内存区间相交

  3. 若相交：
     - 该段退回 `TARGET_PAGE_SIZE`
  4. 若不相交：
     - 仍保留 host 页粒度

  也就是说，这个 PR 修复的不是“host 大页行为本身”，
  而是防止 host 大页对齐把后一个段错误地扩进前一个段里。

  ## 16K 页内布局图

  受影响的 host 页是：

  ```text
  0x60ec000 - 0x60effff
  ```

  修复前：

  ```text
  16K host page: 0x60ec000 - 0x60effff

  [0x60ec000 ---------------- 0x60ecfff]   原本属于前一个 RX PT_LOAD 尾页
                                           其中包含 .plt/.iplt
                                           但被后一个 RW PT_LOAD 向下扩展后覆盖

  [0x60ed000 ---------------- 0x60edfff]   后一个 RW PT_LOAD 的前部
  [0x60ee000 ---------------- 0x60eefff]   RW PT_LOAD
  [0x60ef000 ---------------- 0x60effff]   RW PT_LOAD
  ```

  实际观测到的修复前内容：

  ```text
  0x60ec080: 00 00 00 00 ...
  0x60ec120: 00 00 00 00 ...
  ```

  修复后：

  ```text
  16K host page: 0x60ec000 - 0x60effff

  [0x60ec000 ---------------- 0x60ecfff]   保留前一个 RX PT_LOAD 尾页
                                           .plt/.iplt 内容正确

  [0x60ed000 ---------------- 0x60edfff]   后一个 RW PT_LOAD 从这里开始
  [0x60ee000 ---------------- 0x60eefff]   RW PT_LOAD
  [0x60ef000 ---------------- 0x60effff]   RW PT_LOAD
  ```

  修复后在 `do_init_thread` 前检查到：

  ```text
  0x60ec080:
  ff 25 f2 07 0e 00 68 dc 01 00 00 e9 20 e2 ff ff

  0x60ec120:
  ff 25 a2 07 0e 00 68 00 00 00 00 e9 80 e1 ff ff
  ```

  这些字节与二进制文件中的 `.plt/.iplt` 一致，
  说明装载阶段不再错误清零该页。

  ## 测试

  当前代码树里没有现成覆盖这个历史设计问题的自动化测试，
  所以这个 PR 新增了一个最小单元测试：

  - `tests/unit/test-elfload-pagesize.c`

  覆盖了 3 个场景：

  1. overlap 场景必须回退到 guest 页；
  2. aligned 且不重叠的场景继续保留 host 大页行为；
  3. `p_align` 小于 host 页大小时仍回退到 guest 页。

  运行结果：

  ```bash
  meson test -C build64 test-elfload-pagesize --print-errorlogs
  # 1/1 test-elfload-pagesize OK
  ```

  同时原始复现也重新验证通过：

  ```bash
  export LATX_AOT=0 LATX_KZT=0
  ./build64/latx-x86_64 /tmp/claude-code-test/claude --help
  # exit code 0
  ```

  ## 结果

  这个 PR 修复了 16K LoongArch 宿主上，Claude Code x86_64 二进制在启动阶段
  因为相邻 `PT_LOAD` 回踩而导致的崩溃问题。

  修复后：
  - 不再错误清零 `.plt/.iplt`
  - 不再执行到 `00 00 -> add [rax], al`
  - `Claude --help` 可正常运行
  - 同时新增了针对历史设计风险点的回归测试

  </details>
