### PR TITLE
LATX: Fix SMC page permissions and gate tests

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -577,7 +577,9 @@ foreach target : target_dirs
                  build_by_default: false,
                  name_suffix: 'fa')
 
-  if target == 'x86_64-linux-user' and 'CONFIG_LATX_O1' in config_host
+  if get_option('tests').enabled() and \
+     target == 'x86_64-linux-user' and \
+     'CONFIG_LATX_O1' in config_host
     smc_reload_test_c_args = c_args + [
       '-ffunction-sections',
       '-fvisibility=hidden',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -126,6 +126,6 @@ option('fdt', type: 'combo', value: 'auto',
        choices: ['disabled', 'enabled', 'auto', 'system', 'internal'],
        description: 'Whether and how to find the libfdt library')
 option('tests', type : 'feature', value : 'auto',
-       description: 'Tests build support')
+       description: 'Build tests only when explicitly enabled')
 option('latx_version', type: 'string', value: '',
        description: 'Custom version string')

--- a/target/i386/latx/sbt/aot_smc_reload.c
+++ b/target/i386/latx/sbt/aot_smc_reload.c
@@ -38,7 +38,7 @@ int smc_page_reload(target_ulong page_addr, uint32_t cflags)
     }
 
     p_flags = page_get_flags(page_addr);
-    if (!(p_flags & PAGE_EXEC)) {
+    if (!(p_flags & (PAGE_READ | PAGE_EXEC))) {
         return 0;
     }
     if ((p_flags & PAGE_WRITE) && !page_is_shadow_not_shmm(page_addr)) {

--- a/target/i386/latx/sbt/tests/smc-reload-tu-test.c
+++ b/target/i386/latx/sbt/tests/smc-reload-tu-test.c
@@ -7,6 +7,7 @@
 #include "exec/translate-all.h"
 
 static unsigned int aot_register_count;
+static int test_page_flags;
 
 __thread TCGContext *tcg_ctx;
 int option_smc_reload;
@@ -52,7 +53,7 @@ void aot_tb_register(TranslationBlock *tb)
 
 int page_get_flags(target_ulong address G_GNUC_UNUSED)
 {
-    return PAGE_VALID | PAGE_EXEC;
+    return test_page_flags;
 }
 
 bool page_is_shadow_not_shmm(target_ulong address G_GNUC_UNUSED)
@@ -96,9 +97,26 @@ int main(void)
     reload->ir1_code_buffer = g_malloc(sizeof(guest_code));
     memcpy(reload->ir1_code_buffer, guest_code, sizeof(guest_code));
 
+    test_page_flags = PAGE_READ;
     smc_reload_tree_insert(reload);
     g_assert(smc_page_reload(reload->page_addr, 0) == 1);
     g_assert(aot_register_count == 1);
+    g_assert(tb.tu_jmp[TU_TB_INDEX_NEXT] == 4);
+    g_assert(smc_reload_tree_get_node_count() == 0);
+
+    tb.cflags = CF_INVALID;
+    reload = g_new0(SMCReloadInfo, 1);
+    reload->tb_count = 1;
+    reload->page_addr = (uintptr_t)guest_code & TARGET_PAGE_MASK;
+    reload->tb_vector = g_new(TranslationBlock *, 1);
+    reload->tb_vector[0] = &tb;
+    reload->ir1_code_buffer = g_malloc(sizeof(guest_code));
+    memcpy(reload->ir1_code_buffer, guest_code, sizeof(guest_code));
+
+    test_page_flags = PAGE_VALID | PAGE_EXEC;
+    smc_reload_tree_insert(reload);
+    g_assert(smc_page_reload(reload->page_addr, 0) == 1);
+    g_assert(aot_register_count == 2);
     g_assert(tb.tu_jmp[TU_TB_INDEX_NEXT] == 4);
     g_assert(smc_reload_tree_get_node_count() == 0);
     qemu_spin_destroy(&tb.jmp_lock);

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,4 +1,4 @@
-if get_option('tests').disabled()
+if not get_option('tests').enabled()
   subdir_done()
 endif
 


### PR DESCRIPTION
## Summary

This series fixes two follow-up issues in the SMC reload changes:

- Preserve SMC reload support for readable pages while retaining support for execute-only pages.
- Keep test-only executables out of normal builds unless tests are explicitly enabled.

## Patch details

### 1. `LATX, fix: Preserve readable SMC reload pages`

**Problem**

The SMC reload permission check had been changed from `PAGE_READ` to `PAGE_EXEC`. This allowed execute-only pages, but unintentionally rejected existing readable-page reload candidates.

**RED**

The production-path regression test was extended with separate `PAGE_READ` and `PAGE_EXEC` scenarios. Before the fix, the readable-page scenario failed:

```text
ninja -C build test-latx-smc-reload-tu
./build/test-latx-smc-reload-tu
assertion failed at smc_page_reload(...) == 1 for PAGE_READ
```

**Fix**

Accept a reload candidate when its page has either `PAGE_READ` or `PAGE_EXEC`:

```c
p_flags & (PAGE_READ | PAGE_EXEC)
```

This restores readable-page behavior without losing execute-only page support.

**GREEN**

```text
meson test -C build --no-rebuild --print-errorlogs latx-smc-reload-tu
1/1 OK
```

The affected SMC regression suite also passed:

```text
meson test -C build --no-rebuild --print-errorlogs \
  latx-smc-reload-tu \
  latx-smc-reload-guest-base \
  latx-tb-flush-smc-reload-async
3/3 OK
```

### 2. `LATX, build: Require explicit test enablement`

**Problem**

With the default `tests=auto` configuration, all four root-project test executables were registered with `build_by_default=true`. As a result, ordinary product builds also compiled test-only binaries.

**RED**

Before the fix, a `tests=auto` configuration reported:

- 4 registered tests
- 4 test executables with `build_by_default=true`

**Fix**

Define the root-project tests only when the Meson `tests` feature is explicitly enabled. Tests can now be requested with `--enable-tests`, while the default configuration excludes their executables.

The audit covers all four root-project tests:

- `latx-smc-reload-tu`
- `latx-smc-reload-guest-base`
- `latx-tb-flush-smc-reload-async`
- `test-elfload-pagesize`

## Testing

Manual validation was performed on a LoongArch machine.

With the default `tests=auto` configuration:

```text
0 tests registered
0 test targets
default ninja dry-run planned 0 test builds
```

With tests explicitly enabled:

```text
latx-smc-reload-tu                 OK
latx-smc-reload-guest-base         OK
latx-tb-flush-smc-reload-async     OK
test-elfload-pagesize              OK

4/4 OK
```

## CI note

The existing release-build matrix remains a normal product-build matrix and does not pass `--enable-tests`. A dedicated explicit test job can be added separately if continuous execution of these tests is desired.