### PR TITLE
ci: add static clang compiler

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,7 @@ jobs:
           DOCKER_CMD="./latxbuild/${{ matrix.type.NAME }}.sh ${{ matrix.type.OPT }}"
           docker run --rm \
             --platform linux/loong64 \
+            --env RUNNER_ARCH \
             --volume /tmp/.cache:/root/.cache \
             --volume "$(pwd):/io" \
             --workdir /io \

--- a/configure
+++ b/configure
@@ -1741,9 +1741,8 @@ if test "$latx" = "yes" ; then
     QEMU_LDFLAGS="$latx_ldflags $QEMU_LDFLAGS"
     ;;
   esac
-  if test "$debug" = "yes" ; then
-    # add `--export-dynamic`, used for backtrace
-    QEMU_LDFLAGS="-export-dynamic $QEMU_LDFLAGS"
+  if echo | $cc -dM -E - | grep __clang__ > /dev/null 2>&1 ; then
+    QEMU_LDFLAGS="-fuse-ld=bfd -Wl,-export-dynamic $QEMU_LDFLAGS"
   else
     QEMU_LDFLAGS="-export-dynamic $QEMU_LDFLAGS"
   fi

--- a/latxbuild/build-release.sh
+++ b/latxbuild/build-release.sh
@@ -9,6 +9,10 @@ pkgdir=$srcdir/pkg
 tarballs=$pkgname-$pkgver-$pkgdate.tar.xz
 package_root=$pkgdir/$pkgname-$pkgver
 
