### PR TITLE
configure: allow LAT source archives without keycodemapdb

### DIFF
--- a/configure
+++ b/configure
@@ -272,24 +272,6 @@ then
 else
     git_submodules_action="ignore"
     git_submodules=""
-
-    if ! test -f "$source_path/ui/keycodemapdb/README"
-    then
-        echo
-        echo "ERROR: missing file $source_path/ui/keycodemapdb/README"
-        echo
-        echo "This is not a GIT checkout but module content appears to"
-        echo "be missing. Do not use 'git archive' or GitHub download links"
-        echo "to acquire QEMU source archives. Non-GIT builds are only"
-        echo "supported with source archives linked from:"
-        echo
-        echo "  https://www.qemu.org/download/#source"
-        echo
-        echo "Developers working with GIT can use scripts/archive-source.sh"
-        echo "if they need to create valid source archives."
-        echo
-        exit 1
-    fi
 fi
 git="git"
 


### PR DESCRIPTION
Fixes #328.

GitHub-generated source archives do not include the removed `ui/keycodemapdb` component. LAT linux-user builds do not require it, so remove the inherited QEMU archive validation that rejects those archives.

Validation: exported a source tree with `git archive` and ran `./configure --help` successfully.