### PR TITLE
LATX, opt: Reduce AOT page-load link capacity

### DIFF
--- a/target/i386/latx/sbt/aot_link_seg.c
+++ b/target/i386/latx/sbt/aot_link_seg.c
@@ -10,6 +10,7 @@
  * @brief AOT optimization
  */
 #include "aot_link_seg.h"
+#include "qemu/error-report.h"
 #include "latx-options.h"
 #include "reg-map.h"
 #include "accel/tcg/internal.h"
@@ -22,8 +23,8 @@ enum {
 };
 
 static aot_link_info *aot_global_info;
-static int aot_global_info_total;
-static int aot_global_info_index;
+static size_t aot_global_info_total;
+static size_t aot_global_info_index;
 
 static void patch_jrra(aot_link_info *info)
 {
@@ -79,7 +80,7 @@ __inline static void link_aot_tb(aot_link_info *info)
 
 void try_aot_link(void)
 {
-    for (int i = 0; i < aot_global_info_index; i++) {
+    for (size_t i = 0; i < aot_global_info_index; i++) {
         aot_link_info *info = aot_global_info + i;
         link_aot_tb(info);
 #if defined(CONFIG_LATX_JRRA) || defined(CONFIG_LATX_JRRA_STACK)
@@ -98,7 +99,7 @@ void aot_link_tree_init(void)
     } else {
         aot_global_info_total = AOT_LINK_PAGE_INITIAL_CAPACITY;
     }
-    aot_global_info = malloc(aot_global_info_total * sizeof(aot_link_info));
+    aot_global_info = g_new(aot_link_info, aot_global_info_total);
     aot_global_info_index = 0;
 }
 
@@ -106,9 +107,14 @@ void aot_link_tree_insert(TranslationBlock *curr,
         target_ulong aim1_pc, target_ulong aim2_pc)
 {
     if (aot_global_info_index >= aot_global_info_total) {
+        if (aot_global_info_total >
+            SIZE_MAX / 2 / sizeof(*aot_global_info)) {
+            error_report("AOT link table capacity overflow");
+            exit(EXIT_FAILURE);
+        }
         aot_global_info_total <<= 1;
-        aot_global_info = realloc(aot_global_info,
-            aot_global_info_total * sizeof(aot_link_info));
+        aot_global_info = g_renew(aot_link_info, aot_global_info,
+                                  aot_global_info_total);
     }
     aot_link_info *info = aot_global_info + aot_global_info_index;
     info->curr = curr;

--- a/target/i386/latx/sbt/aot_link_seg.c
+++ b/target/i386/latx/sbt/aot_link_seg.c
@@ -87,7 +87,11 @@ void try_aot_link(void)
 
 void aot_link_tree_init(void)
 {
-    aot_global_info_total = 100000;
+    if (option_aot & 0x2) {
+        aot_global_info_total = 100000;
+    } else {
+        aot_global_info_total = 128;
+    }
     aot_global_info = malloc(aot_global_info_total * sizeof(aot_link_info));
     aot_global_info_index = 0;
 }
@@ -96,7 +100,7 @@ void aot_link_tree_insert(TranslationBlock *curr,
         target_ulong aim1_pc, target_ulong aim2_pc)
 {
     if (aot_global_info_index >= aot_global_info_total) {
-        aot_global_info_total += 1000;
+        aot_global_info_total <<= 1;
         aot_global_info = realloc(aot_global_info,
             aot_global_info_total * sizeof(aot_link_info));
     }

--- a/target/i386/latx/sbt/aot_link_seg.c
+++ b/target/i386/latx/sbt/aot_link_seg.c
@@ -107,14 +107,24 @@ void aot_link_tree_insert(TranslationBlock *curr,
         target_ulong aim1_pc, target_ulong aim2_pc)
 {
     if (aot_global_info_index >= aot_global_info_total) {
+        size_t new_total;
+        aot_link_info *new_info;
+
         if (aot_global_info_total >
             SIZE_MAX / 2 / sizeof(*aot_global_info)) {
-            error_report("AOT link table capacity overflow");
-            exit(EXIT_FAILURE);
+            warn_report_once("AOT link table capacity overflow; "
+                             "skipping additional AOT links");
+            return;
         }
-        aot_global_info_total <<= 1;
-        aot_global_info = g_renew(aot_link_info, aot_global_info,
-                                  aot_global_info_total);
+        new_total = aot_global_info_total << 1;
+        new_info = g_try_renew(aot_link_info, aot_global_info, new_total);
+        if (!new_info) {
+            warn_report_once("Could not grow AOT link table; "
+                             "skipping additional AOT links");
+            return;
+        }
+        aot_global_info = new_info;
+        aot_global_info_total = new_total;
     }
     aot_link_info *info = aot_global_info + aot_global_info_index;
     info->curr = curr;

--- a/target/i386/latx/sbt/aot_link_seg.c
+++ b/target/i386/latx/sbt/aot_link_seg.c
@@ -15,6 +15,12 @@
 #include "accel/tcg/internal.h"
 
 #ifdef CONFIG_LATX_AOT
+enum {
+    AOT_MODE_LOAD_ALL = 2,
+    AOT_LINK_PAGE_INITIAL_CAPACITY = 512,
+    AOT_LINK_SEGMENT_INITIAL_CAPACITY = 100000,
+};
+
 static aot_link_info *aot_global_info;
 static int aot_global_info_total;
 static int aot_global_info_index;
@@ -87,10 +93,10 @@ void try_aot_link(void)
 
 void aot_link_tree_init(void)
 {
-    if (option_aot & 0x2) {
-        aot_global_info_total = 100000;
+    if (option_aot == AOT_MODE_LOAD_ALL) {
+        aot_global_info_total = AOT_LINK_SEGMENT_INITIAL_CAPACITY;
     } else {
-        aot_global_info_total = 128;
+        aot_global_info_total = AOT_LINK_PAGE_INITIAL_CAPACITY;
     }
     aot_global_info = malloc(aot_global_info_total * sizeof(aot_link_info));
     aot_global_info_index = 0;


### PR DESCRIPTION
## Summary

- reduce the initial AOT link table for page-load mode from 100000 entries to 512
- keep load-all mode at 100000 entries
- grow the table geometrically while preserving existing entries
- make growth overflow-safe and degrade to unlinked TBs on allocation failure instead of terminating the process

## Review fixes

The original patch was corrected during review:

- align the page-mode capacity with the documented 512 entries (the patch used 128)
- replace magic mode/capacity values with named constants
- use `size_t` for capacities and indices
- guard doubling against overflow
- use `g_try_renew()` and skip additional AOT links on growth failure, preserving the old allocation and capacity

## Validation

Validated on LoongArch host `l1` at `06965c246dc431a01651ab6598784565b68c71f8`:

- O1+AOT `latx-x86_64` target build: PASS (397/397 on initial build)
- full product build: PASS
- GDB white-box capacity check: page mode starts at 512; insertion 513 grows to 1024 with entries 1, 512, and 513 preserved; load-all mode remains 100000
- `sizeof(aot_link_info) == 24`: page-mode initial allocation drops from 2,400,000 bytes to 12,288 bytes
- deterministic RED: old overflow path exits the process with code 1
- deterministic GREEN: fixed overflow path emits one warning and returns without terminating the process
- explicit test build and Meson tests: 4/4 PASS
- restored default product configuration: registered tests `[]`, full build PASS

Mac-side final checks:

- four-commit series `checkpatch.pl --strict`: 0 errors, 0 warnings
- `git diff --check`: clean
- Standards review: PASS, no P0-P2 findings remaining
- Spec review: PASS, no P0-P2 findings remaining