### PR TITLE
linux-user: Allow zero-length read/write with invalid buffers

### DIFF
--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -11573,7 +11573,7 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
         _exit(arg1);
         return 0; /* avoid warning */
     case TARGET_NR_read:
-        if (arg2 == 0 && arg3 == 0) {
+        if (arg3 == 0) {
             return get_errno(safe_read(arg1, 0, 0));
         } else {
             if (!(p = lock_user(VERIFY_WRITE, arg2, arg3, 0)))
@@ -11587,7 +11587,7 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
         }
         return ret;
     case TARGET_NR_write:
-        if (arg2 == 0 && arg3 == 0) {
+        if (arg3 == 0) {
             return get_errno(safe_write(arg1, 0, 0));
         }
         if (!(p = lock_user(VERIFY_READ, arg2, arg3, 1)))


### PR DESCRIPTION
Skip user buffer locking whenever count is zero for read and write. Xmind can issue write(fd, 0x100ffffffff, 0) while forwarding empty stderr output from Electron/Node. Linux treats zero-length read/write as a no-op and must not validate the user buffer. LATX only skipped lock_user when the buffer was NULL, so a non-NULL invalid pointer returned EFAULT.