### PR TITLE
LATX, fix: Publish lock-free AOT updates safely

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -635,6 +635,22 @@ foreach target : target_dirs
       link_args: smc_reload_test_link_args
     )
     test('latx-tb-flush-smc-reload-async', smc_reload_async_flush_test)
+
+    aot_file_publish_test = executable(
+      'test-latx-aot-file-publish',
+      files(
+        'target/i386/latx/sbt/tests/aot-file-publish-test.c',
+        'target/i386/latx/sbt/file_ctx.c'
+      ),
+      c_args: smc_reload_test_c_args,
+      dependencies: [glib],
+      include_directories: target_inc,
+      link_args: smc_reload_test_link_args + [
+        '-Wl,--wrap=fsync',
+        '-Wl,--wrap=rename'
+      ]
+    )
+    test('latx-aot-file-publish', aot_file_publish_test)
   endif
 
     execs = [{

--- a/target/i386/latx/include/aot.h
+++ b/target/i386/latx/include/aot.h
@@ -310,7 +310,7 @@ void clear_rel_table(void);
 void recover_aot_tb(char *lib_name, uint64_t aot_offset,
         abi_long start, abi_long len);
 
-bool do_generate_aot(int first_seg_in_lib, int end_seg_in_lib);
+int do_generate_aot(int first_seg_in_lib, int end_seg_in_lib);
 struct aot_segment *aot_find_segment(char *path, int offset,
         void *curr_aot_buffer);
 

--- a/target/i386/latx/include/aot.h
+++ b/target/i386/latx/include/aot.h
@@ -310,7 +310,7 @@ void clear_rel_table(void);
 void recover_aot_tb(char *lib_name, uint64_t aot_offset,
         abi_long start, abi_long len);
 
-void do_generate_aot(int first_seg_in_lib, int end_seg_in_lib);
+bool do_generate_aot(int first_seg_in_lib, int end_seg_in_lib);
 struct aot_segment *aot_find_segment(char *path, int offset,
         void *curr_aot_buffer);
 

--- a/target/i386/latx/include/aot_merge.h
+++ b/target/i386/latx/include/aot_merge.h
@@ -26,10 +26,16 @@ typedef struct merge_tb_info {
     aot_rel *aot_rel_table;
     int rel_table_num;
 } merge_tb_info;
-void do_merge_seg_aot(void);
+typedef enum AOTMergeResult {
+    AOT_MERGE_ERROR = -1,
+    AOT_MERGE_NO_BASE,
+    AOT_MERGE_READY,
+    AOT_MERGE_DUPLICATE,
+} AOTMergeResult;
+bool do_merge_seg_aot(void);
 void merge_segment_tree_init(void);
 int is_tb_in_aot(char *seg_name, size_t offset, size_t pc_offset);
 
-void aot2_merge(char *curr_lib_name, int first_seg_id,
-		int last_seg_id, CPUState *cpu);
+AOTMergeResult aot2_merge(char *curr_lib_name, int first_seg_id,
+                          int last_seg_id, CPUState *cpu);
 #endif

--- a/target/i386/latx/include/file_ctx.h
+++ b/target/i386/latx/include/file_ctx.h
@@ -19,6 +19,8 @@ int aot_file_get_lock_path(const char *aot_file, char *lock_path,
                            size_t lock_path_size);
 int aot_file_complete_write(FILE *file, const char *tmp_path);
 int aot_file_publish(const char *tmp_path, const char *aot_file);
+int aot_file_unlink_if_same(const char *aot_file, int file_fd,
+                            const char *lock_path);
 int flock_set(int fd, int type, bool wait);
 uint64_t aot_file_rmgroup(char *aotFile);
 int file_lock(const char *file_name, int *fd, int type, bool wait);

--- a/target/i386/latx/include/file_ctx.h
+++ b/target/i386/latx/include/file_ctx.h
@@ -13,9 +13,14 @@
 #define AOT_FILE_CTX_H
 #include "aot.h"
 int aot_file_ctx(uint64_t maxSize, uint64_t leftMinSize);
+int aot_file_get_tmp_path(const char *aot_file, char *tmp_path,
+                          size_t tmp_path_size);
+int aot_file_get_lock_path(const char *aot_file, char *lock_path,
+                           size_t lock_path_size);
+int aot_file_complete_write(FILE *file, const char *tmp_path);
+int aot_file_publish(const char *tmp_path, const char *aot_file);
 int flock_set(int fd, int type, bool wait);
 uint64_t aot_file_rmgroup(char *aotFile);
-int file_lock(char *file_name, int *fd, int type, bool wait);
+int file_lock(const char *file_name, int *fd, int type, bool wait);
 int send_file_message(char *file_d, char *message);
 #endif
-

--- a/target/i386/latx/include/file_ctx.h
+++ b/target/i386/latx/include/file_ctx.h
@@ -18,7 +18,12 @@ int aot_file_get_tmp_path(const char *aot_file, char *tmp_path,
 int aot_file_get_lock_path(const char *aot_file, char *lock_path,
                            size_t lock_path_size);
 int aot_file_complete_write(FILE *file, const char *tmp_path);
+/*
+ * Negative: rename failed. Zero: rename and directory sync succeeded.
+ * Positive errno: rename succeeded, but directory durability is uncertain.
+ */
 int aot_file_publish(const char *tmp_path, const char *aot_file);
+int aot_file_remove_legacy_fragments(const char *aot_file);
 int aot_file_unlink_if_same(const char *aot_file, int file_fd,
                             const char *lock_path);
 int flock_set(int fd, int type, bool wait);

--- a/target/i386/latx/sbt/aot.c
+++ b/target/i386/latx/sbt/aot.c
@@ -1170,13 +1170,15 @@ void dump_aot_buffer(aot_header *p_header)
 
 }
 
-static void remove_curr_aot_file(void)
+static void remove_curr_aot_file(int fd)
 {
-    remove(aot_file_path);
-    strcat(aot_file_path, "A");
-    if (access(aot_file_path, 0) >= 0) {
-        remove(aot_file_path);
+    char lock_path[PATH_MAX];
+
+    if (aot_file_get_lock_path(aot_file_path, lock_path,
+                               sizeof(lock_path)) < 0) {
+        return;
     }
+    aot_file_unlink_if_same(aot_file_path, fd, lock_path);
 }
 
 time_t aot_st_ctime;
@@ -1212,7 +1214,7 @@ lib_info *aot_load(char *lib_name, void **curr_aot_buffer)
     }
     if (!strstr(aot_version, AOT_VERSION)) {
         qemu_log_mask(LAT_LOG_AOT, "aot file is not complete %s\n", lib_name);
-        remove_curr_aot_file();
+        remove_curr_aot_file(fd);
         goto exit_aot_load;
     }
 
@@ -1234,7 +1236,7 @@ lib_info *aot_load(char *lib_name, void **curr_aot_buffer)
                 || p_header->last_modify_time.tv_nsec != statbuf.st_mtim.tv_nsec) {
             qemu_log_mask(LAT_LOG_AOT, "need remove old aot file. %s lib_size %d %ld\n",
                     aot_file_path, p_header->lib_size, statbuf.st_size);
-            remove_curr_aot_file();
+            remove_curr_aot_file(fd);
             goto exit_aot_load;
         }
     }

--- a/target/i386/latx/sbt/aot.c
+++ b/target/i386/latx/sbt/aot.c
@@ -709,7 +709,7 @@ write_error:
     return -1;
 }
 
