### PR TITLE
revert: remove SMC reload TB locking

### DIFF
--- a/target/i386/latx/sbt/aot_smc_reload.c
+++ b/target/i386/latx/sbt/aot_smc_reload.c
@@ -52,7 +52,7 @@ int smc_page_reload(target_ulong page_addr, uint32_t cflags)
         tb = reload_node->tb_vector[tb_id];
         if (!memcmp(g2h_untagged(tb->pc),
                     reload_node->ir1_code_buffer + ir1_offset, tb->size)) {
-            qemu_spin_lock(&tb->jmp_lock);
+            tb->cflags &= ~CF_INVALID;
             if (!use_tu_jmp(tb)) {
                 if (tb->jmp_reset_offset[0] !=
                     TB_JMP_RESET_OFFSET_INVALID) {
@@ -68,8 +68,6 @@ int smc_page_reload(target_ulong page_addr, uint32_t cflags)
             tb->jmp_list_next[1] = 0;
             tb->jmp_dest[0] = 0;
             tb->jmp_dest[1] = 0;
-            qatomic_and(&tb->cflags, ~CF_INVALID);
-            qemu_spin_unlock(&tb->jmp_lock);
             aot_tb_register(tb);
         }
         ir1_offset += tb->size;

--- a/target/i386/latx/sbt/tests/smc-reload-guest-base-test.c
+++ b/target/i386/latx/sbt/tests/smc-reload-guest-base-test.c
@@ -30,7 +30,6 @@ int __wrap_mprotect(void *addr, size_t len G_GNUC_UNUSED, int prot)
 
 bool use_tu_jmp(TranslationBlock *tb)
 {
-    g_assert(qemu_spin_locked(&tb->jmp_lock));
     return tb->bool_flags & IS_TU_JMP;
 }
 
@@ -57,8 +56,6 @@ void tb_target_set_nop(uintptr_t tc_ptr G_GNUC_UNUSED,
 void aot_tb_register(TranslationBlock *tb)
 {
     assert(tb != NULL);
-    g_assert(!qemu_spin_locked(&tb->jmp_lock));
-    g_assert(!(tb->cflags & CF_INVALID));
     aot_register_count++;
 }
 
@@ -99,7 +96,6 @@ int main(void)
     tb.pc = guest_page;
     tb.size = code_size;
     tb.bool_flags = IS_TU_JMP;
-    tb.cflags = CF_INVALID;
     qemu_spin_init(&tb.jmp_lock);
 
     reload->tb_count = 1;

--- a/target/i386/latx/sbt/tests/smc-reload-tu-test.c
+++ b/target/i386/latx/sbt/tests/smc-reload-tu-test.c
@@ -19,7 +19,6 @@ bool have_guest_base;
 
 bool use_tu_jmp(TranslationBlock *tb)
 {
-    g_assert(qemu_spin_locked(&tb->jmp_lock));
     return tb->bool_flags & IS_TU_JMP;
 }
 
@@ -46,8 +45,6 @@ void tb_target_set_nop(uintptr_t tc_ptr G_GNUC_UNUSED,
 void aot_tb_register(TranslationBlock *tb)
 {
     assert(tb != NULL);
-    g_assert(!qemu_spin_locked(&tb->jmp_lock));
-    g_assert(!(tb->cflags & CF_INVALID));
     aot_register_count++;
 }
 
@@ -85,8 +82,6 @@ int main(void)
     tb.pc = (uintptr_t)guest_code;
     tb.size = sizeof(guest_code);
     tb.bool_flags = IS_TU_JMP;
-    tb.cflags = CF_INVALID;
-    qemu_spin_init(&tb.jmp_lock);
     tb.tu_jmp[TU_TB_INDEX_NEXT] = 4;
     tb.tu_jmp[TU_TB_INDEX_TARGET] = TB_JMP_RESET_OFFSET_INVALID;
 
@@ -103,7 +98,6 @@ int main(void)
     g_assert(aot_register_count == 1);
     g_assert(tb.tu_jmp[TU_TB_INDEX_NEXT] == 4);
     g_assert(smc_reload_tree_get_node_count() == 0);
-
     tb.cflags = CF_INVALID;
     reload = g_new0(SMCReloadInfo, 1);
     reload->tb_count = 1;
@@ -119,6 +113,5 @@ int main(void)
     g_assert(aot_register_count == 2);
     g_assert(tb.tu_jmp[TU_TB_INDEX_NEXT] == 4);
     g_assert(smc_reload_tree_get_node_count() == 0);
-    qemu_spin_destroy(&tb.jmp_lock);
     return 0;
 }


### PR DESCRIPTION
Revert af055e1204. SMC reload runs after the invalidated TB has been removed from lookup structures under mmap_lock, so the added jmp_lock does not provide needed synchronization.

Tests:
- meson test -C build64 --no-rebuild --print-errorlogs latx-smc-reload-tu latx-smc-reload-guest-base