### PR TITLE
linux-user: declare x86_64 syscall header outputs

### DIFF
--- a/linux-user/i386/cpu_loop.c
+++ b/linux-user/i386/cpu_loop.c
@@ -197,7 +197,7 @@ static void emulate_vsyscall(CPUX86State *env)
 #endif
 #ifdef TARGET_X86_64
 #include "syscall_64_nr.h"
-#include "syscall_target_32_nr.h"
+#include "syscall_64_target_32_nr.h"
 int syscall_64_to_32[TARGET32_TARGET_NR_LATX_LAST + 1] = {0};
 #include "syscall_64_to_32_map.h"
 #include "lsenv.h"

--- a/linux-user/i386/syscall_nr.h
+++ b/linux-user/i386/syscall_nr.h
@@ -1,4 +1,4 @@
 #include "syscall_32_nr.h"
 #ifdef TARGET_X86_64
-#include "syscall_target_32_nr.h"
+#include "syscall_64_target_32_nr.h"
 #endif

--- a/linux-user/x86_64/meson.build
+++ b/linux-user/x86_64/meson.build
@@ -1,7 +1,11 @@
 syscall_nr_generators += {
   'x86_64': generator(sh,
-                      arguments: [ meson.current_source_dir() / 'syscallhdr.sh', '@INPUT@', '@OUTPUT@', '@EXTRA_ARGS@' ],
-                      output: '@BASENAME@_nr.h')
+                      arguments: [ meson.current_source_dir() / 'syscallhdr.sh',
+                                   '@INPUT@', '@OUTPUT0@', '@OUTPUT1@',
+                                   '@OUTPUT2@', '@EXTRA_ARGS@' ],
+                      output: [ '@BASENAME@_nr.h',
+                                '@BASENAME@_to_32_map.h',
+                                '@BASENAME@_target_32_nr.h' ])
 }
 
 vdso_inc = gen_vdso.process('vdso.so')

--- a/linux-user/x86_64/syscallhdr.sh
+++ b/linux-user/x86_64/syscallhdr.sh
@@ -3,9 +3,11 @@
 
 in="$1"
 out="$2"
-my_abis=`echo "($3)" | tr ',' '|'`
-prefix="$4"
-offset="$5"
+map_out="$3"
+target32_out="$4"
+my_abis=`echo "($5)" | tr ',' '|'`
+prefix="$6"
+offset="$7"
 
 fileguard=LINUX_USER_X86_64_`basename "$out" | sed \
     -e 'y/abcdefghijklmnopqrstuvwxyz/ABCDEFGHIJKLMNOPQRSTUVWXYZ/' \
@@ -27,9 +29,9 @@ grep -E "^[0-9A-Fa-fXx]+[[:space:]]+${my_abis}" "$in" | sort -n | (
     echo "#endif /* ${fileguard} */"
 ) > "$out"
 #syscall_64_to_32_map.h
-out=$(dirname "$out")/"syscall_64_to_32_map.h"
+out="$map_out"
 in=`echo $in | sed 's/x86_64/i386/g;s/_64.tbl/_32.tbl/g'`
-my_abis=`echo "($3)" |sed 's/,64/,i386/g' | tr ',' '|'`
+my_abis=`echo "($5)" |sed 's/,64/,i386/g' | tr ',' '|'`
 
 fileguard=LINUX_USER_X86_64_MAPS_`basename "$out" | sed \
     -e 'y/abcdefghijklmnopqrstuvwxyz/ABCDEFGHIJKLMNOPQRSTUVWXYZ/' \
@@ -53,8 +55,8 @@ grep -E "^[0-9A-Fa-fXx]+[[:space:]]+${my_abis}" "$in" | sort -n | (
     echo "#endif /* ${fileguard} */"
 ) > "$out"
 
-# syscall_target_32_nr.h
-out=$(dirname "$out")/"syscall_target_32_nr.h"
+# syscall_64_target_32_nr.h
+out="$target32_out"
 
 fileguard=LINUX_USER_I386_TARGET32_`basename "$out" | sed \
     -e 'y/abcdefghijklmnopqrstuvwxyz/ABCDEFGHIJKLMNOPQRSTUVWXYZ/' \


### PR DESCRIPTION
## Summary
- declare all headers produced by the x86_64 syscall generator
- remove the implicit side effects that allowed Ninja to compile before `syscall_target_32_nr.h` existed
- use deterministic generated header names for the x86_64 target

## Validation
- configured a clean x86_64 linux-user build in `/tmp`
- built `libqemu-x86_64-linux-user.fa.p/linux-user_x86_64_cpu_loop.c.o`
- verified the generated `syscall_64_target_32_nr.h` exists before the object compilation
- `git diff --check`

Fixes #327