+if [ -n "${RUNNER_ARCH}" ] && [ -d "/opt/clang/bin" ]; then
+    export PATH=/opt/clang/bin:$PATH
+fi
+
 prepare() {
     [ -d $srcdir/build32 ] || mkdir -p $srcdir/build32
     [ -d $srcdir/build64 ] || mkdir -p $srcdir/build64

--- a/latxbuild/build32-dbg.sh
+++ b/latxbuild/build32-dbg.sh
@@ -6,6 +6,10 @@ opt_level=1
 low_mem_mode=""
 avx_support=""
 
+if [ -n "${RUNNER_ARCH}" ] && [ -d "/opt/clang/bin" ]; then
+    export PATH=/opt/clang/bin:$PATH
+fi
+
 help() {
     echo "Usage:"
     echo "  -c              configure"
@@ -68,20 +72,20 @@ make_cmd() {
         if [ "$opt_level" = "0" ] ; then
             ../configure --target-list=i386-linux-user --enable-latx \
                 --enable-guest-base-zero  --enable-debug --optimize-O0 \
-                --disable-docs ${low_mem_mode} ${avx_support}
+                --disable-docs --disable-werror --disable-kvm ${low_mem_mode} ${avx_support}
         elif [ "$opt_level" = "1" ] ; then
             ../configure --target-list=i386-linux-user --enable-latx \
                 --enable-guest-base-zero  --enable-debug --optimize-O1 \
-                --disable-docs ${low_mem_mode} ${avx_support}
+                --disable-docs --disable-werror --disable-kvm ${low_mem_mode} ${avx_support}
         elif [ "$opt_level" = "2" ] ; then
             ../configure --target-list=i386-linux-user --enable-latx \
                 --enable-guest-base-zero  --enable-debug --optimize-O2 \
-                --disable-docs ${low_mem_mode} ${avx_support}
+                --disable-docs --disable-werror --disable-kvm ${low_mem_mode} ${avx_support}
 
         elif [ "$opt_level" = "3" ] ; then
             ../configure --target-list=i386-linux-user --enable-latx \
                 --enable-guest-base-zero  --enable-debug --optimize-O3 \
-                --disable-docs ${low_mem_mode} ${avx_support}
+                --disable-docs --disable-werror --disable-kvm ${low_mem_mode} ${avx_support}
         else
             echo "invalid options"
         fi

--- a/latxbuild/build32.sh
+++ b/latxbuild/build32.sh
@@ -6,6 +6,10 @@ opt_level=1
 low_mem_mode=""
 avx_support=""
 
+if [ -n "${RUNNER_ARCH}" ] && [ -d "/opt/clang/bin" ]; then
+    export PATH=/opt/clang/bin:$PATH
+fi
+
 help() {
     echo "Usage:"
     echo "  -c              configure"
@@ -69,19 +73,19 @@ make_cmd() {
         if [ "$opt_level" = "0" ] ; then
             ../configure --target-list=i386-linux-user --enable-latx \
                 --enable-guest-base-zero --disable-debug-info --optimize-O0 \
-                --disable-docs ${low_mem_mode} ${avx_support}
+                --disable-docs --disable-werror ${low_mem_mode} ${avx_support}
         elif [ "$opt_level" = "1" ] ; then
             ../configure --target-list=i386-linux-user --enable-latx \
                 --enable-guest-base-zero --disable-debug-info --optimize-O1 \
-                --disable-docs ${low_mem_mode} ${avx_support}
+                --disable-docs --disable-werror ${low_mem_mode} ${avx_support}
         elif [ "$opt_level" = "2" ] ; then
             ../configure --target-list=i386-linux-user --enable-latx \
                 --enable-guest-base-zero --disable-debug-info --optimize-O2 \
-                --disable-docs ${low_mem_mode} ${avx_support}
+                --disable-docs --disable-werror ${low_mem_mode} ${avx_support}
         elif [ "$opt_level" = "3" ] ; then
             ../configure --target-list=i386-linux-user --enable-latx \
                 --enable-guest-base-zero --disable-debug-info --optimize-O3 \
-                --disable-docs ${low_mem_mode} ${avx_support}
+                --disable-docs --disable-werror ${low_mem_mode} ${avx_support}
         else
             echo "invalid options"
         fi

--- a/latxbuild/build64-dbg.sh
+++ b/latxbuild/build64-dbg.sh
@@ -5,6 +5,10 @@ make_configure=0
 opt_level=1
 avx_support=""
 
+if [ -n "${RUNNER_ARCH}" ] && [ -d "/opt/clang/bin" ]; then
+    export PATH=/opt/clang/bin:$PATH
+fi
+
 help() {
     echo "Usage:"
     echo "  -c              configure"
@@ -66,20 +70,20 @@ make_cmd() {
     if [ $make_configure -eq 1 ] ; then
         if [ "$opt_level" = "0" ] ; then
             ../configure --target-list=x86_64-linux-user --enable-latx \
-                --enable-debug --optimize-O0 --static --extra-ldflags=-ldl \
-                --disable-docs ${low_mem_mode} ${avx_support}
+                --enable-debug --optimize-O0 --extra-ldflags=-ldl \
+                --disable-docs --disable-werror --disable-kvm ${low_mem_mode} ${avx_support}
         elif [ "$opt_level" = "1" ] ; then
             ../configure --target-list=x86_64-linux-user --enable-latx \
                 --enable-debug --optimize-O1 --extra-ldflags=-ldl --enable-kzt \
-                --disable-docs ${low_mem_mode} ${avx_support}
+                --disable-docs --disable-werror --disable-kvm ${low_mem_mode} ${avx_support}
         elif [ "$opt_level" = "2" ] ; then
             ../configure --target-list=x86_64-linux-user --enable-latx \
-                --enable-debug --optimize-O2 --static --extra-ldflags=-ldl \
-                --disable-docs ${low_mem_mode} ${avx_support}
+                --enable-debug --optimize-O2 --extra-ldflags=-ldl \
+                --disable-docs --disable-werror --disable-kvm ${low_mem_mode} ${avx_support}
         elif [ "$opt_level" = "3" ] ; then
             ../configure --target-list=x86_64-linux-user --enable-latx \
-                --enable-debug --optimize-O3 --static --extra-ldflags=-ldl \
-                --disable-docs ${low_mem_mode} ${avx_support}
+                --enable-debug --optimize-O3 --extra-ldflags=-ldl \
+                --disable-docs --disable-werror --disable-kvm ${low_mem_mode} ${avx_support}
         else
             echo "invalid options"
         fi

--- a/latxbuild/build64.sh
+++ b/latxbuild/build64.sh
@@ -6,6 +6,10 @@ opt_level=1
 low_mem_mode=""
 avx_support=""
 
+if [ -n "${RUNNER_ARCH}" ] && [ -d "/opt/clang/bin" ]; then
+    export PATH=/opt/clang/bin:$PATH
+fi
+
 help() {
     echo "Usage:"
     echo "  -c              configure"
@@ -67,20 +71,20 @@ make_cmd() {
     if [ $make_configure -eq 1 ] ; then
         if [ "$opt_level" = "0" ] ; then
             ../configure --target-list=x86_64-linux-user --enable-latx \
-                --disable-debug-info --optimize-O0 --static --extra-ldflags=-ldl \
-                --disable-docs ${low_mem_mode} ${avx_support}
+                --disable-debug-info --optimize-O0 --extra-ldflags=-ldl \
+                --disable-docs --disable-werror ${low_mem_mode} ${avx_support}
         elif [ "$opt_level" = "1" ] ; then
             ../configure --target-list=x86_64-linux-user --enable-latx \
                 --disable-debug-info --optimize-O1 --extra-ldflags=-ldl --enable-kzt \
-                --disable-docs ${low_mem_mode} ${avx_support}
+                --disable-docs --disable-werror ${low_mem_mode} ${avx_support}
         elif [ "$opt_level" = "2" ] ; then
             ../configure --target-list=x86_64-linux-user --enable-latx \
-                --disable-debug-info --optimize-O2 --static --extra-ldflags=-ldl \
-                --disable-docs ${low_mem_mode} ${avx_support}
+                --disable-debug-info --optimize-O2 --extra-ldflags=-ldl \
+                --disable-docs --disable-werror ${low_mem_mode} ${avx_support}
         elif [ "$opt_level" = "3" ] ; then
             ../configure --target-list=x86_64-linux-user --enable-latx \
-                --disable-debug-info --optimize-O3 --static --extra-ldflags=-ldl \
-                --disable-docs ${low_mem_mode} ${avx_support}
+                --disable-debug-info --optimize-O3 --extra-ldflags=-ldl \
+                --disable-docs --disable-werror ${low_mem_mode} ${avx_support}
         else
             echo "invalid options"
         fi

--- a/linux-user/i386/signal.c
+++ b/linux-user/i386/signal.c
@@ -250,11 +250,13 @@ __asm__(".macro parse_v var val\n\t"
 
 __asm__(".macro parse_r var r\n\t"
     "\\var = -1\n\t"
+    _IFC_REG(a0,4)   _IFC_REG(a1,5)   _IFC_REG(a2,6)   _IFC_REG(a3,7)
+    _IFC_REG(fp,22)
     _IFC_REG(r0,0) _IFC_REG(r1,1)  _IFC_REG(r2,2)  _IFC_REG(r3,3)
     _IFC_REG(r4,4)   _IFC_REG(r5,5)  _IFC_REG(r6,6)  _IFC_REG(r7,7)
     _IFC_REG(r8,8)   _IFC_REG(r9,9)  _IFC_REG(r10,10) _IFC_REG(r11,11)
     _IFC_REG(r12,12)  _IFC_REG(r13,13) _IFC_REG(r14,14) _IFC_REG(r15,15)
-    _IFC_REG(r16,16)  _IFC_REG(r17,17) _IFC_REG(r18,18) _IFC_REG(r17,19)
+    _IFC_REG(r16,16)  _IFC_REG(r17,17) _IFC_REG(r18,18) _IFC_REG(r19,19)
     _IFC_REG(r20,20)  _IFC_REG(r21,21)  _IFC_REG(r22,22) _IFC_REG(r23,23)
     _IFC_REG(r24,24)  _IFC_REG(r25,25) _IFC_REG(r26,26) _IFC_REG(r27,27)
     _IFC_REG(r28,28)  _IFC_REG(r29,29) _IFC_REG(r30,30) _IFC_REG(r31,31)

--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -9705,14 +9705,14 @@ static void QEMU_NORETURN seccomp_kill_thread(CPUArchState *env)
 }
 
 typedef struct ForkCloneContext {
-    void *jump_buffer[5];
+    jmp_buf jump_buffer;
 } ForkCloneContext;
 
 static int fork_clone_func(void *opaque)
 {
     ForkCloneContext *context = opaque;
 
-    __builtin_longjmp(context->jump_buffer, 1);
+    longjmp(context->jump_buffer, 1);
 }
 
 static int fork_with_flags(unsigned int flags)
@@ -9720,7 +9720,7 @@ static int fork_with_flags(unsigned int flags)
     char stack[PTHREAD_STACK_MIN] __attribute__((aligned(16)));
     ForkCloneContext context;
 
-    if (__builtin_setjmp(context.jump_buffer) == 0) {
+    if (setjmp(context.jump_buffer) == 0) {
         return clone(fork_clone_func, stack + sizeof(stack), flags, &context);
     }
     return 0;

--- a/target/i386/cpu.c
+++ b/target/i386/cpu.c
@@ -4455,7 +4455,9 @@ static void max_x86_cpu_initfn(Object *obj)
 {
     X86CPU *cpu = X86_CPU(obj);
     CPUX86State *env = &cpu->env;
+#ifdef CONFIG_KVM
     KVMState *s = kvm_state;
+#endif
 
     /* We can't fill the features array here because we don't know yet if
      * "migratable" is true or false.
@@ -4478,6 +4480,7 @@ static void max_x86_cpu_initfn(Object *obj)
         object_property_set_str(OBJECT(cpu), "model-id", model_id,
                                 &error_abort);
 
+#ifdef CONFIG_KVM
         if (kvm_enabled()) {
             env->cpuid_min_level =
                 kvm_arch_get_supported_cpuid(s, 0x0, 0, R_EAX);
@@ -4486,13 +4489,16 @@ static void max_x86_cpu_initfn(Object *obj)
             env->cpuid_min_xlevel2 =
                 kvm_arch_get_supported_cpuid(s, 0xC0000000, 0, R_EAX);
         } else {
+#endif
             env->cpuid_min_level =
                 hvf_get_supported_cpuid(0x0, 0, R_EAX);
             env->cpuid_min_xlevel =
                 hvf_get_supported_cpuid(0x80000000, 0, R_EAX);
             env->cpuid_min_xlevel2 =
                 hvf_get_supported_cpuid(0xC0000000, 0, R_EAX);
+#ifdef CONFIG_KVM
         }
+#endif
 
         if (lmce_supported()) {
             object_property_set_bool(OBJECT(cpu), "lmce", true, &error_abort);
@@ -5227,6 +5233,7 @@ static uint64_t x86_cpu_get_supported_feature_word(FeatureWord w,
     FeatureWordInfo *wi = &feature_word_info[w];
     uint64_t r = 0;
 
+#ifdef CONFIG_KVM
     if (kvm_enabled()) {
         switch (wi->type) {
         case CPUID_FEATURE_WORD:
@@ -5239,7 +5246,9 @@ static uint64_t x86_cpu_get_supported_feature_word(FeatureWord w,
                         wi->msr.index);
             break;
         }
-    } else if (hvf_enabled()) {
+    } else
+#endif
+    if (hvf_enabled()) {
         if (wi->type != CPUID_FEATURE_WORD) {
             return 0;
         }
@@ -5822,6 +5831,7 @@ void cpu_x86_cpuid(CPUX86State *env, uint32_t index, uint32_t count,
         break;
     case 0xA:
         /* Architectural Performance Monitoring Leaf */
+#ifdef CONFIG_KVM
         if (kvm_enabled() && cpu->enable_pmu) {
             KVMState *s = cs->kvm_state;
 
@@ -5829,7 +5839,9 @@ void cpu_x86_cpuid(CPUX86State *env, uint32_t index, uint32_t count,
             *ebx = kvm_arch_get_supported_cpuid(s, 0xA, count, R_EBX);
             *ecx = kvm_arch_get_supported_cpuid(s, 0xA, count, R_ECX);
             *edx = kvm_arch_get_supported_cpuid(s, 0xA, count, R_EDX);
-        } else if (hvf_enabled() && cpu->enable_pmu) {
+        } else
+#endif
+        if (hvf_enabled() && cpu->enable_pmu) {
             *eax = hvf_get_supported_cpuid(0xA, count, R_EAX);
             *ebx = hvf_get_supported_cpuid(0xA, count, R_EBX);
             *ecx = hvf_get_supported_cpuid(0xA, count, R_ECX);
@@ -6689,6 +6701,7 @@ static void x86_cpu_filter_features(X86CPU *cpu, bool verbose)
         mark_unavailable_features(cpu, w, unavailable_features, prefix);
     }
 
+#ifdef CONFIG_KVM
     if ((env->features[FEAT_7_0_EBX] & CPUID_7_0_EBX_INTEL_PT) &&
         kvm_enabled()) {
         KVMState *s = CPU(cpu)->kvm_state;
@@ -6716,6 +6729,7 @@ static void x86_cpu_filter_features(X86CPU *cpu, bool verbose)
             mark_unavailable_features(cpu, FEAT_7_0_EBX, CPUID_7_0_EBX_INTEL_PT, prefix);
         }
     }
+#endif
 }
 
 static void x86_cpu_hyperv_realize(X86CPU *cpu)

--- a/target/i386/latx/sbt/aot_recover_tb.c
+++ b/target/i386/latx/sbt/aot_recover_tb.c
@@ -214,7 +214,7 @@ static void recover_tb_range(target_ulong page, struct aot_tb *p_aot_tbs,
         /* Reserve space for tu tbmin table. */
         TBMini *tbmini_ptr= (TBMini *)
             ROUND_UP((uintptr_t)tcg_ctx->code_gen_ptr, CODE_GEN_ALIGN);
-        qatomic_set(&tcg_ctx->code_gen_ptr, ROUND_UP((uintptr_t)tbmini_ptr +
+        qatomic_set(&tcg_ctx->code_gen_ptr, (void *)ROUND_UP((uintptr_t)tbmini_ptr +
                     sizeof(struct TBMini) * (tb_num_in_tu + 1), qemu_icache_linesize));
         /* First tbm save tb_num_in_tu and TB_MAGIC. */
         aot_tbmini_set_pointer((uintptr_t)tbmini_ptr, tb_num_in_tu, TB_MAGIC);

--- a/target/i386/latx/translator/tr-pattern.c
+++ b/target/i386/latx/translator/tr-pattern.c
@@ -20,6 +20,10 @@
     ".ifc \\r, $r" #n "\n\t"                 \
     "\\var = " #n "\n\t"                     \
     ".endif\n\t"
+#define PARSE_R_IFC_ALIAS(n, alias)             \
+    ".ifc \\r, $" #alias "\n\t"              \
+    "\\var = " #n "\n\t"                     \
+    ".endif\n\t"
 /*
  * LTO may duplicate or reorder file-scope assembly.  Keep the assembler
  * macro with its users and give each extended asm statement a unique name.
@@ -43,6 +47,22 @@
     PARSE_R_IFC_REG(26) PARSE_R_IFC_REG(27) \
     PARSE_R_IFC_REG(28) PARSE_R_IFC_REG(29) \
     PARSE_R_IFC_REG(30) PARSE_R_IFC_REG(31) \
+    PARSE_R_IFC_ALIAS(0, zero) PARSE_R_IFC_ALIAS(1, ra) \
+    PARSE_R_IFC_ALIAS(2, tp)   PARSE_R_IFC_ALIAS(3, sp) \
+    PARSE_R_IFC_ALIAS(4, a0)   PARSE_R_IFC_ALIAS(5, a1) \
+    PARSE_R_IFC_ALIAS(6, a2)   PARSE_R_IFC_ALIAS(7, a3) \
+    PARSE_R_IFC_ALIAS(8, a4)   PARSE_R_IFC_ALIAS(9, a5) \
+    PARSE_R_IFC_ALIAS(10, a6)  PARSE_R_IFC_ALIAS(11, a7) \
+    PARSE_R_IFC_ALIAS(12, t0)  PARSE_R_IFC_ALIAS(13, t1) \
+    PARSE_R_IFC_ALIAS(14, t2)  PARSE_R_IFC_ALIAS(15, t3) \
+    PARSE_R_IFC_ALIAS(16, t4)  PARSE_R_IFC_ALIAS(17, t5) \
+    PARSE_R_IFC_ALIAS(18, t6)  PARSE_R_IFC_ALIAS(19, t7) \
+    PARSE_R_IFC_ALIAS(20, t8)  PARSE_R_IFC_ALIAS(21, u0) \
+    PARSE_R_IFC_ALIAS(22, fp)  PARSE_R_IFC_ALIAS(23, s0) \
+    PARSE_R_IFC_ALIAS(24, s1)  PARSE_R_IFC_ALIAS(25, s2) \
+    PARSE_R_IFC_ALIAS(26, s3)  PARSE_R_IFC_ALIAS(27, s4) \
+    PARSE_R_IFC_ALIAS(28, s5)  PARSE_R_IFC_ALIAS(29, s6) \
+    PARSE_R_IFC_ALIAS(30, s7)  PARSE_R_IFC_ALIAS(31, s8) \
     ".iflt \\var\n\t"                         \
     ".error \"Unable to parse register name \\r\"\n\t" \
     ".endif\n\t"                                \


### PR DESCRIPTION
Install the static Clang toolchain in the LoongArch build images and
use it for release and debug builds.

Fix Clang-specific build issues in signal handling, clone context
jump buffers, KVM conditional compilation, linker flags, and LoongArch
register-name parsing.

