### PR TITLE
LATX, fix: Raise TF trap at successor PC

### DIFF
--- a/target/i386/latx/include/translate.h
+++ b/target/i386/latx/include/translate.h
@@ -1344,6 +1344,7 @@ void generate_xcomisx(IR2_OPND, IR2_OPND, bool, bool, uint8_t);
 /* extern ADDR tb_look_up_native; */
 
 void tr_generate_exit_tb(IR1_INST *branch, int succ_id);
+void tr_generate_exit_tb_to_next(IR1_INST *ir1);
 #ifdef CONFIG_LATX_XCOMISX_OPT
 void tr_generate_exit_stub_tb(IR1_INST *branch, int succ_id, void *func, IR1_INST *stub);
 #endif

--- a/target/i386/latx/ir1/ir1.c
+++ b/target/i386/latx/ir1/ir1.c
@@ -1721,6 +1721,13 @@ bool ir1_is_tb_ending(IR1_INST *ir1)
 #if defined(CONFIG_LATX_KZT)
     if(option_kzt && ir1_opcode(ir1) == dt_X86_INS_INT3) return true;
 #endif
+    if (option_anonym &&
+        (ir1_opcode(ir1) == dt_X86_INS_POPF ||
+         ir1_opcode(ir1) == dt_X86_INS_POPFD ||
+         ir1_opcode(ir1) == dt_X86_INS_POPFQ)) {
+        return true;
+    }
+
     if (ir1_opcode(ir1) == dt_X86_INS_CALL && !ir1_is_indirect_call(ir1) &&
         ir1_addr_next(ir1) == ir1_target_addr(ir1)) {
         return false;

--- a/target/i386/latx/latx-config.c
+++ b/target/i386/latx/latx-config.c
@@ -93,6 +93,9 @@ int target_latx_host(CPUArchState *env, struct TranslationBlock *tb,
     TCGProfile *prof = &tcg_ctx->prof;
     int64_t ti = profile_getclock();
 #endif
+    if (option_anonym && (tb->flags & HF_TF_MASK)) {
+        max_insns = 1;
+    }
     tr_disasm(tb, max_insns);
     /* return code_size and skip translate */
     if (!tb->icount && tb->pc < reserved_va) {

--- a/target/i386/latx/translator/tr-eflag.c
+++ b/target/i386/latx/translator/tr-eflag.c
@@ -56,6 +56,9 @@ bool translate_popf(IR1_INST *pir1)
     ra_free_temp(eflags_temp_opnd);
 
     la_addi_addrx(esp_opnd, esp_opnd, sp_step);
+    if (option_anonym) {
+        tr_generate_exit_tb_to_next(pir1);
+    }
     return true;
 }
 

--- a/target/i386/latx/translator/tr-misc.c
+++ b/target/i386/latx/translator/tr-misc.c
@@ -33,26 +33,6 @@ struct cpu_state_info {
 
 bool translate_nop(IR1_INST *pir1)
 {
-    if (option_anonym) {
-        IR2_OPND eflags_opnd = ra_alloc_eflags();
-        IR2_OPND eflags_temp_opnd = ra_alloc_itemp();
-        IR2_OPND tmp_opnd = ra_alloc_itemp();
-        IR2_OPND eip_opnd = ra_alloc_dbt_arg2();
-        IR2_OPND label_TF = ra_alloc_label();
-
-        la_andi(eflags_temp_opnd, eflags_opnd, TF_MASK);
-        la_beqz(eflags_temp_opnd, label_TF);
-        li_d(eip_opnd, ir1_addr(pir1));
-        la_store_addrx(eip_opnd, env_ir2_opnd,
-                        lsenv_offset_of_eip(lsenv));
-        tr_save_registers_to_env(0xff, 0xff, option_save_xmm, options_to_save());
-        aot_load_host_addr(tmp_opnd, (ADDR)helper_raise_trapop,
-            LOAD_HELPER_RAISE_TRAPOP, 0);
-        la_jirl(zero_ir2_opnd, tmp_opnd, 0);
-        ra_free_temp(tmp_opnd);
-        la_label(label_TF);
-    }
-
     la_andi(zero_ir2_opnd, zero_ir2_opnd, 0);
 
     return true;

--- a/target/i386/latx/translator/translate.c
+++ b/target/i386/latx/translator/translate.c
@@ -2596,6 +2596,44 @@ static inline void set_tb_canlink(IR1_INST *branch, int succ_id, ADDR succ_x86_a
     }
 }
 
+static void tr_generate_single_step_exit(IR2_OPND next_pc)
+{
+    IR2_OPND helper_addr = ra_alloc_itemp();
+
+    la_store_addrx(next_pc, env_ir2_opnd, lsenv_offset_of_eip(lsenv));
+    tr_save_registers_to_env(0xff, 0xff, option_save_xmm,
+                             options_to_save());
+#ifdef TARGET_X86_64
+    tr_save_x64_8_registers_to_env(0xff, option_save_xmm);
+#endif
+    aot_load_host_addr(helper_addr, (ADDR)helper_raise_trapop,
+                       LOAD_HELPER_RAISE_TRAPOP, 0);
+    la_jirl(zero_ir2_opnd, helper_addr, 0);
+    ra_free_temp(helper_addr);
+}
+
+void tr_generate_exit_tb_to_next(IR1_INST *ir1)
+{
+    TranslationBlock *tb = lsenv->tr_data->curr_tb;
+    IR2_OPND next_pc = ra_alloc_dbt_arg2();
+    target_ulong call_offset = aot_get_call_offset(ir1_addr_next(ir1));
+
+    aot_load_guest_addr(next_pc, ir1_addr_next(ir1), LOAD_CALL_TARGET,
+                        call_offset);
+
+    if (tb->flags & HF_TF_MASK) {
+        tr_generate_single_step_exit(next_pc);
+        return;
+    }
+
+    IR2_OPND base = ra_alloc_data();
+    IR2_OPND target = ra_alloc_data();
+
+    la_data_li(base, (ADDR)tb->tc.ptr);
+    la_data_li(target, context_switch_native_to_bt_ret_0);
+    aot_la_append_ir2_jmp_far(target, base, B_EPILOGUE_RET_0, 0);
+}
+
 #ifdef CONFIG_LATX_XCOMISX_OPT
 inline
 void tr_generate_exit_tb(IR1_INST *branch, int succ_id)
@@ -2675,6 +2713,15 @@ void tr_generate_exit_tb(IR1_INST *branch, int succ_id)
             tb->first_jmp_align = ir2_opnd_label_id(&label_first_jmp_align);
         }
 direct_jmp:
+        if (option_anonym && (tb->flags & HF_TF_MASK)) {
+            target_ulong call_offset = aot_get_call_offset(succ_x86_addr);
+
+            aot_load_guest_addr(succ_x86_addr_opnd, succ_x86_addr,
+                                LOAD_CALL_TARGET, call_offset);
+            tr_generate_single_step_exit(succ_x86_addr_opnd);
+            break;
+        }
+
         /*
          * If option_lsfpu is open, condition jmp will jmp to next tb diretly.
          * Therefore LATX do not always need to update last_tb, after tb link.
@@ -2741,6 +2788,11 @@ direct_jmp:
     case dt_X86_INS_IRETD:
     case dt_X86_INS_IRETQ:
 indirect_jmp:
+        if (option_anonym && (tb->flags & HF_TF_MASK)) {
+            tr_generate_single_step_exit(succ_x86_addr_opnd);
+            break;
+        }
+
         tb->bool_flags |= IS_INDIRECT_JMP;
         /*
          * If option_lsfpu is open, LATX do not need to fpu_rotate, therefore


### PR DESCRIPTION
TF single-step handling waited until a NOP and reported the current instruction address. This delayed #DB and supplied the wrong exception PC.

End the translation block after POPF and limit TF-enabled blocks to one instruction. Raise EXCP01_DB with the actual successor PC for direct and indirect control flow, and remove the NOP-specific handling.