### PR TITLE
LATX, fix: use invalid PC sentinel for fast_jmp_cache

### DIFF
--- a/include/exec/fasttb.h
+++ b/include/exec/fasttb.h
@@ -1,5 +1,8 @@
 #ifndef FASTTB_H
 #define FASTTB_H
+
+#define FASTTB_INVALID_PC ((unsigned long)-1)
+
 struct FastTB {
     unsigned long pc;
     const void *ptr;    /* pointer to the translated code */

--- a/target/i386/latx/latx-config.c
+++ b/target/i386/latx/latx-config.c
@@ -461,14 +461,19 @@ void latx_fast_jmp_cache_clear(CPUState *cs, int h)
     X86CPU *cpu = X86_CPU(cs);
     CPUX86State *env = &cpu->env;
     FastTB *fast_jmp_cache = (FastTB *)env->tb_jmp_cache_ptr;
-    qatomic_set(&fast_jmp_cache[h].pc, 0);
+    qatomic_set(&fast_jmp_cache[h].pc, FASTTB_INVALID_PC);
 }
 
 void latx_fast_jmp_cache_clear_all(CPUState *cs)
 {
     X86CPU *cpu = X86_CPU(cs);
     CPUX86State *env = &cpu->env;
-    memset(env->tb_jmp_cache_ptr, 0, sizeof(struct FastTB) * TB_JMP_CACHE_SIZE);
+    FastTB *fast_jmp_cache = (FastTB *)env->tb_jmp_cache_ptr;
+
+    for (int i = 0; i < TB_JMP_CACHE_SIZE; i++) {
+        fast_jmp_cache[i].pc = FASTTB_INVALID_PC;
+        fast_jmp_cache[i].ptr = NULL;
+    }
 }
 
 bool latx_fast_jmp_cache_init(void *env)
@@ -479,6 +484,9 @@ bool latx_fast_jmp_cache_init(void *env)
     fast_jmp_cache = calloc(TB_JMP_CACHE_SIZE, sizeof(struct FastTB));
     if (!fast_jmp_cache) {
         return false;
+    }
+    for (int i = 0; i < TB_JMP_CACHE_SIZE; i++) {
+        fast_jmp_cache[i].pc = FASTTB_INVALID_PC;
     }
     x86env->tb_jmp_cache_ptr = fast_jmp_cache;
 


### PR DESCRIPTION
Switch fast_jmp_cache empty-slot pc from 0 to invalid_pc(-1) to avoid false hit when next_x86_addr is 0, fixed the SIGSEGV issue when running Foxmail.