### PR TITLE
LATX, fix: Avoid invalid IR1 predecessor access

### DIFF
--- a/target/i386/latx/translator/translate.c
+++ b/target/i386/latx/translator/translate.c
@@ -247,15 +247,15 @@ IR1_INST *get_ir1_list(struct TranslationBlock *tb, ADDRX pc, int max_insns)
             tb->s_data->tu_tb_mode = TU_TB_MODE_BROKEN;
             tb->s_data->next_pc = tb->pc;
 #endif
-            IR1_INST *pre = &ir1_list[ir1_num - 1];
             pir1->info = (void *)((uint64_t)pir1_base +
                     (ir1_num * sizeof(struct la_dt_insn)));
             pir1->info->id = dt_X86_INS_INVALID;
-			if (ir1_num == 0) {
-				pir1->info->address = pc;
-			} else {
-				pir1->info->address = pre->info->address + pre->info->size;
-			}
+            if (ir1_num == 0) {
+                pir1->info->address = pc;
+            } else {
+                IR1_INST *pre = &ir1_list[ir1_num - 1];
+                pir1->info->address = pre->info->address + pre->info->size;
+            }
             ir1_num++;
             break;
         }


### PR DESCRIPTION
## Summary

- Avoid forming `ir1_list[-1]` when disassembly fails before producing the
  first IR1 instruction.
- Derive the synthesized invalid instruction address from a predecessor only
  after confirming that one exists.
- Keep the touched block compliant with the project indentation rules.

## Root cause

The failure path formed a pointer to `ir1_list[ir1_num - 1]` before checking
whether `ir1_num` was zero. A decode failure on the first instruction therefore
formed an out-of-bounds predecessor pointer even though the zero-instruction
branch did not dereference it.

## Validation

Mac:

- Deterministic RED by temporarily restoring the old hunk: strict checkpatch
  reported 6 errors.
- GREEN: strict checkpatch reports 0 errors and 0 warnings.
- `git diff --check` passes.
- Standards and specification reviews both pass with no P0-P2 findings.

LoongArch (`l1`, commit `c91ac892ce776d26c2c97fd35c479d5dca1fc16e`):

- Incremental compilation of
  `libqemu-x86_64-linux-user.fa.p/target_i386_latx_translator_translate.c.o`
  passes.
- `ninja -C build latx-x86_64 -j8` passes.
- Final `ninja -C build -j8` passes.
- `meson test -C build --no-rebuild --print-errorlogs`: 4/4 tests pass.

Signed-off-by: Wenqiang Wei <weiwenqiang@mail.ustc.edu.cn>
