### PR TITLE
stable-1.6: backport selected LATX fixes

### DIFF
--- a/include/exec/fasttb.h
+++ b/include/exec/fasttb.h
@@ -1,5 +1,8 @@
 #ifndef FASTTB_H
 #define FASTTB_H
+
+#define FASTTB_INVALID_PC ((unsigned long)-1)
+
 struct FastTB {
     unsigned long pc;
     const void *ptr;    /* pointer to the translated code */

--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -8153,7 +8153,7 @@ static abi_long do_ioctl(int fd, int cmd, abi_ulong arg)
 #endif
     /* slow path to iterate the ioctl_entries */
     if (ie->target_cmd != cmd) {
-        if (TARGET_IOC_TYPE(cmd) == 'H') {
+        if (TARGET_IOC_TYPE(cmd) == 'H' || TARGET_IOC_TYPE(cmd) == 'U') {
             switch(TARGET_IOC_NR(cmd)) {
                 case TARGET_IOC_NR(TARGET_HIDIOCSFEATURE(0)):
                 case TARGET_IOC_NR(TARGET_HIDIOCGFEATURE(0)):

--- a/target/i386/latx/latx-config.c
+++ b/target/i386/latx/latx-config.c
@@ -466,14 +466,19 @@ void latx_fast_jmp_cache_clear(CPUState *cs, int h)
     X86CPU *cpu = X86_CPU(cs);
     CPUX86State *env = &cpu->env;
     FastTB *fast_jmp_cache = (FastTB *)env->tb_jmp_cache_ptr;
-    qatomic_set(&fast_jmp_cache[h].pc, 0);
+    qatomic_set(&fast_jmp_cache[h].pc, FASTTB_INVALID_PC);
 }
 
 void latx_fast_jmp_cache_clear_all(CPUState *cs)
 {
     X86CPU *cpu = X86_CPU(cs);
     CPUX86State *env = &cpu->env;
-    memset(env->tb_jmp_cache_ptr, 0, sizeof(struct FastTB) * TB_JMP_CACHE_SIZE);
+    FastTB *fast_jmp_cache = (FastTB *)env->tb_jmp_cache_ptr;
+
+    for (int i = 0; i < TB_JMP_CACHE_SIZE; i++) {
+        fast_jmp_cache[i].pc = FASTTB_INVALID_PC;
+        fast_jmp_cache[i].ptr = NULL;
+    }
 }
 
 bool latx_fast_jmp_cache_init(void *env)
@@ -484,6 +489,9 @@ bool latx_fast_jmp_cache_init(void *env)
     fast_jmp_cache = calloc(TB_JMP_CACHE_SIZE, sizeof(struct FastTB));
     if (!fast_jmp_cache) {
         return false;
+    }
+    for (int i = 0; i < TB_JMP_CACHE_SIZE; i++) {
+        fast_jmp_cache[i].pc = FASTTB_INVALID_PC;
     }
     x86env->tb_jmp_cache_ptr = fast_jmp_cache;
 

--- a/target/i386/latx/translator/tr-avx-mov.c
+++ b/target/i386/latx/translator/tr-avx-mov.c
@@ -309,7 +309,7 @@ bool translate_vmovd(IR1_INST *pir1)
         IR2_OPND dest = ra_alloc_xmm(ir1_opnd_base_reg_num(opnd0));
         IR2_OPND src = load_ireg_from_ir1(opnd1, UNKNOWN_EXTENSION, false);
         la_xvandi_b(dest, dest, 0);
-        la_vinsgr2vr_w(dest, src, 0);
+        la_xvinsgr2vr_w(dest, src, 0);
         set_high128_xreg_to_zero(dest);
     } else if (ir1_opnd_is_gpr(opnd0) && ir1_opnd_is_xmm(opnd1)) {
         IR2_OPND dest = load_ireg_from_ir1(opnd0, UNKNOWN_EXTENSION, false);
@@ -435,7 +435,7 @@ bool translate_vmovq(IR1_INST * pir1) {
             IR2_OPND dest = load_freg128_from_ir1(opnd0);
             IR2_OPND src = load_ireg_from_ir1(opnd1, UNKNOWN_EXTENSION, false);
             la_xvandi_b(dest, dest, 0x0);
-            la_vinsgr2vr_d(dest, src, 0x0);
+            la_xvinsgr2vr_d(dest, src, 0x0);
 
         } else if (ir1_opnd_is_gpr(opnd0) && ir1_opnd_is_xmm(opnd1)) {
             IR2_OPND dest = load_ireg_from_ir1(opnd0, UNKNOWN_EXTENSION, false);

--- a/target/i386/latx/translator/tr-pattern.c
+++ b/target/i386/latx/translator/tr-pattern.c
@@ -658,6 +658,10 @@ static bool translate_cqo_idiv(IR1_INST *ir1)
 {
     IR1_INST *next = ir1->instptn.next;
 
+    IR2_OPND ir2_opnd_addr;
+    ir2_opnd_build(&ir2_opnd_addr, IR2_OPND_IMM, ir1_addr(next));
+    la_x86_inst(ir2_opnd_addr);
+
     IR2_OPND src_opnd_0 =
         load_ireg_from_ir1(ir1_get_opnd(next, 0), SIGN_EXTENSION, false);
 
@@ -885,6 +889,10 @@ static bool translate_xor_div(IR1_INST *ir1)
 {
     IR1_INST *next = ir1->instptn.next;
 
+    IR2_OPND ir2_opnd_addr;
+    ir2_opnd_build(&ir2_opnd_addr, IR2_OPND_IMM, ir1_addr(next));
+    la_x86_inst(ir2_opnd_addr);
+
     IR2_OPND src_opnd_0 =
         load_ireg_from_ir1(ir1_get_opnd(next, 0), ZERO_EXTENSION, false);
 
@@ -929,6 +937,10 @@ static bool translate_xor_div(IR1_INST *ir1)
 static bool translate_cdq_idiv(IR1_INST *ir1)
 {
     IR1_INST *next = ir1->instptn.next;
+
+    IR2_OPND ir2_opnd_addr;
+    ir2_opnd_build(&ir2_opnd_addr, IR2_OPND_IMM, ir1_addr(next));
+    la_x86_inst(ir2_opnd_addr);
 
     IR2_OPND src_opnd_0 =
         load_ireg_from_ir1(ir1_get_opnd(next, 0), SIGN_EXTENSION, false);

--- a/tcg/tcg.c
+++ b/tcg/tcg.c
@@ -699,6 +699,9 @@ static void *tcg_tb_lookup_fast(uintptr_t tc_ptr)
                 CODE_GEN_ALIGN));
     while (tbm->mtbp_struct.magic != TB_MAGIC) {
         tbm = (TBMini *)((uint64_t)tbm - CODE_GEN_ALIGN);
+        if (!in_code_gen_buffer((void *)tbm)) {
+            return NULL;
+        }
     }
     void *tb = (void *)(tbm->mtbp_uint64 &
                 MAKE_64BIT_MASK(0, HOST_VIRT_ADDR_SPACE_BITS));


### PR DESCRIPTION
Backport selected LATX fixes from master for stable-1.6.

Included fixes:
- tcg_tb_lookup_fast bounds check
- HID ioctl compatibility
- vmovd/vmovq upper bits cleanup
- Java divide-by-zero instruction location
- fast_jmp_cache invalid PC sentinel

Validation:
- ./latxbuild/build-release.sh