-bool do_generate_aot(int first_seg_in_lib, int end_seg_in_lib)
+int do_generate_aot(int first_seg_in_lib, int end_seg_in_lib)
 {
     if (tb_num == 0) {
         return false;
@@ -786,7 +786,7 @@ bool do_generate_aot(int first_seg_in_lib, int end_seg_in_lib)
     }
 
     int lockfd = -1;
-    bool success = write_aot_file(&lockfd, p_header, p_insn,
+    int success = write_aot_file(&lockfd, p_header, p_insn,
             insn_buffer, total_code_cache_size,
             p_ir1, ir1_buffer, ir1_size) == 0;
     free(insn_buffer);

--- a/target/i386/latx/sbt/aot.c
+++ b/target/i386/latx/sbt/aot.c
@@ -653,6 +653,9 @@ static int write_aot_file(int *lockfd, aot_header *p_header, uint32_t *p_insn,
         uint8_t *p_ir1, uint8_t *ir1_buffer, int ir1_size)
 {
     char tmp_file_path[PATH_MAX];
+    FILE *pfile;
+    size_t write_size;
+    int fd;
 
     get_aot_path(curr_lib_name, aot_file_path);
     if (aot_file_get_tmp_path(aot_file_path, tmp_file_path,
@@ -662,19 +665,19 @@ static int write_aot_file(int *lockfd, aot_header *p_header, uint32_t *p_insn,
     }
 
     /* Write file metadata infomation(aot_buffer) into aot. */
-    int fd = open(tmp_file_path, O_CREAT | O_EXCL | O_WRONLY, 0644);
+    fd = open(tmp_file_path, O_CREAT | O_EXCL | O_WRONLY, 0644);
     if (fd < 0) {
         qemu_log_mask(LAT_LOG_AOT, "open AOT temporary file failed: %s\n",
                       strerror(errno));
         return -1;
     }
-    FILE *pfile = fdopen(fd, "w");
+    pfile = fdopen(fd, "w");
     if (!pfile) {
         close(fd);
         unlink(tmp_file_path);
         return -1;
     }
-    size_t write_size = (uintptr_t)p_insn - (uintptr_t)p_header;
+    write_size = (uintptr_t)p_insn - (uintptr_t)p_header;
 
     /* FILE *tp = pfile; */
     if (fwrite(p_header, write_size, 1, pfile) != 1) {
@@ -711,6 +714,9 @@ write_error:
 
 int do_generate_aot(int first_seg_in_lib, int end_seg_in_lib)
 {
+    int lockfd = -1;
+    int success;
+
     if (tb_num == 0) {
         return false;
     }
@@ -785,8 +791,7 @@ int do_generate_aot(int first_seg_in_lib, int end_seg_in_lib)
             p_aot_tbs, tb_table_end, &ir1_size);
     }
 
-    int lockfd = -1;
-    int success = write_aot_file(&lockfd, p_header, p_insn,
+    success = write_aot_file(&lockfd, p_header, p_insn,
             insn_buffer, total_code_cache_size,
             p_ir1, ir1_buffer, ir1_size) == 0;
     free(insn_buffer);
@@ -969,6 +974,7 @@ void pre_translate(int begin_id, int end_id, CPUState *cpu,
 static bool rename_aot_file(char *lib_name)
 {
     char tmp_file_path[PATH_MAX];
+    int ret;
 
     get_aot_path(lib_name, aot_file_path);
     if (aot_file_get_tmp_path(aot_file_path, tmp_file_path,
@@ -978,11 +984,16 @@ static bool rename_aot_file(char *lib_name)
     if (access(tmp_file_path, 0) < 0) {
         return false;
     }
-    int ret = aot_file_publish(tmp_file_path, aot_file_path);
+    ret = aot_file_publish(tmp_file_path, aot_file_path);
     if (ret < 0) {
         qemu_log_mask(LAT_LOG_AOT, "publish AOT file failed: %s\n",
                       strerror(-ret));
         return false;
+    }
+    if (ret > 0) {
+        qemu_log_mask(LAT_LOG_AOT,
+                      "AOT file published without directory sync: %s\n",
+                      strerror(ret));
     }
     return true;
 }
@@ -990,11 +1001,13 @@ static bool rename_aot_file(char *lib_name)
 static inline void gen_aot_by_lib(int first_seg_id, int end_seg_id,
 		CPUState *cpu, uint32_t tb_count)
 {
-    curr_lib_name = seg_info_vector[first_seg_id]->file_name;
+    char tmp_file_path[PATH_MAX];
+    AOTMergeResult merge_result;
     int lockfd = -1;
-    if (need_gen_aot(cpu, curr_lib_name, &lockfd, tb_count) >= 0) {
-        char tmp_file_path[PATH_MAX];
 
+    curr_lib_name = seg_info_vector[first_seg_id]->file_name;
+
+    if (need_gen_aot(cpu, curr_lib_name, &lockfd, tb_count) >= 0) {
         get_aot_path(curr_lib_name, aot_file_path);
         if (aot_file_get_tmp_path(aot_file_path, tmp_file_path,
                                   sizeof(tmp_file_path)) < 0) {
@@ -1003,10 +1016,19 @@ static inline void gen_aot_by_lib(int first_seg_id, int end_seg_id,
         if (unlink(tmp_file_path) && errno != ENOENT) {
             goto unlock;
         }
+        if (aot_file_remove_legacy_fragments(aot_file_path) < 0) {
+            goto unlock;
+        }
         pre_translate(first_seg_id, end_seg_id, cpu, NULL);
         if (do_generate_aot(first_seg_id, end_seg_id)) {
-            aot2_merge(curr_lib_name, first_seg_id, end_seg_id, cpu);
-            generated_aot_file |= rename_aot_file(curr_lib_name);
+            merge_result =
+                aot2_merge(curr_lib_name, first_seg_id, end_seg_id, cpu);
+            if (merge_result == AOT_MERGE_NO_BASE ||
+                merge_result == AOT_MERGE_READY) {
+                generated_aot_file |= rename_aot_file(curr_lib_name);
+            } else {
+                unlink(tmp_file_path);
+            }
         }
 unlock:
         flock_set(lockfd, F_UNLCK, true);

--- a/target/i386/latx/sbt/aot.c
+++ b/target/i386/latx/sbt/aot.c
@@ -652,64 +652,67 @@ static int write_aot_file(int *lockfd, aot_header *p_header, uint32_t *p_insn,
         uint32_t *insn_buffer, unsigned long total_code_cache_size,
         uint8_t *p_ir1, uint8_t *ir1_buffer, int ir1_size)
 {
-    char *pathtmp;
+    char tmp_file_path[PATH_MAX];
+
     get_aot_path(curr_lib_name, aot_file_path);
-    pathtmp = aot_file_path;
-    strcat(pathtmp, "A");
-    if (access(pathtmp, 0) >= 0) {
-        qemu_log_mask(LAT_LOG_AOT,
-                      "ERROR: other process generated aot file %s\n", pathtmp);
+    if (aot_file_get_tmp_path(aot_file_path, tmp_file_path,
+                              sizeof(tmp_file_path)) < 0) {
+        qemu_log_mask(LAT_LOG_AOT, "AOT temporary path is too long\n");
         return -1;
     }
 
     /* Write file metadata infomation(aot_buffer) into aot. */
-    int fd = open(pathtmp, O_CREAT | O_WRONLY | O_TRUNC, 0644);
-	assert(fd > 2);
-	if (fd <= 2) {
-	    exit(EXIT_FAILURE);
-	}
+    int fd = open(tmp_file_path, O_CREAT | O_EXCL | O_WRONLY, 0644);
+    if (fd < 0) {
+        qemu_log_mask(LAT_LOG_AOT, "open AOT temporary file failed: %s\n",
+                      strerror(errno));
+        return -1;
+    }
     FILE *pfile = fdopen(fd, "w");
+    if (!pfile) {
+        close(fd);
+        unlink(tmp_file_path);
+        return -1;
+    }
     size_t write_size = (uintptr_t)p_insn - (uintptr_t)p_header;
 
     /* FILE *tp = pfile; */
     if (fwrite(p_header, write_size, 1, pfile) != 1) {
         qemu_log_mask(LAT_LOG_AOT, "Error! write aot metadata failed!\n");
-        fclose(pfile);
-        return -1;
+        goto write_error;
     }
     if (fwrite(insn_buffer, total_code_cache_size, 1, pfile) != 1) {
         qemu_log_mask(LAT_LOG_AOT, "Error! write aot translated code failed!\n");
-        fclose(pfile);
-        return -1;
+        goto write_error;
     }
     if (ir1_buffer && fwrite(ir1_buffer, ir1_size, 1, pfile) != 1) {
         qemu_log_mask(LAT_LOG_AOT, "Error! write aot ir1 code failed!\n");
-        fclose(pfile);
-        return -1;
+        goto write_error;
     }
     if (fwrite(AOT_VERSION, strlen(AOT_VERSION), 1, pfile) != 1) {
         qemu_log_mask(LAT_LOG_AOT, "Error! write aot AOT_VERSION failed!\n");
-        fclose(pfile);
-        return -1;
+        goto write_error;
     }
     if (option_debug_aot) {
         qemu_log_mask(LAT_LOG_AOT, "!!!! name %s size %ld curr_tb_num %d pid %d!!!\n",
-                pathtmp, get_fileSize(pfile), curr_lib_tb_num, getpid());
+                tmp_file_path, get_fileSize(pfile), curr_lib_tb_num, getpid());
     }
-    if (fclose(pfile) != 0) {
-        qemu_log_mask(LAT_LOG_AOT, "Error! close aot file failed\n");
+    if (aot_file_complete_write(pfile, tmp_file_path) < 0) {
+        qemu_log_mask(LAT_LOG_AOT, "Error! sync aot file failed\n");
         return -1;
     }
-
-    generated_aot_file = true;
-
     return 0;
+
+write_error:
+    fclose(pfile);
+    unlink(tmp_file_path);
+    return -1;
 }
 
-void do_generate_aot(int first_seg_in_lib, int end_seg_in_lib) 
+bool do_generate_aot(int first_seg_in_lib, int end_seg_in_lib)
 {
     if (tb_num == 0) {
-        return;
+        return false;
     }
     TaskState *ts = (TaskState *)thread_cpu->opaque;
     sigset_t oldmask, mask;
@@ -724,7 +727,7 @@ void do_generate_aot(int first_seg_in_lib, int end_seg_in_lib)
         qemu_log_mask(LAT_LOG_AOT,
             "skip aot generation for %s due to buffer preparation failure\n",
             curr_lib_name);
-        return;
+        return false;
     }
 
     p_header->aot_file_type = get_file_type(curr_lib_name);
@@ -733,14 +736,16 @@ void do_generate_aot(int first_seg_in_lib, int end_seg_in_lib)
         struct stat statbuf;
         if (stat(curr_lib_name, &statbuf)) {
             qemu_log_mask(LAT_LOG_AOT, "ERROR stat %s failed\n", curr_lib_name);
-            return;
+            free(p_header);
+            return false;
         }
         for (int i = first_seg_in_lib; i < end_seg_in_lib; i++) {
             seg_info *seg = seg_info_vector[i];
             if (seg->lib_size != statbuf.st_size ||
                     seg->tv_sec != statbuf.st_mtim.tv_sec) {
                 fprintf(stderr, "error, orignal lib changed %s\n", curr_lib_name);
-                return;
+                free(p_header);
+                return false;
             }
         }
         p_header->lib_size = statbuf.st_size;
@@ -760,7 +765,8 @@ void do_generate_aot(int first_seg_in_lib, int end_seg_in_lib)
         fill_tb_table(p_aot_tbs, p_header, p_segments);
     uintptr_t tb_table_end = table_end_addr;
     if(total_code_cache_size == 0) {
-        return;
+        free(p_header);
+        return false;
     }
     /* fill relocation table */
     fill_rel_table(p_header);
@@ -780,12 +786,13 @@ void do_generate_aot(int first_seg_in_lib, int end_seg_in_lib)
     }
 
     int lockfd = -1;
-    write_aot_file(&lockfd, p_header, p_insn, 
+    bool success = write_aot_file(&lockfd, p_header, p_insn,
             insn_buffer, total_code_cache_size,
-            p_ir1, ir1_buffer, ir1_size);
+            p_ir1, ir1_buffer, ir1_size) == 0;
     free(insn_buffer);
     free(ir1_buffer);
     free(p_header);
+    return success;
 }
 
 static const char lib_black_list[][PATH_MAX] =
@@ -904,9 +911,10 @@ static inline int need_gen_aot(CPUState *cpu,
         return -1;
     }
     get_aot_path(curr_lib_name, aot_file_path);
-    strcpy(aot_file_lock, aot_file_path);
-    strcat(aot_file_lock, ".lock");
-    assert(aot_file_lock);
+    if (aot_file_get_lock_path(aot_file_path, aot_file_lock,
+                               PATH_MAX) < 0) {
+        return -1;
+    }
     
     if (file_lock(aot_file_lock, lockfd, F_WRLCK, false) < 0) {
         return -1;
@@ -943,8 +951,11 @@ void pre_translate(int begin_id, int end_id, CPUState *cpu,
 
     get_aot_path(curr_lib_name, aot_file_path);
     if (access(aot_file_path, 0) >= 0) {
-        strcat(aot_file_path, "A");
-        if (access(aot_file_path, 0) >= 0) {
+        char tmp_file_path[PATH_MAX];
+
+        if (aot_file_get_tmp_path(aot_file_path, tmp_file_path,
+                                  sizeof(tmp_file_path)) < 0 ||
+            access(tmp_file_path, 0) >= 0) {
             tb_num = 0;
             return;
         }
@@ -955,16 +966,25 @@ void pre_translate(int begin_id, int end_id, CPUState *cpu,
     tb_vector = ts_vector;
 }
 
-static void rename_aot_file(char *lib_name)
+static bool rename_aot_file(char *lib_name)
 {
     char tmp_file_path[PATH_MAX];
+
     get_aot_path(lib_name, aot_file_path);
-    strcpy(tmp_file_path, aot_file_path);
-    strcat(tmp_file_path, "A");
-    if (access(tmp_file_path, 0) < 0) {
-        return;
+    if (aot_file_get_tmp_path(aot_file_path, tmp_file_path,
+                              sizeof(tmp_file_path)) < 0) {
+        return false;
     }
-    rename(tmp_file_path, aot_file_path);
+    if (access(tmp_file_path, 0) < 0) {
+        return false;
+    }
+    int ret = aot_file_publish(tmp_file_path, aot_file_path);
+    if (ret < 0) {
+        qemu_log_mask(LAT_LOG_AOT, "publish AOT file failed: %s\n",
+                      strerror(-ret));
+        return false;
+    }
+    return true;
 }
 
 static inline void gen_aot_by_lib(int first_seg_id, int end_seg_id,
@@ -973,10 +993,22 @@ static inline void gen_aot_by_lib(int first_seg_id, int end_seg_id,
     curr_lib_name = seg_info_vector[first_seg_id]->file_name;
     int lockfd = -1;
     if (need_gen_aot(cpu, curr_lib_name, &lockfd, tb_count) >= 0) {
+        char tmp_file_path[PATH_MAX];
+
+        get_aot_path(curr_lib_name, aot_file_path);
+        if (aot_file_get_tmp_path(aot_file_path, tmp_file_path,
+                                  sizeof(tmp_file_path)) < 0) {
+            goto unlock;
+        }
+        if (unlink(tmp_file_path) && errno != ENOENT) {
+            goto unlock;
+        }
         pre_translate(first_seg_id, end_seg_id, cpu, NULL);
-        do_generate_aot(first_seg_id, end_seg_id);
-        aot2_merge(curr_lib_name, first_seg_id, end_seg_id, cpu);
-        rename_aot_file(curr_lib_name);
+        if (do_generate_aot(first_seg_id, end_seg_id)) {
+            aot2_merge(curr_lib_name, first_seg_id, end_seg_id, cpu);
+            generated_aot_file |= rename_aot_file(curr_lib_name);
+        }
+unlock:
         flock_set(lockfd, F_UNLCK, true);
         close(lockfd);
     }

--- a/target/i386/latx/sbt/aot.c
+++ b/target/i386/latx/sbt/aot.c
@@ -655,13 +655,11 @@ static int write_aot_file(int *lockfd, aot_header *p_header, uint32_t *p_insn,
     char *pathtmp;
     get_aot_path(curr_lib_name, aot_file_path);
     pathtmp = aot_file_path;
+    strcat(pathtmp, "A");
     if (access(pathtmp, 0) >= 0) {
-        strcat(pathtmp, "A");
-        if (access(pathtmp, 0) >= 0) {
-            qemu_log_mask(LAT_LOG_AOT, "ERROR: other process generated aot file %s\n",
-                pathtmp);
-            return -1;
-        }
+        qemu_log_mask(LAT_LOG_AOT,
+                      "ERROR: other process generated aot file %s\n", pathtmp);
+        return -1;
     }
 
     /* Write file metadata infomation(aot_buffer) into aot. */
@@ -957,17 +955,30 @@ void pre_translate(int begin_id, int end_id, CPUState *cpu,
     tb_vector = ts_vector;
 }
 
+static void rename_aot_file(char *lib_name)
+{
+    char tmp_file_path[PATH_MAX];
+    get_aot_path(lib_name, aot_file_path);
+    strcpy(tmp_file_path, aot_file_path);
+    strcat(tmp_file_path, "A");
+    if (access(tmp_file_path, 0) < 0) {
+        return;
+    }
+    rename(tmp_file_path, aot_file_path);
+}
+
 static inline void gen_aot_by_lib(int first_seg_id, int end_seg_id,
 		CPUState *cpu, uint32_t tb_count)
 {
     curr_lib_name = seg_info_vector[first_seg_id]->file_name;
     int lockfd = -1;
     if (need_gen_aot(cpu, curr_lib_name, &lockfd, tb_count) >= 0) {
-    	pre_translate(first_seg_id, end_seg_id, cpu, NULL);
+        pre_translate(first_seg_id, end_seg_id, cpu, NULL);
         do_generate_aot(first_seg_id, end_seg_id);
         aot2_merge(curr_lib_name, first_seg_id, end_seg_id, cpu);
-    	flock_set(lockfd, F_UNLCK, true);
-    	close(lockfd);
+        rename_aot_file(curr_lib_name);
+        flock_set(lockfd, F_UNLCK, true);
+        close(lockfd);
     }
 }
 
@@ -1146,13 +1157,6 @@ lib_info *aot_load(char *lib_name, void **curr_aot_buffer)
     if (access(aot_file_path, 0) < 0) {
         return NULL;
     }
-    int lockfd = -1;
-    strcpy(aot_file_lock, aot_file_path);
-    strcat(aot_file_lock, ".lock");
-    if (file_lock(aot_file_lock, &lockfd, F_RDLCK, false) < 0) {
-        close(lockfd);
-        return NULL;
-    }
 
     /* Open aot_file. */
     void *buffer;
@@ -1212,8 +1216,6 @@ exit_aot_load:
         fclose(pf);
     }
     close(fd);
-    flock_set(lockfd, F_UNLCK, true);
-    close(lockfd);
     return curr_lib_info;
 }
 

--- a/target/i386/latx/sbt/aot_merge.c
+++ b/target/i386/latx/sbt/aot_merge.c
@@ -930,17 +930,14 @@ static void aot2_merge_tu(char *curr_lib_name, int first_seg_id,
     }
 #endif
 
-    char tmp_file_path[PATH_MAX]; 
-    strcpy(tmp_file_path, aot_file_path);
-    strcat(tmp_file_path, "A");
-    remove(tmp_file_path);
+    strcat(aot_file_path, "A");
+    remove(aot_file_path);
     /* The second and first AOT files are duplicated. */
     if (curr_tb_num <= tb_num1) {
     	assert(curr_tb_num >= tb_num1);
     	free(tb_message_vector);
     	return;
     }
-    remove(aot_file_path);
     pre_translate(first_seg_id, last_seg_id, cpu, tb_message_vector);
     do_generate_aot(first_seg_id, last_seg_id);
     free(tb_message_vector);

--- a/target/i386/latx/sbt/aot_merge.c
+++ b/target/i386/latx/sbt/aot_merge.c
@@ -417,8 +417,15 @@ static void fill_page_table(struct aot_segment *curr_seg, aot_header *p_header,
 	}
 }
 
-static void merge_aot_generate(void)
+static bool merge_aot_generate(void)
 {
+    char tmp_file_path[PATH_MAX];
+    FILE *pfile;
+    uint32_t *insn_buffer = NULL;
+    size_t write_size;
+    bool success = false;
+    int fd;
+
     /*
      * Prepare all TBs which will be handled later.
      * 1. Calculate TBs number.
@@ -440,7 +447,7 @@ static void merge_aot_generate(void)
     struct stat statbuf;
     if (stat(merge_seg_info_vector[0]->file_name, &statbuf)) {
         qemu_log_mask(LAT_LOG_AOT, "ERROT stat %s failed\n", merge_seg_info_vector[0]->file_name);
-        return;
+        goto out;
     }
     p_header->lib_size = statbuf.st_size;
     p_header->last_modify_time = statbuf.st_mtim;
@@ -540,7 +547,7 @@ static void merge_aot_generate(void)
     p_header->rel_entry_num = merge_rel_entry_num;
     uint32_t *p_insn =
         (uint32_t *)ROUND_UP((uintptr_t)(p_aot_rel + merge_rel_entry_num), 8);
-    uint32_t *insn_buffer = (uint32_t *)malloc(total_code_cache_size);
+    insn_buffer = (uint32_t *)malloc(total_code_cache_size);
     assert(insn_buffer && "insn_buffer malloc failed!");
 
     uint64_t two_buffer_off = (void *)insn_buffer - (void *)p_insn;
@@ -559,7 +566,6 @@ static void merge_aot_generate(void)
     }
     /* Write file metadata infomation(aot_buffer) into aot. */
 
-    char tmp_file_path[PATH_MAX];
     if (aot_file_get_tmp_path(aot_file_path, tmp_file_path,
                               sizeof(tmp_file_path)) < 0) {
         goto out;
@@ -567,18 +573,18 @@ static void merge_aot_generate(void)
     if (unlink(tmp_file_path) && errno != ENOENT) {
         goto out;
     }
-    int fd = open(tmp_file_path, O_CREAT | O_EXCL | O_WRONLY, 0644);
+    fd = open(tmp_file_path, O_CREAT | O_EXCL | O_WRONLY, 0644);
     if (fd < 0) {
         goto out;
     }
-    FILE *pfile = fdopen(fd, "w");
+    pfile = fdopen(fd, "w");
     if (pfile == NULL) {
         close(fd);
         unlink(tmp_file_path);
         qemu_log_mask(LAT_LOG_AOT, "Error! write aot metadata failed!\n");
         goto out;
     }
-    size_t write_size = (uintptr_t)p_insn - (uintptr_t)p_header;
+    write_size = (uintptr_t)p_insn - (uintptr_t)p_header;
     if (fwrite(p_header, write_size, 1, pfile) != 1) {
         qemu_log_mask(LAT_LOG_AOT, "Error! write aot metadata failed!\n");
         goto write_error;
@@ -595,6 +601,7 @@ static void merge_aot_generate(void)
         qemu_log_mask(LAT_LOG_AOT, "Error! sync aot file failed\n");
         goto out;
     }
+    success = true;
     goto out;
 
 write_error:
@@ -604,14 +611,15 @@ out:
     free(p_header);
     free(insn_buffer);
     free(merge_seg_info_vector);
-    return;
+    return success;
 }
 
-void do_merge_seg_aot(void)
+bool do_merge_seg_aot(void)
 {
     struct stat statbuf;
     TaskState *ts = (TaskState *)thread_cpu->opaque;
     sigset_t oldmask, mask;
+    bool success = false;
     sigfillset(&mask);
     sigdelset(&mask, SIGSEGV);
     sigprocmask(SIG_BLOCK, &mask, &oldmask);
@@ -665,14 +673,23 @@ void do_merge_seg_aot(void)
                 aot_buffer_all[buf_index].p);
         }
     }
-    merge_aot_generate();
+    success = merge_aot_generate();
 out:
     sigprocmask(SIG_SETMASK, &oldmask, NULL);
     qatomic_xchg(&ts->signal_pending, 0);
+    return success;
 }
 
 static int aot_load_no_lock(char *lib_name)
 {
+    void *buffer;
+    struct stat statbuf;
+    int count = 2;
+    int j = 0;
+    char aot_version[sizeof(AOT_VERSION)];
+    char tmp_file_path[PATH_MAX];
+    char path[PATH_MAX];
+
     aot_buffer_all_num = 0;
     if (lib_name == NULL) {
         return -1;
@@ -681,14 +698,6 @@ static int aot_load_no_lock(char *lib_name)
     if (access(aot_file_path, 0) < 0) {
         return -1;
     }
-    void *buffer;
-    struct stat statbuf;
-    int count = 2;
-    size_t total_file_sz = 0;
-    char aot_version[strlen(AOT_VERSION) + 1];
-    char tmp_file_path[PATH_MAX];
-    char path[PATH_MAX];
-
     if (lstat(aot_file_path, &statbuf)) {
         aot_buffer_all_num = 0;
         return -1;
@@ -697,70 +706,85 @@ static int aot_load_no_lock(char *lib_name)
                               sizeof(tmp_file_path)) < 0) {
         return -1;
     }
-    aot_buffer_all = calloc(count, sizeof(*aot_buffer_all));
-    if (!aot_buffer_all) {
-        return -1;
-    }
+    aot_buffer_all = g_new0(aot_file_info, count);
     aot_buffer_all_num = count;
     aot_st_ctime = statbuf.st_ctime;
-    int j = 0;
     for (int i = 0; i < count; i++) {
+        FILE *pf;
+        long file_end;
+        size_t file_sz;
+        int fd;
+
         pstrcpy(path, sizeof(path), i ? tmp_file_path : aot_file_path);
-        int fd = open(path, O_RDONLY);
+        fd = open(path, O_RDONLY);
         if (fd < 0) {
-            continue;
+            goto load_error;
         }
-        FILE *pf = fdopen(fd, "r");
+        pf = fdopen(fd, "r");
         if (!pf) {
             close(fd);
-            continue;
+            goto load_error;
         }
         /* Get file size */
-        fseek(pf, 0, SEEK_END);      /* seek to end of file */
-        size_t file_sz = ftell(pf);  /* get current file pointer */
+        if (fseek(pf, 0, SEEK_END)) {
+            fclose(pf);
+            goto load_error;
+        }
+        file_end = ftell(pf);
+        if (file_end < 0) {
+            fclose(pf);
+            goto load_error;
+        }
+        file_sz = file_end;
         /*check aot complete.*/
         if (fseek(pf, -strlen(AOT_VERSION), SEEK_END) != 0) {
-            aot_buffer_all_num--;
             fclose(pf);
-            continue;
+            goto load_error;
         }
+        memset(aot_version, 0, sizeof(aot_version));
         if (fread(aot_version, strlen(AOT_VERSION), 1, pf) != 1) {
-            aot_buffer_all_num--;
             fclose(pf);
-            continue;
+            goto load_error;
         }
-        if (!strstr(aot_version, AOT_VERSION)) {
+        if (memcmp(aot_version, AOT_VERSION, strlen(AOT_VERSION))) {
             fclose(pf);
-            unlink(path);
-            aot_buffer_all_num = j;
-            return 0;
+            goto load_error;
         }
 
-        fseek(pf, 0, SEEK_SET);      /* seek back to beginning of file */
+        if (fseek(pf, 0, SEEK_SET)) {
+            fclose(pf);
+            goto load_error;
+        }
 
         /* Read aot file */
         buffer = malloc(file_sz);
         assert(buffer);
-        aot_buffer_all[j].maplen = file_sz;
         if ((int)(intptr_t)buffer == -1) {
-            aot_buffer_all_num--;
             fclose(pf);
-            continue;
+            goto load_error;
         }
         if (fread(buffer, file_sz, 1, pf) != 1) {
             qemu_log_mask(LAT_LOG_AOT, "fread error %s.\n", strerror(errno));
-            aot_buffer_all_num--;
+            free(buffer);
             fclose(pf);
-            continue;
+            goto load_error;
         }
         fclose(pf);
         aot_buffer_all[j].p = buffer;
+        aot_buffer_all[j].maplen = file_sz;
         j++;
-        /* align with 8 bytes. */
-        total_file_sz += file_sz;
     }
     aot_buffer_all_num = j;
-    return total_file_sz;
+    return 0;
+
+load_error:
+    for (int i = 0; i < j; i++) {
+        free(aot_buffer_all[i].p);
+    }
+    g_free(aot_buffer_all);
+    aot_buffer_all = NULL;
+    aot_buffer_all_num = 0;
+    return -1;
 }
 
 #ifdef CONFIG_LATX_TU
@@ -887,9 +911,11 @@ static void get_seg_tb(int first_seg_id, int last_seg_id)
     }
 }
 
-static void aot2_merge_tu(char *curr_lib_name, int first_seg_id,
-		int last_seg_id, CPUState *cpu)
+static AOTMergeResult aot2_merge_tu(char *curr_lib_name, int first_seg_id,
+                                    int last_seg_id, CPUState *cpu)
 {
+    char tmp_file_path[PATH_MAX];
+    bool generated;
     void *buffer1 = aot_buffer_all[0].p;
     void *buffer2 = aot_buffer_all[1].p;
     assert(buffer1);
@@ -903,7 +929,7 @@ static void aot2_merge_tu(char *curr_lib_name, int first_seg_id,
     int seg_num1 = p_header1->segments_num;
     int seg_num2 = p_header2->segments_num;
     if (seg_num1 > 1200000) {
-    	return;
+        return AOT_MERGE_ERROR;
     }
     int tb_num1 = get_tb_num(p_segment1, seg_num1);
     int tb_num2 = get_tb_num(p_segment2, seg_num2);
@@ -957,42 +983,53 @@ static void aot2_merge_tu(char *curr_lib_name, int first_seg_id,
     }
 #endif
 
-    char tmp_file_path[PATH_MAX];
     if (aot_file_get_tmp_path(aot_file_path, tmp_file_path,
                               sizeof(tmp_file_path)) < 0) {
         free(tb_message_vector);
-        return;
+        return AOT_MERGE_ERROR;
     }
-    unlink(tmp_file_path);
+    if (unlink(tmp_file_path) && errno != ENOENT) {
+        free(tb_message_vector);
+        return AOT_MERGE_ERROR;
+    }
     /* The second and first AOT files are duplicated. */
     if (curr_tb_num <= tb_num1) {
     	assert(curr_tb_num >= tb_num1);
     	free(tb_message_vector);
-    	return;
+        return AOT_MERGE_DUPLICATE;
     }
     pre_translate(first_seg_id, last_seg_id, cpu, tb_message_vector);
-    do_generate_aot(first_seg_id, last_seg_id);
+    generated = do_generate_aot(first_seg_id, last_seg_id);
     free(tb_message_vector);
+    return generated ? AOT_MERGE_READY : AOT_MERGE_ERROR;
 }
 #endif
 
 #include<sys/syscall.h>
-void aot2_merge(char *curr_lib_name, int first_seg_id, 
-		int last_seg_id, CPUState *cpu)
+AOTMergeResult aot2_merge(char *curr_lib_name, int first_seg_id,
+                          int last_seg_id, CPUState *cpu)
 {
+    AOTMergeResult result;
+
     get_aot_path(curr_lib_name, aot_file_path);
-    aot_load_no_lock(curr_lib_name);
+    if (access(aot_file_path, F_OK) < 0) {
+        return errno == ENOENT ? AOT_MERGE_NO_BASE : AOT_MERGE_ERROR;
+    }
+    if (aot_load_no_lock(curr_lib_name) < 0) {
+        return AOT_MERGE_ERROR;
+    }
     if (aot_buffer_all_num < 2) {
-        return;
+        return AOT_MERGE_ERROR;
     }
 #ifdef CONFIG_LATX_TU
-	aot2_merge_tu(curr_lib_name, first_seg_id, last_seg_id, cpu);
+    result = aot2_merge_tu(curr_lib_name, first_seg_id, last_seg_id, cpu);
 #else
     g_tree_destroy(merge_segment_tree);
     merge_segment_tree_init();
     merge_rel_entry_num = 0;
-    do_merge_seg_aot();
+    result = do_merge_seg_aot() ? AOT_MERGE_READY : AOT_MERGE_ERROR;
 #endif
     aot_buffer_all_num = 0;
+    return result;
 }
 #endif

--- a/target/i386/latx/sbt/aot_merge.c
+++ b/target/i386/latx/sbt/aot_merge.c
@@ -680,10 +680,17 @@ out:
     return success;
 }
 
-static int aot_load_no_lock(char *lib_name)
+typedef enum AOTLoadResult {
+    AOT_LOAD_ERROR = -1,
+    AOT_LOAD_OK,
+    AOT_LOAD_INVALID_BASE,
+} AOTLoadResult;
+
+static AOTLoadResult aot_load_no_lock(char *lib_name)
 {
     void *buffer;
     struct stat statbuf;
+    AOTLoadResult result;
     int count = 2;
     int j = 0;
     char aot_version[sizeof(AOT_VERSION)];
@@ -735,6 +742,13 @@ static int aot_load_no_lock(char *lib_name)
             fclose(pf);
             goto load_error;
         }
+        if ((size_t)file_end < strlen(AOT_VERSION)) {
+            fclose(pf);
+            if (i == 0) {
+                goto invalid_base;
+            }
+            goto load_error;
+        }
         file_sz = file_end;
         /*check aot complete.*/
         if (fseek(pf, -strlen(AOT_VERSION), SEEK_END) != 0) {
@@ -748,6 +762,9 @@ static int aot_load_no_lock(char *lib_name)
         }
         if (memcmp(aot_version, AOT_VERSION, strlen(AOT_VERSION))) {
             fclose(pf);
+            if (i == 0) {
+                goto invalid_base;
+            }
             goto load_error;
         }
 
@@ -775,16 +792,21 @@ static int aot_load_no_lock(char *lib_name)
         j++;
     }
     aot_buffer_all_num = j;
-    return 0;
+    return AOT_LOAD_OK;
 
+invalid_base:
+    result = AOT_LOAD_INVALID_BASE;
+    goto release_buffers;
 load_error:
+    result = AOT_LOAD_ERROR;
+release_buffers:
     for (int i = 0; i < j; i++) {
         free(aot_buffer_all[i].p);
     }
     g_free(aot_buffer_all);
     aot_buffer_all = NULL;
     aot_buffer_all_num = 0;
-    return -1;
+    return result;
 }
 
 #ifdef CONFIG_LATX_TU
@@ -1010,12 +1032,20 @@ AOTMergeResult aot2_merge(char *curr_lib_name, int first_seg_id,
                           int last_seg_id, CPUState *cpu)
 {
     AOTMergeResult result;
+    AOTLoadResult load_result;
 
     get_aot_path(curr_lib_name, aot_file_path);
     if (access(aot_file_path, F_OK) < 0) {
         return errno == ENOENT ? AOT_MERGE_NO_BASE : AOT_MERGE_ERROR;
     }
-    if (aot_load_no_lock(curr_lib_name) < 0) {
+    load_result = aot_load_no_lock(curr_lib_name);
+    if (load_result == AOT_LOAD_INVALID_BASE) {
+        if (unlink(aot_file_path) && errno != ENOENT) {
+            return AOT_MERGE_ERROR;
+        }
+        return AOT_MERGE_NO_BASE;
+    }
+    if (load_result == AOT_LOAD_ERROR) {
         return AOT_MERGE_ERROR;
     }
     if (aot_buffer_all_num < 2) {

--- a/target/i386/latx/sbt/aot_merge.c
+++ b/target/i386/latx/sbt/aot_merge.c
@@ -559,33 +559,47 @@ static void merge_aot_generate(void)
     }
     /* Write file metadata infomation(aot_buffer) into aot. */
 
-    aot_file_rmgroup(aot_file_path);
-    int fd = open(aot_file_path, O_CREAT | O_WRONLY | O_TRUNC, 0644);
+    char tmp_file_path[PATH_MAX];
+    if (aot_file_get_tmp_path(aot_file_path, tmp_file_path,
+                              sizeof(tmp_file_path)) < 0) {
+        goto out;
+    }
+    if (unlink(tmp_file_path) && errno != ENOENT) {
+        goto out;
+    }
+    int fd = open(tmp_file_path, O_CREAT | O_EXCL | O_WRONLY, 0644);
+    if (fd < 0) {
+        goto out;
+    }
     FILE *pfile = fdopen(fd, "w");
     if (pfile == NULL) {
+        close(fd);
+        unlink(tmp_file_path);
         qemu_log_mask(LAT_LOG_AOT, "Error! write aot metadata failed!\n");
         goto out;
     }
     size_t write_size = (uintptr_t)p_insn - (uintptr_t)p_header;
     if (fwrite(p_header, write_size, 1, pfile) != 1) {
         qemu_log_mask(LAT_LOG_AOT, "Error! write aot metadata failed!\n");
-        fclose(pfile);
-        goto out;
+        goto write_error;
     }
     if (fwrite(insn_buffer, total_code_cache_size, 1, pfile) != 1) {
         qemu_log_mask(LAT_LOG_AOT, "Error! write aot translated code failed!\n");
-        fclose(pfile);
-        goto out;
+        goto write_error;
     }
     if (fwrite(AOT_VERSION, strlen(AOT_VERSION), 1, pfile) != 1) {
         qemu_log_mask(LAT_LOG_AOT, "Error! write aot AOT_VERSION failed!\n");
-        fclose(pfile);
+        goto write_error;
+    }
+    if (aot_file_complete_write(pfile, tmp_file_path) < 0) {
+        qemu_log_mask(LAT_LOG_AOT, "Error! sync aot file failed\n");
         goto out;
     }
-    if (fclose(pfile) != 0) {
-        qemu_log_mask(LAT_LOG_AOT, "Error! close aot file failed\n");
-        goto out;
-    }
+    goto out;
+
+write_error:
+    fclose(pfile);
+    unlink(tmp_file_path);
 out:
     free(p_header);
     free(insn_buffer);

--- a/target/i386/latx/sbt/aot_merge.c
+++ b/target/i386/latx/sbt/aot_merge.c
@@ -669,23 +669,38 @@ static int aot_load_no_lock(char *lib_name)
     }
     void *buffer;
     struct stat statbuf;
-    int count = aot_get_file_init(aot_file_path);
+    int count = 2;
     size_t total_file_sz = 0;
     char aot_version[strlen(AOT_VERSION) + 1];
-    lsassert(count > 0);
     char tmp_file_path[PATH_MAX];
+    char path[PATH_MAX];
+
     if (lstat(aot_file_path, &statbuf)) {
         aot_buffer_all_num = 0;
         return -1;
     }
+    if (aot_file_get_tmp_path(aot_file_path, tmp_file_path,
+                              sizeof(tmp_file_path)) < 0) {
+        return -1;
+    }
+    aot_buffer_all = calloc(count, sizeof(*aot_buffer_all));
+    if (!aot_buffer_all) {
+        return -1;
+    }
+    aot_buffer_all_num = count;
     aot_st_ctime = statbuf.st_ctime;
     int j = 0;
     for (int i = 0; i < count; i++) {
-        memset(tmp_file_path, 0, PATH_MAX);
-        aot_get_file_name(aot_file_path, tmp_file_path, i);
-        int fd = open(tmp_file_path, O_RDONLY);
+        pstrcpy(path, sizeof(path), i ? tmp_file_path : aot_file_path);
+        int fd = open(path, O_RDONLY);
+        if (fd < 0) {
+            continue;
+        }
         FILE *pf = fdopen(fd, "r");
-        lsassert(pf && ("open aot file failed!"));
+        if (!pf) {
+            close(fd);
+            continue;
+        }
         /* Get file size */
         fseek(pf, 0, SEEK_END);      /* seek to end of file */
         size_t file_sz = ftell(pf);  /* get current file pointer */
@@ -702,10 +717,7 @@ static int aot_load_no_lock(char *lib_name)
         }
         if (!strstr(aot_version, AOT_VERSION)) {
             fclose(pf);
-            for (int ii = i; ii < count; ii++) {
-                aot_get_file_name(aot_file_path, tmp_file_path, ii);
-                remove(tmp_file_path);
-            }
+            unlink(path);
             aot_buffer_all_num = j;
             return 0;
         }
@@ -733,6 +745,7 @@ static int aot_load_no_lock(char *lib_name)
         /* align with 8 bytes. */
         total_file_sz += file_sz;
     }
+    aot_buffer_all_num = j;
     return total_file_sz;
 }
 
@@ -930,8 +943,13 @@ static void aot2_merge_tu(char *curr_lib_name, int first_seg_id,
     }
 #endif
 
-    strcat(aot_file_path, "A");
-    remove(aot_file_path);
+    char tmp_file_path[PATH_MAX];
+    if (aot_file_get_tmp_path(aot_file_path, tmp_file_path,
+                              sizeof(tmp_file_path)) < 0) {
+        free(tb_message_vector);
+        return;
+    }
+    unlink(tmp_file_path);
     /* The second and first AOT files are duplicated. */
     if (curr_tb_num <= tb_num1) {
     	assert(curr_tb_num >= tb_num1);

--- a/target/i386/latx/sbt/file_ctx.c
+++ b/target/i386/latx/sbt/file_ctx.c
@@ -27,6 +27,72 @@ struct aot_info {
     time_t st_actime;
 };
 
+int aot_file_get_tmp_path(const char *aot_file, char *tmp_path,
+                          size_t tmp_path_size)
+{
+    int len = snprintf(tmp_path, tmp_path_size, "%s.tmp", aot_file);
+
+    if (len < 0 || (size_t)len >= tmp_path_size) {
+        return -ENAMETOOLONG;
+    }
+    return 0;
+}
+
+int aot_file_get_lock_path(const char *aot_file, char *lock_path,
+                           size_t lock_path_size)
+{
+    int len = snprintf(lock_path, lock_path_size, "%s.lock", aot_file);
+
+    if (len < 0 || (size_t)len >= lock_path_size) {
+        return -ENAMETOOLONG;
+    }
+    return 0;
+}
+
+int aot_file_complete_write(FILE *file, const char *tmp_path)
+{
+    int saved_errno = 0;
+    int fd = fileno(file);
+
+    if (fflush(file) || fsync(fd)) {
+        saved_errno = errno;
+    }
+    if (fclose(file) && !saved_errno) {
+        saved_errno = errno;
+    }
+    if (saved_errno) {
+        unlink(tmp_path);
+        return -saved_errno;
+    }
+    return 0;
+}
+
+int aot_file_publish(const char *tmp_path, const char *aot_file)
+{
+    int saved_errno = 0;
+
+    if (rename(tmp_path, aot_file)) {
+        saved_errno = errno;
+        unlink(tmp_path);
+        return -saved_errno;
+    }
+
+    char *dir_name = g_path_get_dirname(aot_file);
+    int dir_fd = open(dir_name, O_RDONLY | O_DIRECTORY);
+
+    g_free(dir_name);
+    if (dir_fd < 0) {
+        return -errno;
+    }
+    if (fsync(dir_fd)) {
+        saved_errno = errno;
+    }
+    if (close(dir_fd) && !saved_errno) {
+        saved_errno = errno;
+    }
+    return -saved_errno;
+}
+
 int flock_set(int fd, int type, bool wait)
 {
     struct flock fflock = {0};
@@ -74,7 +140,7 @@ int send_file_message(char *file_d, char *message)
     fclose(pfile);
     return 0;
 }
-int file_lock(char *file_name, int *fd, int type, bool wait)
+int file_lock(const char *file_name, int *fd, int type, bool wait)
 {
     int mask = O_RDONLY;
 
@@ -94,6 +160,7 @@ int file_lock(char *file_name, int *fd, int type, bool wait)
     }
     return flock_set(*fd, type, wait);
 }
+
 static int aot_file_cmp(const void *a, const void *b)
 {
     struct aot_info * pa = *(struct aot_info **)a;

--- a/target/i386/latx/sbt/file_ctx.c
+++ b/target/i386/latx/sbt/file_ctx.c
@@ -161,6 +161,33 @@ int file_lock(const char *file_name, int *fd, int type, bool wait)
     return flock_set(*fd, type, wait);
 }
 
+int aot_file_unlink_if_same(const char *aot_file, int file_fd,
+                            const char *lock_path)
+{
+    struct stat opened;
+    struct stat current;
+    int lock_fd = -1;
+    int ret = 0;
+
+    if (file_lock(lock_path, &lock_fd, F_WRLCK, true) < 0) {
+        ret = -errno;
+        if (lock_fd >= 0) {
+            close(lock_fd);
+        }
+        return ret;
+    }
+    if (fstat(file_fd, &opened) || lstat(aot_file, &current)) {
+        ret = -errno;
+    } else if (opened.st_dev == current.st_dev &&
+               opened.st_ino == current.st_ino &&
+               unlink(aot_file)) {
+        ret = -errno;
+    }
+    flock_set(lock_fd, F_UNLCK, true);
+    close(lock_fd);
+    return ret;
+}
+
 static int aot_file_cmp(const void *a, const void *b)
 {
     struct aot_info * pa = *(struct aot_info **)a;

--- a/target/i386/latx/sbt/file_ctx.c
+++ b/target/i386/latx/sbt/file_ctx.c
@@ -69,6 +69,8 @@ int aot_file_complete_write(FILE *file, const char *tmp_path)
 
 int aot_file_publish(const char *tmp_path, const char *aot_file)
 {
+    char *dir_name;
+    int dir_fd;
     int saved_errno = 0;
 
     if (rename(tmp_path, aot_file)) {
@@ -77,20 +79,41 @@ int aot_file_publish(const char *tmp_path, const char *aot_file)
         return -saved_errno;
     }
 
-    char *dir_name = g_path_get_dirname(aot_file);
-    int dir_fd = open(dir_name, O_RDONLY | O_DIRECTORY);
+    dir_name = g_path_get_dirname(aot_file);
+    dir_fd = open(dir_name, O_RDONLY | O_DIRECTORY);
 
-    g_free(dir_name);
     if (dir_fd < 0) {
-        return -errno;
+        saved_errno = errno;
+        g_free(dir_name);
+        return saved_errno;
     }
+    g_free(dir_name);
     if (fsync(dir_fd)) {
         saved_errno = errno;
     }
     if (close(dir_fd) && !saved_errno) {
         saved_errno = errno;
     }
-    return -saved_errno;
+    return saved_errno;
+}
+
+int aot_file_remove_legacy_fragments(const char *aot_file)
+{
+    char legacy_path[PATH_MAX];
+    int len;
+
+    len = snprintf(legacy_path, sizeof(legacy_path), "%sA", aot_file);
+    if (len < 0 || (size_t)len >= sizeof(legacy_path)) {
+        return -ENAMETOOLONG;
+    }
+
+    for (int i = 0; i < 99; i++) {
+        legacy_path[len - 1] = 'A' + i;
+        if (unlink(legacy_path) && errno != ENOENT) {
+            return -errno;
+        }
+    }
+    return 0;
 }
 
 int flock_set(int fd, int type, bool wait)
@@ -235,6 +258,11 @@ static bool is_aot_file(char *file_name)
     return ends_with(file_name, "aot2") || ends_with(file_name, ".aot2");
 }
 
+static bool is_aot_tmp(char *file_name)
+{
+    return ends_with(file_name, ".aot2.tmp");
+}
+
 static bool is_aot_lock(char *file_name)
 {
     return ends_with(file_name, ".lock");
@@ -248,16 +276,54 @@ static void aot_file_release_oldfile(struct aot_info **f_info,
     assert(needRelaeseMB);
     int fd = -1;
     for (int i = 0; i < count; i++) {
+        if (is_aot_tmp(f_info[i]->d_name)) {
+            char final_path[PATH_MAX];
+            struct stat statbuf;
+            size_t final_len = strlen(f_info[i]->d_name) - strlen(".tmp");
+
+            pstrcpy(final_path, sizeof(final_path), f_info[i]->d_name);
+            final_path[final_len] = '\0';
+            if (aot_file_get_lock_path(final_path, aot_file_lock,
+                                       PATH_MAX) < 0) {
+                continue;
+            }
+            if (file_lock(aot_file_lock, &fd, F_WRLCK, false) < 0) {
+                if (fd >= 0) {
+                    close(fd);
+                    fd = -1;
+                }
+                continue;
+            }
+            if (!stat(f_info[i]->d_name, &statbuf) &&
+                !unlink(f_info[i]->d_name)) {
+                hasReleaseSize += statbuf.st_size / (1024 * 1024);
+            }
+            flock_set(fd, F_UNLCK, true);
+            close(fd);
+            fd = -1;
+            if (hasReleaseSize >= needRelaeseMB) {
+                break;
+            }
+            continue;
+        }
         if (is_aot_lock(f_info[i]->d_name)) {
+            char tmp_path[PATH_MAX];
+            int l;
+
             strcpy(aot_file_path, f_info[i]->d_name);
-            int l = strlen(aot_file_path);
+            l = strlen(aot_file_path);
             for (int j = l - 1; j > 0; j--) {
                 if (aot_file_path[j] == '.') {
                    aot_file_path[j] = '\0';
                    break;
                 }
             }
-            if(access(aot_file_path, R_OK) < 0) {
+            if (aot_file_get_tmp_path(aot_file_path, tmp_path,
+                                      sizeof(tmp_path)) < 0) {
+                continue;
+            }
+            if (access(aot_file_path, R_OK) < 0 &&
+                access(tmp_path, F_OK) < 0) {
                 if (file_lock(f_info[i]->d_name, &fd, F_WRLCK, false) >= 0) {
                     remove(f_info[i]->d_name);
                 }
@@ -307,11 +373,13 @@ int aot_file_ctx(uint64_t maxSize, uint64_t leftMinSize)
         snprintf(subdir, PATH_MAX, "%s%s", aot_dir, p_dirent->d_name);
         if (stat(subdir, &statbuf)) {
             qemu_log_mask(LAT_LOG_AOT, "(%s:%d)lstat error\n", __FILE__, __LINE__);
-	    qemu_log_mask(LAT_LOG_AOT, "lstat %s \n", subdir);
-	    qemu_log_mask(LAT_LOG_AOT, "lstat %d \n", errno);
+            qemu_log_mask(LAT_LOG_AOT, "lstat %s\n", subdir);
+            qemu_log_mask(LAT_LOG_AOT, "lstat %d\n", errno);
             continue;
         }
-        if (!is_aot_file(p_dirent->d_name) && !is_aot_lock(p_dirent->d_name)) {
+        if (!is_aot_file(p_dirent->d_name) &&
+            !is_aot_tmp(p_dirent->d_name) &&
+            !is_aot_lock(p_dirent->d_name)) {
             continue;
         }
         aot_total_size += statbuf.st_size;

--- a/target/i386/latx/sbt/tests/aot-file-publish-test.c
+++ b/target/i386/latx/sbt/tests/aot-file-publish-test.c
@@ -37,7 +37,10 @@ int main(void)
     char tmp_path[PATH_MAX];
     g_autofree char *test_dir = NULL;
     g_autofree char *aot_path = NULL;
+    char lock_path[PATH_MAX];
     FILE *file;
+    int old_fd;
+    int current_fd;
 
     g_assert(aot_file_get_tmp_path("/tmp/cache.aot2", tmp_path,
                                    sizeof(tmp_path)) == 0);
@@ -78,7 +81,22 @@ int main(void)
     assert_file_contents(aot_path, "old");
     g_assert(!g_file_test(tmp_path, G_FILE_TEST_EXISTS));
 
-    g_assert(unlink(aot_path) == 0);
+    g_assert(aot_file_get_lock_path(aot_path, lock_path,
+                                    sizeof(lock_path)) == 0);
+    old_fd = open(aot_path, O_RDONLY);
+    g_assert(old_fd >= 0);
+    g_assert(g_file_set_contents(tmp_path, "new", -1, NULL));
+    g_assert(rename(tmp_path, aot_path) == 0);
+    g_assert(aot_file_unlink_if_same(aot_path, old_fd, lock_path) == 0);
+    assert_file_contents(aot_path, "new");
+    g_assert(close(old_fd) == 0);
+
+    current_fd = open(aot_path, O_RDONLY);
+    g_assert(current_fd >= 0);
+    g_assert(aot_file_unlink_if_same(aot_path, current_fd, lock_path) == 0);
+    g_assert(!g_file_test(aot_path, G_FILE_TEST_EXISTS));
+    g_assert(close(current_fd) == 0);
+    g_assert(unlink(lock_path) == 0);
     g_assert(rmdir(test_dir) == 0);
     return 0;
 }

--- a/target/i386/latx/sbt/tests/aot-file-publish-test.c
+++ b/target/i386/latx/sbt/tests/aot-file-publish-test.c
@@ -9,6 +9,32 @@ char aot_file_path_buffer[PATH_MAX];
 char aot_file_lock_buffer[PATH_MAX];
 char *aot_file_path = aot_file_path_buffer;
 char *aot_file_lock = aot_file_lock_buffer;
+int qemu_loglevel;
+
+int qemu_log(const char *fmt, ...)
+{
+    return 0;
+}
+
+void pstrcpy(char *buf, int buf_size, const char *str)
+{
+    g_strlcpy(buf, str, buf_size);
+}
+
+int aot_get_file_name(char *aot_file, char *buf, int index)
+{
+    int len;
+
+    if (index == 0) {
+        pstrcpy(buf, PATH_MAX, aot_file);
+        return access(buf, F_OK) < 0 ? -1 : 0;
+    }
+    len = snprintf(buf, PATH_MAX, "%s%c", aot_file, 'A' + index - 1);
+    if (len < 0 || len >= PATH_MAX || access(buf, F_OK) < 0) {
+        return -1;
+    }
+    return 0;
+}
 
 int __wrap_fsync(int fd)
 {
@@ -45,6 +71,7 @@ int main(void)
     g_autofree char *legacy_b_path = NULL;
     g_autofree char *cache_dir = NULL;
     g_autofree char *cache_parent = NULL;
+    g_autofree char *stale_lock_path = NULL;
     g_autofree char *stale_tmp_path = NULL;
     g_autofree char *stale_contents = NULL;
     g_autofree char *old_home = NULL;
@@ -138,6 +165,8 @@ int main(void)
     g_assert(g_setenv("HOME", test_dir, true));
     g_assert(aot_file_ctx(2, 1) == 0);
     g_assert(!g_file_test(stale_tmp_path, G_FILE_TEST_EXISTS));
+    stale_lock_path = g_build_filename(cache_dir, "stale.aot2.lock", NULL);
+    g_assert(unlink(stale_lock_path) == 0);
     if (old_home) {
         g_assert(g_setenv("HOME", old_home, true));
     } else {

--- a/target/i386/latx/sbt/tests/aot-file-publish-test.c
+++ b/target/i386/latx/sbt/tests/aot-file-publish-test.c
@@ -1,0 +1,84 @@
+#include "qemu/osdep.h"
+
+#include "file_ctx.h"
+#include "aot-file-publish-test.h"
+
+static bool fail_rename;
+static bool fail_fsync;
+
+int __wrap_fsync(int fd)
+{
+    if (fail_fsync) {
+        errno = EIO;
+        return -1;
+    }
+    return __real_fsync(fd);
+}
+
+int __wrap_rename(const char *old_path, const char *new_path)
+{
+    if (fail_rename) {
+        errno = EIO;
+        return -1;
+    }
+    return __real_rename(old_path, new_path);
+}
+
+static void assert_file_contents(const char *path, const char *expected)
+{
+    g_autofree char *contents = NULL;
+
+    g_assert(g_file_get_contents(path, &contents, NULL, NULL));
+    g_assert(strcmp(contents, expected) == 0);
+}
+
+int main(void)
+{
+    char tmp_path[PATH_MAX];
+    g_autofree char *test_dir = NULL;
+    g_autofree char *aot_path = NULL;
+    FILE *file;
+
+    g_assert(aot_file_get_tmp_path("/tmp/cache.aot2", tmp_path,
+                                   sizeof(tmp_path)) == 0);
+    g_assert(strcmp(tmp_path, "/tmp/cache.aot2.tmp") == 0);
+
+    test_dir = g_dir_make_tmp("latx-aot-publish-XXXXXX", NULL);
+    g_assert(test_dir != NULL);
+    aot_path = g_build_filename(test_dir, "cache.aot2", NULL);
+    g_assert(aot_file_get_tmp_path(aot_path, tmp_path,
+                                   sizeof(tmp_path)) == 0);
+
+    g_assert(g_file_set_contents(aot_path, "old", -1, NULL));
+    file = fopen(tmp_path, "w");
+    g_assert(file != NULL);
+    g_assert(fputs("new", file) >= 0);
+    g_assert(aot_file_complete_write(file, tmp_path) == 0);
+    g_assert(aot_file_publish(tmp_path, aot_path) == 0);
+    assert_file_contents(aot_path, "new");
+    g_assert(!g_file_test(tmp_path, G_FILE_TEST_EXISTS));
+
+    g_assert(g_file_set_contents(aot_path, "old", -1, NULL));
+    file = fopen(tmp_path, "w");
+    g_assert(file != NULL);
+    g_assert(fputs("new", file) >= 0);
+    g_assert(aot_file_complete_write(file, tmp_path) == 0);
+    fail_rename = true;
+    g_assert(aot_file_publish(tmp_path, aot_path) == -EIO);
+    fail_rename = false;
+    assert_file_contents(aot_path, "old");
+    g_assert(!g_file_test(tmp_path, G_FILE_TEST_EXISTS));
+
+    file = fopen(tmp_path, "w");
+    g_assert(file != NULL);
+    g_assert(fputs("new", file) >= 0);
+    fail_fsync = true;
+    g_assert(aot_file_complete_write(file, tmp_path) == -EIO);
+    fail_fsync = false;
+    assert_file_contents(aot_path, "old");
+    g_assert(!g_file_test(tmp_path, G_FILE_TEST_EXISTS));
+
+    g_assert(unlink(aot_path) == 0);
+    g_assert(rmdir(test_dir) == 0);
+    return 0;
+}

--- a/target/i386/latx/sbt/tests/aot-file-publish-test.c
+++ b/target/i386/latx/sbt/tests/aot-file-publish-test.c
@@ -5,6 +5,10 @@
 
 static bool fail_rename;
 static bool fail_fsync;
+char aot_file_path_buffer[PATH_MAX];
+char aot_file_lock_buffer[PATH_MAX];
+char *aot_file_path = aot_file_path_buffer;
+char *aot_file_lock = aot_file_lock_buffer;
 
 int __wrap_fsync(int fd)
 {
@@ -37,6 +41,13 @@ int main(void)
     char tmp_path[PATH_MAX];
     g_autofree char *test_dir = NULL;
     g_autofree char *aot_path = NULL;
+    g_autofree char *legacy_a_path = NULL;
+    g_autofree char *legacy_b_path = NULL;
+    g_autofree char *cache_dir = NULL;
+    g_autofree char *cache_parent = NULL;
+    g_autofree char *stale_tmp_path = NULL;
+    g_autofree char *stale_contents = NULL;
+    g_autofree char *old_home = NULL;
     char lock_path[PATH_MAX];
     FILE *file;
     int old_fd;
@@ -81,6 +92,25 @@ int main(void)
     assert_file_contents(aot_path, "old");
     g_assert(!g_file_test(tmp_path, G_FILE_TEST_EXISTS));
 
+    file = fopen(tmp_path, "w");
+    g_assert(file != NULL);
+    g_assert(fputs("new", file) >= 0);
+    g_assert(aot_file_complete_write(file, tmp_path) == 0);
+    fail_fsync = true;
+    g_assert(aot_file_publish(tmp_path, aot_path) == EIO);
+    fail_fsync = false;
+    assert_file_contents(aot_path, "new");
+    g_assert(!g_file_test(tmp_path, G_FILE_TEST_EXISTS));
+
+    legacy_a_path = g_strconcat(aot_path, "A", NULL);
+    legacy_b_path = g_strconcat(aot_path, "B", NULL);
+    g_assert(g_file_set_contents(legacy_a_path, "legacy-a", -1, NULL));
+    g_assert(g_file_set_contents(legacy_b_path, "legacy-b", -1, NULL));
+    g_assert(aot_file_remove_legacy_fragments(aot_path) == 0);
+    g_assert(!g_file_test(legacy_a_path, G_FILE_TEST_EXISTS));
+    g_assert(!g_file_test(legacy_b_path, G_FILE_TEST_EXISTS));
+    assert_file_contents(aot_path, "new");
+
     g_assert(aot_file_get_lock_path(aot_path, lock_path,
                                     sizeof(lock_path)) == 0);
     old_fd = open(aot_path, O_RDONLY);
@@ -97,6 +127,25 @@ int main(void)
     g_assert(!g_file_test(aot_path, G_FILE_TEST_EXISTS));
     g_assert(close(current_fd) == 0);
     g_assert(unlink(lock_path) == 0);
+
+    old_home = g_strdup(g_getenv("HOME"));
+    cache_dir = g_build_filename(test_dir, ".cache", "latx", NULL);
+    g_assert(g_mkdir_with_parents(cache_dir, 0700) == 0);
+    stale_tmp_path = g_build_filename(cache_dir, "stale.aot2.tmp", NULL);
+    stale_contents = g_malloc0(2 * MiB);
+    g_assert(g_file_set_contents(stale_tmp_path, stale_contents, 2 * MiB,
+                                 NULL));
+    g_assert(g_setenv("HOME", test_dir, true));
+    g_assert(aot_file_ctx(2, 1) == 0);
+    g_assert(!g_file_test(stale_tmp_path, G_FILE_TEST_EXISTS));
+    if (old_home) {
+        g_assert(g_setenv("HOME", old_home, true));
+    } else {
+        g_unsetenv("HOME");
+    }
+    g_assert(g_rmdir(cache_dir) == 0);
+    cache_parent = g_build_filename(test_dir, ".cache", NULL);
+    g_assert(g_rmdir(cache_parent) == 0);
     g_assert(rmdir(test_dir) == 0);
     return 0;
 }

--- a/target/i386/latx/sbt/tests/aot-file-publish-test.h
+++ b/target/i386/latx/sbt/tests/aot-file-publish-test.h
@@ -1,0 +1,7 @@
+#ifndef LATX_AOT_FILE_PUBLISH_TEST_H
+#define LATX_AOT_FILE_PUBLISH_TEST_H
+
+int __real_fsync(int fd);
+int __real_rename(const char *old_path, const char *new_path);
+
+#endif

--- a/target/i386/latx/sbt/tests/aot-file-publish-test.h
+++ b/target/i386/latx/sbt/tests/aot-file-publish-test.h
@@ -3,5 +3,7 @@
 
 int __real_fsync(int fd);
 int __real_rename(const char *old_path, const char *new_path);
+int __wrap_fsync(int fd);
+int __wrap_rename(const char *old_path, const char *new_path);
 
 #endif


### PR DESCRIPTION
## Summary

- Publish generated and merged AOT caches through an exclusive `.tmp` file, file sync, atomic rename, and parent-directory sync.
- Keep lock-free readers from deleting a concurrently replaced cache by comparing the opened inode under the writer lock.
- Preserve the current cache on temporary-file, read, validation, or merge failures; replace only deterministically invalid base files.
- Remove deprecated A/B fragments under the writer lock and include stale `.tmp` files in cache-capacity reclamation.
- Build the focused publication regression test only when tests are explicitly enabled.

## Root cause

The lock-free reader change in #300 did not propagate write and merge failures through the publication path. Fixed-name temporary files also overlapped the legacy A/B cache-group convention, reader invalidation acted on a pathname that could already name a new inode, and the non-TU merge path still truncated the final file in place.

This draft supersedes #300 with the original change plus the publication, recovery, and concurrency fixes.

## Validation

Validated on LoongArch host `l1` at `bdb6a3044dba8883c9cf5129817c9c6f7a0caf65`:

- Deterministic RED before the recovery helpers were present, followed by GREEN for `test-latx-aot-file-publish`.
- Failure injection covers file-sync and rename failures, post-rename directory-sync failure, legacy A/B cleanup, stale `.tmp` reclamation, and inode-safe invalidation.
- AOT-enabled non-TU configuration: `file_ctx.c`, `aot.c`, and `aot_merge.c` objects compile successfully.
- Explicit test configuration: complete `latx-x86_64` build succeeds; 5/5 tests pass.
- Default product configuration: complete `latx-x86_64` build succeeds; Meson reports 0 test targets.
- `git diff --check` passes. Per-commit checkpatch has no errors; the only warning is the generic MAINTAINERS prompt for the new test file, already covered by the existing `target/i386/` maintenance scope.