### PR TITLE
linux-user, fix: Restrict task-dir getdents64 filtering

### DIFF
--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -14250,10 +14250,11 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
 
         if (path_len > 0) {
             real_path[path_len] = '\0';
-            int pid;
-            char extra[2];
+            char *endptr;
 
-            if (sscanf(real_path, "/proc/%d/task%1s", &pid, extra) == 1) {
+            if (!strncmp(real_path, "/proc/", 6)
+                && strtol(real_path + 6, &endptr, 10) > 0
+                && !strcmp(endptr, "/task")) {
 #ifdef CONFIG_LATX_DEBUG
                 fprintf(stderr, "latx: Detected task directory: %s\n", real_path);
 #endif


### PR DESCRIPTION
The getdents64 ghost-thread filter was intended to run only for /proc/<pid>/task, but the sscanf check also matched paths such as /proc/<pid>/fd after parsing the pid. That hid numeric fd entries from /proc/self/fd and prevented jspawnhelper from marking the fail pipe close-on-exec.

Match the path by parsing the pid and requiring the remaining suffix to be exactly /task, so fd, maps, and other proc directories are not filtered as task directories.