### PR TITLE
LATX, opt: align the slot generated in generate_indirect_goto

### DIFF
--- a/target/i386/latx/latx-signal.c
+++ b/target/i386/latx/latx-signal.c
@@ -151,11 +151,6 @@ void unlink_indirect_jmp(CPUArchState *env, TranslationBlock *tb, ucontext_t *uc
         insn = qatomic_read((uint32_t *)(jmp_rx + INS_SIZE));
         jmp_rw += INS_SIZE;
     } 
-#ifdef CONFIG_LATX_AOT
-    else {
-        qatomic_set((uint32_t *)(jmp_rw + INS_SIZE), nop);
-    }
-#endif
 #endif
 
 #ifdef CONFIG_LATX_FAST_JMPCACHE


### PR DESCRIPTION
This opt can speed up programs similar to the one below.:
```c
#include <signal.h>
#include <stdint.h>
#include <stdio.h>
#include <sys/time.h>
#include <unistd.h>

static volatile uint64_t g_sink;

__attribute__((noinline)) void f0(uint64_t x) { g_sink += x; }
__attribute__((noinline)) void f1(uint64_t x) { g_sink ^= x; }
__attribute__((noinline)) void f2(uint64_t x) { g_sink += (x << 1); }
__attribute__((noinline)) void f3(uint64_t x) { g_sink ^= (x >> 3); }

static void handler(int sig) {
    (void)sig;
}

int main(void) {
    struct sigaction sa = {0};
    sa.sa_handler = handler;
    sigaction(SIGALRM, &sa, NULL);

    struct itimerval it = {0};
    it.it_interval.tv_usec = 1000;
    it.it_value = it.it_interval;
    setitimer(ITIMER_REAL, &it, NULL);

    void (*fp[4])(uint64_t) = {f0, f1, f2, f3};

    uint64_t i = 0;
    while (1) {
        fp[i & 3](i);
        i++;
        if ((i & ((1ULL<<24)-1)) == 0) {
            write(1, ".", 1);
        }
    }
    return 0;
}
```