### PR TITLE
LATX, fix: Support CEF sandbox isolation

### DIFF
--- a/include/qemu/rcu.h
+++ b/include/qemu/rcu.h
@@ -123,6 +123,12 @@ extern void rcu_unregister_thread(void);
  */
 extern void rcu_enable_atfork(void);
 extern void rcu_disable_atfork(void);
+extern void rcu_defer_atfork_child(void);
+extern void rcu_cancel_atfork_child_defer(void);
+extern void rcu_start_deferred_thread(void);
+extern void rcu_raw_clone_prepare(void);
+extern void rcu_raw_clone_parent(void);
+extern void rcu_raw_clone_child(void);
 
 struct rcu_head;
 typedef void RCUCBFunc(struct rcu_head *head);

--- a/linux-user/guest-seccomp.c
+++ b/linux-user/guest-seccomp.c
@@ -1,0 +1,473 @@
+#include "qemu/osdep.h"
+#include "cpu.h"
+#include "qemu.h"
+#include "guest-seccomp.h"
+#include "signal-common.h"
+
+#include <linux/audit.h>
+#include <linux/filter.h>
+#include <linux/seccomp.h>
+#include <sys/prctl.h>
+
+#ifndef SECCOMP_RET_USER_NOTIF
+#define SECCOMP_RET_USER_NOTIF 0x7fc00000U
+#endif
+
+typedef struct GuestSeccompData {
+    int32_t nr;
+    uint32_t arch;
+    uint64_t instruction_pointer;
+    uint64_t args[6];
+} GuestSeccompData;
+
+typedef struct GuestSeccompFilter {
+    struct GuestSeccompFilter *previous;
+    unsigned int len;
+    struct sock_filter insns[];
+} GuestSeccompFilter;
+
+static bool seccomp_jump_valid(unsigned int pc, uint32_t offset,
+                               unsigned int len)
+{
+    return offset < len && pc < len - offset - 1;
+}
+
+static bool seccomp_filter_valid(const struct sock_filter *insns,
+                                 unsigned int len)
+{
+    unsigned int i;
+
+    if (len == 0 || len > BPF_MAXINSNS ||
+        BPF_CLASS(insns[len - 1].code) != BPF_RET) {
+        return false;
+    }
+
+    for (i = 0; i < len; i++) {
+        const struct sock_filter *insn = &insns[i];
+
+        switch (insn->code) {
+        case BPF_LD | BPF_W | BPF_ABS:
+            if ((insn->k & 3) ||
+                insn->k > sizeof(GuestSeccompData) - sizeof(uint32_t)) {
+                return false;
+            }
+            break;
+        case BPF_LD | BPF_W | BPF_IMM:
+        case BPF_LDX | BPF_W | BPF_IMM:
+            break;
+        case BPF_LD | BPF_W | BPF_MEM:
+        case BPF_LDX | BPF_W | BPF_MEM:
+        case BPF_ST:
+        case BPF_STX:
+            if (insn->k >= BPF_MEMWORDS) {
+                return false;
+            }
+            break;
+        case BPF_ALU | BPF_ADD | BPF_K:
+        case BPF_ALU | BPF_ADD | BPF_X:
+        case BPF_ALU | BPF_SUB | BPF_K:
+        case BPF_ALU | BPF_SUB | BPF_X:
+        case BPF_ALU | BPF_MUL | BPF_K:
+        case BPF_ALU | BPF_MUL | BPF_X:
+        case BPF_ALU | BPF_DIV | BPF_X:
+        case BPF_ALU | BPF_OR | BPF_K:
+        case BPF_ALU | BPF_OR | BPF_X:
+        case BPF_ALU | BPF_AND | BPF_K:
+        case BPF_ALU | BPF_AND | BPF_X:
+        case BPF_ALU | BPF_LSH | BPF_K:
+        case BPF_ALU | BPF_LSH | BPF_X:
+        case BPF_ALU | BPF_RSH | BPF_K:
+        case BPF_ALU | BPF_RSH | BPF_X:
+        case BPF_ALU | BPF_MOD | BPF_X:
+        case BPF_ALU | BPF_XOR | BPF_K:
+        case BPF_ALU | BPF_XOR | BPF_X:
+        case BPF_ALU | BPF_NEG:
+            break;
+        case BPF_ALU | BPF_DIV | BPF_K:
+        case BPF_ALU | BPF_MOD | BPF_K:
+            if (insn->k == 0) {
+                return false;
+            }
+            break;
+        case BPF_JMP | BPF_JA:
+            if (!seccomp_jump_valid(i, insn->k, len)) {
+                return false;
+            }
+            break;
+        case BPF_JMP | BPF_JEQ | BPF_K:
+        case BPF_JMP | BPF_JEQ | BPF_X:
+        case BPF_JMP | BPF_JGT | BPF_K:
+        case BPF_JMP | BPF_JGT | BPF_X:
+        case BPF_JMP | BPF_JGE | BPF_K:
+        case BPF_JMP | BPF_JGE | BPF_X:
+        case BPF_JMP | BPF_JSET | BPF_K:
+        case BPF_JMP | BPF_JSET | BPF_X:
+            if (!seccomp_jump_valid(i, insn->jt, len) ||
+                !seccomp_jump_valid(i, insn->jf, len)) {
+                return false;
+            }
+            break;
+        case BPF_RET | BPF_K:
+        case BPF_RET | BPF_A:
+        case BPF_MISC | BPF_TAX:
+        case BPF_MISC | BPF_TXA:
+            break;
+        default:
+            return false;
+        }
+    }
+    return true;
+}
+
+static uint32_t seccomp_run_filter(const GuestSeccompFilter *filter,
+                                   const GuestSeccompData *data)
+{
+    uint32_t accumulator = 0;
+    uint32_t index = 0;
+    uint32_t memory[BPF_MEMWORDS] = { 0 };
+    unsigned int pc = 0;
+
+    while (pc < filter->len) {
+        const struct sock_filter *insn = &filter->insns[pc++];
+        uint32_t operand = BPF_SRC(insn->code) == BPF_X ? index : insn->k;
+        bool condition;
+
+        switch (insn->code) {
+        case BPF_LD | BPF_W | BPF_ABS:
+            memcpy(&accumulator, (const uint8_t *)data + insn->k,
+                   sizeof(accumulator));
+            break;
+        case BPF_LD | BPF_W | BPF_IMM:
+            accumulator = insn->k;
+            break;
+        case BPF_LDX | BPF_W | BPF_IMM:
+            index = insn->k;
+            break;
+        case BPF_LD | BPF_W | BPF_MEM:
+            accumulator = memory[insn->k];
+            break;
+        case BPF_LDX | BPF_W | BPF_MEM:
+            index = memory[insn->k];
+            break;
+        case BPF_ST:
+            memory[insn->k] = accumulator;
+            break;
+        case BPF_STX:
+            memory[insn->k] = index;
+            break;
+        case BPF_ALU | BPF_ADD | BPF_K:
+        case BPF_ALU | BPF_ADD | BPF_X:
+            accumulator += operand;
+            break;
+        case BPF_ALU | BPF_SUB | BPF_K:
+        case BPF_ALU | BPF_SUB | BPF_X:
+            accumulator -= operand;
+            break;
+        case BPF_ALU | BPF_MUL | BPF_K:
+        case BPF_ALU | BPF_MUL | BPF_X:
+            accumulator *= operand;
+            break;
+        case BPF_ALU | BPF_DIV | BPF_K:
+        case BPF_ALU | BPF_DIV | BPF_X:
+            if (operand == 0) {
+                return SECCOMP_RET_KILL_THREAD;
+            }
+            accumulator /= operand;
+            break;
+        case BPF_ALU | BPF_OR | BPF_K:
+        case BPF_ALU | BPF_OR | BPF_X:
+            accumulator |= operand;
+            break;
+        case BPF_ALU | BPF_AND | BPF_K:
+        case BPF_ALU | BPF_AND | BPF_X:
+            accumulator &= operand;
+            break;
+        case BPF_ALU | BPF_LSH | BPF_K:
+        case BPF_ALU | BPF_LSH | BPF_X:
+            accumulator = operand < 32 ? accumulator << operand : 0;
+            break;
+        case BPF_ALU | BPF_RSH | BPF_K:
+        case BPF_ALU | BPF_RSH | BPF_X:
+            accumulator = operand < 32 ? accumulator >> operand : 0;
+            break;
+        case BPF_ALU | BPF_NEG:
+            accumulator = -accumulator;
+            break;
+        case BPF_ALU | BPF_MOD | BPF_K:
+        case BPF_ALU | BPF_MOD | BPF_X:
+            if (operand == 0) {
+                return SECCOMP_RET_KILL_THREAD;
+            }
+            accumulator %= operand;
+            break;
+        case BPF_ALU | BPF_XOR | BPF_K:
+        case BPF_ALU | BPF_XOR | BPF_X:
+            accumulator ^= operand;
+            break;
+        case BPF_JMP | BPF_JA:
+            pc += insn->k;
+            break;
+        case BPF_JMP | BPF_JEQ | BPF_K:
+        case BPF_JMP | BPF_JEQ | BPF_X:
+            condition = accumulator == operand;
+            pc += condition ? insn->jt : insn->jf;
+            break;
+        case BPF_JMP | BPF_JGT | BPF_K:
+        case BPF_JMP | BPF_JGT | BPF_X:
+            condition = accumulator > operand;
+            pc += condition ? insn->jt : insn->jf;
+            break;
+        case BPF_JMP | BPF_JGE | BPF_K:
+        case BPF_JMP | BPF_JGE | BPF_X:
+            condition = accumulator >= operand;
+            pc += condition ? insn->jt : insn->jf;
+            break;
+        case BPF_JMP | BPF_JSET | BPF_K:
+        case BPF_JMP | BPF_JSET | BPF_X:
+            condition = (accumulator & operand) != 0;
+            pc += condition ? insn->jt : insn->jf;
+            break;
+        case BPF_RET | BPF_K:
+            return insn->k;
+        case BPF_RET | BPF_A:
+            return accumulator;
+        case BPF_MISC | BPF_TAX:
+            index = accumulator;
+            break;
+        case BPF_MISC | BPF_TXA:
+            accumulator = index;
+            break;
+        default:
+            g_assert_not_reached();
+        }
+    }
+    return SECCOMP_RET_KILL_THREAD;
+}
+
+static abi_long seccomp_load_filter(abi_ulong program,
+                                    GuestSeccompFilter **result)
+{
+    struct target_sock_fprog *target_program;
+    struct target_sock_filter *target_insns;
+    GuestSeccompFilter *filter;
+    abi_ulong target_filter;
+    unsigned int len;
+    unsigned int i;
+
+    if (!program) {
+        return -TARGET_EFAULT;
+    }
+    if (!lock_user_struct(VERIFY_READ, target_program, program, 1)) {
+        return -TARGET_EFAULT;
+    }
+    len = tswap16(target_program->len);
+    target_filter = tswapal(target_program->filter);
+    unlock_user_struct(target_program, program, 0);
+
+    if (len == 0 || len > BPF_MAXINSNS) {
+        return -TARGET_EINVAL;
+    }
+    target_insns = lock_user(VERIFY_READ, target_filter,
+                             len * sizeof(*target_insns), 1);
+    if (!target_insns) {
+        return -TARGET_EFAULT;
+    }
+
+    filter = g_malloc(sizeof(*filter) + len * sizeof(filter->insns[0]));
+    filter->previous = NULL;
+    filter->len = len;
+    for (i = 0; i < len; i++) {
+        filter->insns[i].code = tswap16(target_insns[i].code);
+        filter->insns[i].jt = target_insns[i].jt;
+        filter->insns[i].jf = target_insns[i].jf;
+        filter->insns[i].k = tswap32(target_insns[i].k);
+    }
+    unlock_user(target_insns, target_filter, 0);
+
+    if (!seccomp_filter_valid(filter->insns, filter->len)) {
+        g_free(filter);
+        return -TARGET_EINVAL;
+    }
+    *result = filter;
+    return 0;
+}
+
+static abi_long seccomp_install_filter(CPUArchState *env, abi_ulong flags,
+                                       abi_ulong program)
+{
+    const abi_ulong supported_flags = SECCOMP_FILTER_FLAG_TSYNC |
+                                      SECCOMP_FILTER_FLAG_LOG |
+                                      SECCOMP_FILTER_FLAG_SPEC_ALLOW;
+    CPUState *cpu = env_cpu(env);
+    TaskState *task = cpu->opaque;
+    GuestSeccompFilter *filter;
+    abi_long ret;
+
+    if (flags & ~supported_flags) {
+        return -TARGET_EINVAL;
+    }
+    if (prctl(PR_GET_NO_NEW_PRIVS, 0, 0, 0, 0) != 1) {
+        return -TARGET_EACCES;
+    }
+    ret = seccomp_load_filter(program, &filter);
+    if (ret) {
+        return ret;
+    }
+    filter->previous = task->seccomp_filter;
+
+    if (flags & SECCOMP_FILTER_FLAG_TSYNC) {
+        CPUState *other_cpu;
+
+        start_exclusive();
+        cpu_list_lock();
+        CPU_FOREACH(other_cpu) {
+            TaskState *other_task = other_cpu->opaque;
+
+            if (other_task->seccomp_filter != task->seccomp_filter) {
+                ret = other_task->ts_tid;
+                break;
+            }
+        }
+        if (ret == 0) {
+            CPU_FOREACH(other_cpu) {
+                TaskState *other_task = other_cpu->opaque;
+
+                other_task->seccomp_filter = filter;
+            }
+        }
+        cpu_list_unlock();
+        end_exclusive();
+        if (ret != 0) {
+            g_free(filter);
+        }
+        return ret;
+    }
+
+    task->seccomp_filter = filter;
+    return 0;
+}
+
+abi_long guest_seccomp_prctl(CPUArchState *env, abi_long option,
+                             abi_long mode, abi_ulong program)
+{
+    TaskState *task = env_cpu(env)->opaque;
+
+    if (option == PR_GET_SECCOMP) {
+        return task->seccomp_filter ? SECCOMP_MODE_FILTER :
+                                      SECCOMP_MODE_DISABLED;
+    }
+    if (mode != SECCOMP_MODE_FILTER) {
+        return -TARGET_EINVAL;
+    }
+    return seccomp_install_filter(env, 0, program);
+}
+
+abi_long guest_seccomp_syscall(CPUArchState *env, abi_long operation,
+                               abi_ulong flags, abi_ulong args)
+{
+    switch (operation) {
+    case SECCOMP_SET_MODE_FILTER:
+        return seccomp_install_filter(env, flags, args);
+    case SECCOMP_GET_ACTION_AVAIL:
+    {
+        uint32_t action;
+
+        if (flags != 0) {
+            return -TARGET_EINVAL;
+        }
+        if (get_user_u32(action, args)) {
+            return -TARGET_EFAULT;
+        }
+        switch (action) {
+        case SECCOMP_RET_KILL_PROCESS:
+        case SECCOMP_RET_KILL_THREAD:
+        case SECCOMP_RET_TRAP:
+        case SECCOMP_RET_ERRNO:
+        case SECCOMP_RET_TRACE:
+        case SECCOMP_RET_LOG:
+        case SECCOMP_RET_ALLOW:
+            return 0;
+        default:
+            return -TARGET_EOPNOTSUPP;
+        }
+    }
+    default:
+        return -TARGET_EINVAL;
+    }
+}
+
+uint32_t guest_seccomp_target_arch(void)
+{
+#ifdef TARGET_X86_64
+    return AUDIT_ARCH_X86_64;
+#else
+    return AUDIT_ARCH_I386;
+#endif
+}
+
+GuestSeccompAction guest_seccomp_filter_syscall(CPUArchState *env, int num,
+                                                uint32_t arch,
+                                                const abi_long args[6],
+                                                abi_long *result)
+{
+    TaskState *task = env_cpu(env)->opaque;
+    GuestSeccompFilter *filter = task->seccomp_filter;
+    GuestSeccompData data;
+    uint32_t decision = SECCOMP_RET_ALLOW;
+    unsigned int i;
+
+    if (!filter) {
+        return GUEST_SECCOMP_CONTINUE;
+    }
+
+    data.nr = num;
+    data.arch = arch;
+    data.instruction_pointer = env->eip;
+    for (i = 0; i < ARRAY_SIZE(data.args); i++) {
+        data.args[i] = (abi_ulong)args[i];
+    }
+
+    for (; filter; filter = filter->previous) {
+        uint32_t current = seccomp_run_filter(filter, &data);
+        int32_t current_action = current & SECCOMP_RET_ACTION_FULL;
+        int32_t decision_action = decision & SECCOMP_RET_ACTION_FULL;
+
+        if (current_action < decision_action) {
+            decision = current;
+        }
+    }
+
+    switch (decision & SECCOMP_RET_ACTION_FULL) {
+    case SECCOMP_RET_ALLOW:
+    case SECCOMP_RET_LOG:
+        return GUEST_SECCOMP_CONTINUE;
+    case SECCOMP_RET_ERRNO:
+        *result = -(abi_long)MIN(decision & SECCOMP_RET_DATA, 4095U);
+        return GUEST_SECCOMP_RETURN;
+    case SECCOMP_RET_TRAP:
+    {
+        target_siginfo_t info = {
+            .si_signo = TARGET_SIGSYS,
+            .si_errno = decision & SECCOMP_RET_DATA,
+            .si_code = TARGET_SYS_SECCOMP,
+            ._sifields._sigsys._call_addr = env->eip,
+            ._sifields._sigsys._syscall = num,
+            ._sifields._sigsys._arch = data.arch,
+        };
+
+        queue_signal(env, TARGET_SIGSYS, QEMU_SI_SYS, &info);
+        *result = num;
+        return GUEST_SECCOMP_RETURN;
+    }
+    case SECCOMP_RET_TRACE:
+    case SECCOMP_RET_USER_NOTIF:
+        *result = -TARGET_ENOSYS;
+        return GUEST_SECCOMP_RETURN;
+    case SECCOMP_RET_KILL_PROCESS:
+        return GUEST_SECCOMP_KILL_PROCESS;
+    case SECCOMP_RET_KILL_THREAD:
+        return GUEST_SECCOMP_KILL_THREAD;
+    default:
+        return GUEST_SECCOMP_KILL_PROCESS;
+    }
+}

--- a/linux-user/guest-seccomp.h
+++ b/linux-user/guest-seccomp.h
@@ -1,0 +1,21 @@
+#ifndef LINUX_USER_GUEST_SECCOMP_H
+#define LINUX_USER_GUEST_SECCOMP_H
+
+typedef enum GuestSeccompAction {
+    GUEST_SECCOMP_CONTINUE,
+    GUEST_SECCOMP_RETURN,
+    GUEST_SECCOMP_KILL_THREAD,
+    GUEST_SECCOMP_KILL_PROCESS,
+} GuestSeccompAction;
+
+abi_long guest_seccomp_prctl(CPUArchState *env, abi_long option,
+                             abi_long mode, abi_ulong program);
+abi_long guest_seccomp_syscall(CPUArchState *env, abi_long operation,
+                               abi_ulong flags, abi_ulong args);
+uint32_t guest_seccomp_target_arch(void);
+GuestSeccompAction guest_seccomp_filter_syscall(CPUArchState *env, int num,
+                                                uint32_t arch,
+                                                const abi_long args[6],
+                                                abi_long *result);
+
+#endif

--- a/linux-user/i386/cpu_loop.c
+++ b/linux-user/i386/cpu_loop.c
@@ -22,6 +22,7 @@
 #include "qemu.h"
 #include "cpu_loop-common.h"
 #include "latx-options.h"
+#include <linux/audit.h>
 
 /***********************************************************/
 /* CPUX86 core interface */
@@ -225,12 +226,11 @@ void cpu_loop(CPUX86State *env)
         switch(trapnr) {
         case 0x80:
             /* linux syscall from int $0x80 */
-            ret = do_syscall(env,
 #ifdef TARGET_X86_64
-                             syscall_64_to_32[env->regs[R_EAX]],
-#else
+            ret = do_syscall_with_seccomp(
+                             env, syscall_64_to_32[env->regs[R_EAX]],
                              env->regs[R_EAX],
-#endif
+                             CODEIS64 ? AUDIT_ARCH_X86_64 : AUDIT_ARCH_I386,
                              env->regs[R_EBX],
                              env->regs[R_ECX],
                              env->regs[R_EDX],
@@ -238,6 +238,16 @@ void cpu_loop(CPUX86State *env)
                              env->regs[R_EDI],
                              env->regs[R_EBP],
                              0, 0);
+#else
+            ret = do_syscall(env, env->regs[R_EAX],
+                             env->regs[R_EBX],
+                             env->regs[R_ECX],
+                             env->regs[R_EDX],
+                             env->regs[R_ESI],
+                             env->regs[R_EDI],
+                             env->regs[R_EBP],
+                             0, 0);
+#endif
             if (ret == -TARGET_ERESTARTSYS) {
                 env->eip -= 2;
             } else if (ret != -TARGET_QEMU_ESIGRETURN) {

--- a/linux-user/meson.build
+++ b/linux-user/meson.build
@@ -3,6 +3,7 @@ linux_user_ss.add(files(
   'elfload.c',
   'exit.c',
   'fd-trans.c',
+  'guest-seccomp.c',
   'linuxload.c',
   'main.c',
   'mmap.c',

--- a/linux-user/qemu.h
+++ b/linux-user/qemu.h
@@ -101,6 +101,8 @@ struct emulated_sigtable {
     target_siginfo_t info;
 };
 
+struct GuestSeccompFilter;
+
 /* NOTE: we force a big alignment so that the stack stored after is
    aligned too */
 typedef struct TaskState {
@@ -120,6 +122,8 @@ typedef struct TaskState {
     uint32_t v86flags;
     uint32_t v86mask;
     abi_ulong child_tidptr;
+    /* Immutable seccomp filter chain inherited by guest threads. */
+    struct GuestSeccompFilter *seccomp_filter;
 #ifdef TARGET_M68K
     abi_ulong tp_value;
 #endif
@@ -283,6 +287,11 @@ abi_long do_syscall(void *cpu_env, int num, abi_long arg1,
                     abi_long arg2, abi_long arg3, abi_long arg4,
                     abi_long arg5, abi_long arg6, abi_long arg7,
                     abi_long arg8);
+abi_long do_syscall_with_seccomp(void *cpu_env, int num, int seccomp_num,
+                                uint32_t seccomp_arch, abi_long arg1,
+                                abi_long arg2, abi_long arg3, abi_long arg4,
+                                abi_long arg5, abi_long arg6, abi_long arg7,
+                                abi_long arg8);
 extern __thread CPUState *thread_cpu;
 void cpu_loop(CPUArchState *env);
 const char *target_strerror(int err);

--- a/linux-user/signal-common.h
+++ b/linux-user/signal-common.h
@@ -70,6 +70,7 @@ void tswap_siginfo(target_siginfo_t *tinfo,
                    const target_siginfo_t *info);
 void set_sigmask(const sigset_t *set);
 void force_sig(int sig);
+void QEMU_NORETURN force_sig_abort(int sig);
 void force_sigsegv(int oldsig);
 #if defined(TARGET_ARCH_HAS_SETUP_FRAME)
 void setup_frame(int sig, struct target_sigaction *ka,
@@ -79,4 +80,3 @@ void setup_rt_frame(int sig, struct target_sigaction *ka,
                     target_siginfo_t *info,
                     target_sigset_t *set, CPUArchState *env);
 #endif
-

--- a/linux-user/signal.c
+++ b/linux-user/signal.c
@@ -502,6 +502,14 @@ void tswap_siginfo(target_siginfo_t *tinfo,
         __put_user(info->_sifields._rt._sigval.sival_ptr,
                    &tinfo->_sifields._rt._sigval.sival_ptr);
         break;
+    case QEMU_SI_SYS:
+        __put_user(info->_sifields._sigsys._call_addr,
+                   &tinfo->_sifields._sigsys._call_addr);
+        __put_user(info->_sifields._sigsys._syscall,
+                   &tinfo->_sifields._sigsys._syscall);
+        __put_user(info->_sifields._sigsys._arch,
+                   &tinfo->_sifields._sigsys._arch);
+        break;
     default:
         g_assert_not_reached();
     }
@@ -772,6 +780,11 @@ static void QEMU_NORETURN dump_core_and_abort(int target_sig)
 
     /* unreachable */
     abort();
+}
+
+void QEMU_NORETURN force_sig_abort(int sig)
+{
+    dump_core_and_abort(sig);
 }
 
 /* queue a signal so that it will be send to the virtual CPU as soon

--- a/linux-user/strace.c
+++ b/linux-user/strace.c
@@ -344,6 +344,13 @@ static void print_siginfo(const target_siginfo_t *tinfo)
                  (unsigned int)tinfo->_sifields._rt._uid,
                  tinfo->_sifields._rt._sigval.sival_ptr);
         break;
+    case QEMU_SI_SYS:
+        qemu_log_tmp(", si_call_addr=" TARGET_ABI_FMT_lx
+                     ", si_syscall=%d, si_arch=%u",
+                     tinfo->_sifields._sigsys._call_addr,
+                     tinfo->_sifields._sigsys._syscall,
+                     tinfo->_sifields._sigsys._arch);
+        break;
     default:
         g_assert_not_reached();
     }

--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -23,6 +23,7 @@
 #include "qemu/path.h"
 #include "qemu/memfd.h"
 #include "qemu/queue.h"
+#include "qemu/rcu.h"
 #include <elf.h>
 #include <endian.h>
 #include <grp.h>
@@ -142,6 +143,7 @@
 #include "ioctl/mpt3sas_ctl.h"
 
 #include "qemu.h"
+#include "guest-seccomp.h"
 #include "signal-common.h"
 #include "qemu/guest-random.h"
 #include "qemu/selfmap.h"
@@ -165,6 +167,15 @@
 #include <sys/ptrace.h>
 #ifndef CLONE_IO
 #define CLONE_IO                0x80000000      /* Clone io context */
+#endif
+#ifndef CLONE_NEWUSER
+#define CLONE_NEWUSER           0x10000000      /* New user namespace */
+#endif
+#ifndef CLONE_NEWPID
+#define CLONE_NEWPID            0x20000000      /* New pid namespace */
+#endif
+#ifndef CLONE_NEWNET
+#define CLONE_NEWNET            0x40000000      /* New network namespace */
 #endif
 
 #include <linux/netfilter_ipv4.h>
@@ -194,9 +205,16 @@
     (CLONE_DETACHED | CLONE_IO)
 
 /* Flags for fork which we can implement within QEMU itself */
+#define CLONE_FORK_NAMESPACE_FLAGS \
+    (CLONE_NEWUSER | CLONE_NEWPID | CLONE_NEWNET)
+
+#define CLONE_DIRECT_FORK_FLAGS \
+    (CLONE_NEWUSER | CLONE_NEWPID | CLONE_NEWNET | CLONE_FS)
+
 #define CLONE_OPTIONAL_FORK_FLAGS               \
     (CLONE_SETTLS | CLONE_PARENT_SETTID |       \
-     CLONE_CHILD_CLEARTID | CLONE_CHILD_SETTID)
+     CLONE_CHILD_CLEARTID | CLONE_CHILD_SETTID | \
+     CLONE_FORK_NAMESPACE_FLAGS | CLONE_FS)
 
 /* Flags for thread creation which we can implement within QEMU itself */
 #define CLONE_OPTIONAL_THREAD_FLAGS                             \
@@ -213,9 +231,12 @@
 /* CLONE_VFORK is special cased early in do_fork(). The other flag bits
  * have almost all been allocated. We cannot support any of
  * CLONE_NEWNS, CLONE_NEWCGROUP, CLONE_NEWUTS, CLONE_NEWIPC,
- * CLONE_NEWUSER, CLONE_NEWPID, CLONE_NEWNET, CLONE_PTRACE, CLONE_UNTRACED.
+ * CLONE_PTRACE, CLONE_UNTRACED.
  * The checks against the invalid thread masks above will catch these.
  * (The one remaining unallocated bit is 0x1000 which used to be CLONE_PID.)
+ * Fork-like CLONE_NEWUSER is applied in the single-threaded child. PID,
+ * network, and shared-fs clone flags require a deferred single-thread child
+ * and use the libc clone wrapper so the kernel creates the requested state.
  */
 
 /* Define DEBUG_ERESTARTSYS to force every syscall to be restarted
@@ -8805,6 +8826,10 @@ abi_long do_arch_prctl(CPUX86State *env, int code, abi_ulong addr)
 
 
 static pthread_mutex_t clone_lock = PTHREAD_MUTEX_INITIALIZER;
+static int do_sys_futex(int *uaddr, int op, int val,
+                        const struct timespec *timeout, int *uaddr2,
+                        int val3);
+
 typedef struct {
     CPUArchState *env;
     pthread_mutex_t mutex;
@@ -8853,6 +8878,86 @@ static void *clone_func(void *arg)
     return NULL;
 }
 
+static void cleanup_guest_thread_resources(CPUArchState *env)
+{
+    assert(env->gdt.base);
+    target_munmap(env->gdt.base, sizeof(uint64_t) * TARGET_GDT_ENTRIES, 0);
+#ifdef CONFIG_LATX_FAST_JMPCACHE
+    if (env->tb_jmp_cache_ptr) {
+        free(env->tb_jmp_cache_ptr);
+        env->tb_jmp_cache_ptr = NULL;
+    }
+#endif
+}
+
+/* clone_lock is held and at least one other guest thread exists. */
+static void QEMU_NORETURN exit_guest_thread_locked(CPUArchState *env)
+{
+    CPUState *cpu = env_cpu(env);
+    TaskState *ts = cpu->opaque;
+
+    object_property_set_bool(OBJECT(cpu), "realized", false, NULL);
+    object_unparent(OBJECT(cpu));
+    object_unref(OBJECT(cpu));
+    pthread_mutex_unlock(&clone_lock);
+
+    if (ts->child_tidptr) {
+        put_user_u32(0, ts->child_tidptr);
+        do_sys_futex(g2h(cpu, ts->child_tidptr), FUTEX_WAKE, INT_MAX,
+                     NULL, NULL, 0);
+    }
+    thread_cpu = NULL;
+    g_free(ts);
+    rcu_unregister_thread();
+    pthread_exit(NULL);
+}
+
+static void QEMU_NORETURN seccomp_kill_thread(CPUArchState *env)
+{
+#ifdef CONFIG_LATX_AOT
+    CPUState *cpu = env_cpu(env);
+#endif
+
+    /* KILL actions take precedence over already-pending guest signals. */
+    block_signals();
+    cleanup_guest_thread_resources(env);
+    pthread_mutex_lock(&clone_lock);
+#ifdef CONFIG_LATX_AOT
+    if (current_cpu->cpu_index == 0) {
+        aot_exit_entry(cpu, false);
+    }
+#endif
+    if (CPU_NEXT(first_cpu)) {
+        exit_guest_thread_locked(env);
+    }
+    pthread_mutex_unlock(&clone_lock);
+
+    /* A single-thread KILL_THREAD terminates the process as SIGSYS. */
+    force_sig_abort(TARGET_SIGSYS);
+}
+
+typedef struct ForkCloneContext {
+    void *jump_buffer[5];
+} ForkCloneContext;
+
+static int fork_clone_func(void *opaque)
+{
+    ForkCloneContext *context = opaque;
+
+    __builtin_longjmp(context->jump_buffer, 1);
+}
+
+static int fork_with_flags(unsigned int flags)
+{
+    char stack[PTHREAD_STACK_MIN] __attribute__((aligned(16)));
+    ForkCloneContext context;
+
+    if (__builtin_setjmp(context.jump_buffer) == 0) {
+        return clone(fork_clone_func, stack + sizeof(stack), flags, &context);
+    }
+    return 0;
+}
+
 /* do_fork() Must return host values and target errnos (unlike most
    do_*() functions). */
 static int do_fork(CPUArchState *env, unsigned int flags, abi_ulong newsp,
@@ -8860,6 +8965,10 @@ static int do_fork(CPUArchState *env, unsigned int flags, abi_ulong newsp,
                    abi_ulong child_tidptr)
 {
     CPUState *cpu = env_cpu(env);
+    unsigned int namespace_flags;
+    unsigned int direct_fork_flags;
+    bool userns_via_unshare;
+    int namespace_pipe[2] = { -1, -1 };
     int ret;
     TaskState *ts;
     CPUState *new_cpu;
@@ -8867,15 +8976,22 @@ static int do_fork(CPUArchState *env, unsigned int flags, abi_ulong newsp,
     sigset_t sigmask;
 
     flags &= ~CLONE_IGNORED_FLAGS;
+    namespace_flags = flags & CLONE_FORK_NAMESPACE_FLAGS;
 
     /* Emulate vfork() with fork() */
     if (flags & CLONE_VFORK)
         flags &= ~(CLONE_VFORK | CLONE_VM);
 
+    direct_fork_flags = flags & (CLONE_NEWPID | CLONE_NEWNET | CLONE_FS);
+    userns_via_unshare = namespace_flags == CLONE_NEWUSER &&
+                         !direct_fork_flags;
+
     if (flags & CLONE_VM) {
         TaskState *parent_ts = (TaskState *)cpu->opaque;
         new_thread_info info;
         pthread_attr_t attr;
+
+        rcu_start_deferred_thread();
 
         if (((flags & CLONE_THREAD_FLAGS) != CLONE_THREAD_FLAGS) ||
             (flags & CLONE_INVALID_THREAD_FLAGS)) {
@@ -8908,6 +9024,7 @@ static int do_fork(CPUArchState *env, unsigned int flags, abi_ulong newsp,
         ts->bprm = parent_ts->bprm;
         ts->info = parent_ts->info;
         ts->signal_mask = parent_ts->signal_mask;
+        ts->seccomp_filter = parent_ts->seccomp_filter;
 
         if (flags & CLONE_CHILD_CLEARTID) {
             ts->child_tidptr = child_tidptr;
@@ -8965,6 +9082,10 @@ static int do_fork(CPUArchState *env, unsigned int flags, abi_ulong newsp,
             return -TARGET_EINVAL;
         }
 
+        if (userns_via_unshare && pipe2(namespace_pipe, O_CLOEXEC) < 0) {
+            return -1;
+        }
+
         /* We can't support custom termination signals */
         /* We don't support child exit with no SIGCHLD sent
         if ((flags & CSIGNAL) != TARGET_SIGCHLD) {
@@ -8973,15 +9094,66 @@ static int do_fork(CPUArchState *env, unsigned int flags, abi_ulong newsp,
         */
 
         if (block_signals()) {
+            if (userns_via_unshare) {
+                close(namespace_pipe[0]);
+                close(namespace_pipe[1]);
+            }
             return -TARGET_ERESTARTSYS;
         }
 
         fork_start();
-        ret = fork();
+        if (userns_via_unshare) {
+            rcu_defer_atfork_child();
+        }
+        if (direct_fork_flags) {
+            CPUState *other_cpu;
+            unsigned int cpu_count = 0;
+
+            CPU_FOREACH(other_cpu) {
+                cpu_count++;
+            }
+            if (cpu_count != 1) {
+                errno = EINVAL;
+                ret = -1;
+            } else {
+                rcu_raw_clone_prepare();
+                ret = fork_with_flags(flags &
+                                      (CLONE_DIRECT_FORK_FLAGS | CSIGNAL));
+                if (ret == 0) {
+                    rcu_raw_clone_child();
+                } else {
+                    rcu_raw_clone_parent();
+                }
+            }
+        } else {
+            ret = fork();
+        }
         if (ret == 0) {
+            int namespace_errno = 0;
+            ssize_t len;
+
+            if (userns_via_unshare) {
+                close(namespace_pipe[0]);
+                if (unshare(CLONE_NEWUSER) < 0) {
+                    namespace_errno = errno;
+                }
+                do {
+                    len = write(namespace_pipe[1], &namespace_errno,
+                                sizeof(namespace_errno));
+                } while (len < 0 && errno == EINTR);
+                close(namespace_pipe[1]);
+                if (len != (ssize_t)sizeof(namespace_errno) ||
+                    namespace_errno) {
+                    _exit(EXIT_FAILURE);
+                }
+            }
+
             /* Child Process.  */
             cpu_clone_regs_child(env, newsp, flags);
             fork_end(1);
+            if (userns_via_unshare) {
+                rcu_start_deferred_thread();
+            }
             /* There is a race condition here.  The parent process could
                theoretically read the TID in the child process before the child
                tid is set.  This would require using either ptrace
@@ -8998,8 +9170,38 @@ static int do_fork(CPUArchState *env, unsigned int flags, abi_ulong newsp,
             if (flags & CLONE_CHILD_CLEARTID)
                 ts->child_tidptr = child_tidptr;
         } else {
+            int namespace_errno = EIO;
+            ssize_t len = -1;
+
+            if (userns_via_unshare) {
+                close(namespace_pipe[1]);
+                rcu_cancel_atfork_child_defer();
+            }
             cpu_clone_regs_parent(env, flags);
             fork_end(0);
+
+            if (userns_via_unshare && ret > 0) {
+                do {
+                    len = read(namespace_pipe[0], &namespace_errno,
+                               sizeof(namespace_errno));
+                } while (len < 0 && errno == EINTR);
+                close(namespace_pipe[0]);
+            } else if (userns_via_unshare) {
+                close(namespace_pipe[0]);
+            }
+
+            if (userns_via_unshare && ret > 0 &&
+                (len != (ssize_t)sizeof(namespace_errno) ||
+                 namespace_errno)) {
+                int status;
+
+                while (waitpid(ret, &status, 0) < 0 && errno == EINTR) {
+                    /* Retry until the namespace child can be reaped. */
+                }
+                errno = len == (ssize_t)sizeof(namespace_errno) ?
+                        namespace_errno : EIO;
+                ret = -1;
+            }
         }
         g_assert(!cpu_in_exclusive_context(cpu));
     }
@@ -11516,8 +11718,7 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
         /*
          * During thread exit, need to free gdt table to avoid memory leak.
          */
-        assert(env->gdt.base);
-        target_munmap(env->gdt.base, sizeof(uint64_t) * TARGET_GDT_ENTRIES, 0);
+        cleanup_guest_thread_resources(env);
         /* In old applications this may be used to implement _exit(2).
            However in threaded applications it is used for thread termination,
            and _exit_group is used for application termination.
@@ -11525,14 +11726,6 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
         if (block_signals()) {
             return -TARGET_ERESTARTSYS;
         }
-#ifdef CONFIG_LATX_FAST_JMPCACHE
-        {
-            CPUX86State *x86env = env;
-            if (x86env->tb_jmp_cache_ptr) {
-                free(x86env->tb_jmp_cache_ptr);
-            }
-        }
-#endif
         pthread_mutex_lock(&clone_lock);
 #ifdef CONFIG_LATX_AOT
         if(current_cpu->cpu_index == 0) {
@@ -11541,28 +11734,7 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
 #endif
 
         if (CPU_NEXT(first_cpu)) {
-            TaskState *ts = cpu->opaque;
-
-            object_property_set_bool(OBJECT(cpu), "realized", false, NULL);
-            object_unparent(OBJECT(cpu));
-            object_unref(OBJECT(cpu));
-            /*
-             * At this point the CPU should be unrealized and removed
-             * from cpu lists. We can clean-up the rest of the thread
-             * data without the lock held.
-             */
-
-            pthread_mutex_unlock(&clone_lock);
-
-            if (ts->child_tidptr) {
-                put_user_u32(0, ts->child_tidptr);
-                do_sys_futex(g2h(cpu, ts->child_tidptr),
-                             FUTEX_WAKE, INT_MAX, NULL, NULL, 0);
-            }
-            thread_cpu = NULL;
-            g_free(ts);
-            rcu_unregister_thread();
-            pthread_exit(NULL);
+            exit_guest_thread_locked(env);
         }
 
         pthread_mutex_unlock(&clone_lock);
@@ -14915,9 +15087,7 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
 #endif /* AARCH64 */
         case PR_GET_SECCOMP:
         case PR_SET_SECCOMP:
-            /* Disable seccomp to prevent the target disabling syscalls we
-             * need. */
-            return -TARGET_EINVAL;
+            return guest_seccomp_prctl(env, arg1, arg2, arg3);
         default:
             /* Most prctl options have no pointer arguments */
             return get_errno(prctl(arg1, g2h_untagged(arg2), g2h_untagged(arg3),
@@ -17347,9 +17517,17 @@ defined(__loongarch__)
     case TARGET_NR_setns:
         return get_errno(setns(arg1, arg2));
 #endif
+#ifdef TARGET_NR_seccomp
+    case TARGET_NR_seccomp:
+        return guest_seccomp_syscall(env, arg1, arg2, arg3);
+#endif
 #if defined(TARGET_NR_unshare) && defined(CONFIG_SETNS)
     case TARGET_NR_unshare:
-        return get_errno(unshare(arg1));
+        ret = get_errno(unshare(arg1));
+        if (arg1 & CLONE_NEWUSER) {
+            rcu_start_deferred_thread();
+        }
+        return ret;
 #endif
 #if defined(TARGET_NR_kcmp) && defined(__NR_kcmp)
     case TARGET_NR_kcmp:
@@ -17508,12 +17686,19 @@ defined(__loongarch__)
     return ret;
 }
 
-abi_long do_syscall(void *cpu_env, int num, abi_long arg1,
-                    abi_long arg2, abi_long arg3, abi_long arg4,
-                    abi_long arg5, abi_long arg6, abi_long arg7,
-                    abi_long arg8)
+abi_long do_syscall_with_seccomp(void *cpu_env, int num, int seccomp_num,
+                                uint32_t seccomp_arch, abi_long arg1,
+                                abi_long arg2, abi_long arg3, abi_long arg4,
+                                abi_long arg5, abi_long arg6, abi_long arg7,
+                                abi_long arg8)
 {
     CPUState *cpu = env_cpu(cpu_env);
+    CPUArchState *env = cpu->env_ptr;
+    const abi_long seccomp_args[6] = {
+        arg1, arg2, arg3, arg4, arg5, arg6,
+    };
+    GuestSeccompAction seccomp_action = GUEST_SECCOMP_CONTINUE;
+    bool apply_seccomp = true;
     abi_long ret;
 #if defined(CONFIG_LATX_JRRA) || defined(CONFIG_LATX_JRRA_STACK)
     /*GR2SCR scr0, zeor; for todo.*/
@@ -17543,8 +17728,28 @@ abi_long do_syscall(void *cpu_env, int num, abi_long arg1,
         print_syscall(cpu_env, num, arg1, arg2, arg3, arg4, arg5, arg6);
     }
 
-    ret = do_syscall1(cpu_env, num, arg1, arg2, arg3, arg4,
-                      arg5, arg6, arg7, arg8);
+#ifdef CONFIG_LATX_TUNNEL_LIB
+    apply_seccomp = num != TUNNEL_VIRTUAL_SYSCALL_ID;
+#endif
+    if (apply_seccomp) {
+        seccomp_action = guest_seccomp_filter_syscall(
+            env, seccomp_num, seccomp_arch, seccomp_args, &ret);
+    }
+
+    switch (seccomp_action) {
+    case GUEST_SECCOMP_CONTINUE:
+        ret = do_syscall1(cpu_env, num, arg1, arg2, arg3, arg4,
+                          arg5, arg6, arg7, arg8);
+        break;
+    case GUEST_SECCOMP_RETURN:
+        break;
+    case GUEST_SECCOMP_KILL_THREAD:
+        seccomp_kill_thread(env);
+    case GUEST_SECCOMP_KILL_PROCESS:
+        force_sig_abort(TARGET_SIGSYS);
+    default:
+        g_assert_not_reached();
+    }
 
     if (unlikely(qemu_loglevel_mask(LOG_STRACE)) ||
         unlikely(qemu_loglevel_mask(LOG_STRACE_ERROR))) {
@@ -17554,4 +17759,15 @@ abi_long do_syscall(void *cpu_env, int num, abi_long arg1,
 
     record_syscall_return(cpu, num, ret);
     return ret;
+}
+
+abi_long do_syscall(void *cpu_env, int num, abi_long arg1,
+                    abi_long arg2, abi_long arg3, abi_long arg4,
+                    abi_long arg5, abi_long arg6, abi_long arg7,
+                    abi_long arg8)
+{
+    return do_syscall_with_seccomp(cpu_env, num, num,
+                                   guest_seccomp_target_arch(),
+                                   arg1, arg2, arg3, arg4,
+                                   arg5, arg6, arg7, arg8);
 }

--- a/linux-user/syscall_defs.h
+++ b/linux-user/syscall_defs.h
@@ -616,6 +616,7 @@ typedef struct {
 #define QEMU_SI_FAULT 3
 #define QEMU_SI_CHLD 4
 #define QEMU_SI_RT 5
+#define QEMU_SI_SYS 6
 
 typedef struct target_siginfo {
 #ifdef TARGET_MIPS
@@ -669,8 +670,17 @@ typedef struct target_siginfo {
 			int _band;	/* POLL_IN, POLL_OUT, POLL_MSG */
 			int _fd;
 		} _sigpoll;
+
+        /* SIGSYS */
+        struct {
+            abi_ulong _call_addr;
+            int _syscall;
+            unsigned int _arch;
+        } _sigsys;
 	} _sifields;
 } target_siginfo_t;
+
+#define TARGET_SYS_SECCOMP 1
 
 /*
  * si_code values

--- a/util/rcu.c
+++ b/util/rcu.c
@@ -363,26 +363,31 @@ void rcu_unregister_thread(void)
     qemu_mutex_unlock(&rcu_registry_lock);
 }
 
-static void rcu_init_complete(void)
+static void rcu_start_call_thread(void)
 {
     QemuThread thread;
 
+    qemu_thread_create(&thread, "call_rcu", call_rcu_thread,
+                       NULL, QEMU_THREAD_DETACHED);
+}
+
+static void rcu_init_complete(bool start_thread)
+{
     qemu_mutex_init(&rcu_registry_lock);
     qemu_mutex_init(&rcu_sync_lock);
     qemu_event_init(&rcu_gp_event, true);
 
     qemu_event_init(&rcu_call_ready_event, false);
 
-    /* The caller is assumed to have iothread lock, so the call_rcu thread
-     * must have been quiescent even after forking, just recreate it.
-     */
-    qemu_thread_create(&thread, "call_rcu", call_rcu_thread,
-                       NULL, QEMU_THREAD_DETACHED);
+    if (start_thread) {
+        rcu_start_call_thread();
+    }
 
     rcu_register_thread();
 }
 
 static int atfork_depth = 1;
+static bool atfork_child_deferred;
 
 void rcu_enable_atfork(void)
 {
@@ -392,6 +397,25 @@ void rcu_enable_atfork(void)
 void rcu_disable_atfork(void)
 {
     atfork_depth--;
+}
+
+void rcu_defer_atfork_child(void)
+{
+    assert(!atfork_child_deferred);
+    atfork_child_deferred = true;
+}
+
+void rcu_cancel_atfork_child_defer(void)
+{
+    atfork_child_deferred = false;
+}
+
+void rcu_start_deferred_thread(void)
+{
+    if (atfork_child_deferred) {
+        atfork_child_deferred = false;
+        rcu_start_call_thread();
+    }
 }
 
 #ifdef CONFIG_POSIX
@@ -426,7 +450,22 @@ static void rcu_init_child(void)
     }
 
     memset(&registry, 0, sizeof(registry));
-    rcu_init_complete();
+    rcu_init_complete(!atfork_child_deferred);
+}
+
+void rcu_raw_clone_prepare(void)
+{
+    rcu_init_lock();
+}
+
+void rcu_raw_clone_parent(void)
+{
+    rcu_init_unlock();
+}
+
+void rcu_raw_clone_child(void)
+{
+    rcu_init_child();
 }
 #endif
 
@@ -436,5 +475,5 @@ static void __attribute__((__constructor__)) rcu_init(void)
 #ifdef CONFIG_POSIX
     pthread_atfork(rcu_init_lock, rcu_init_unlock, rcu_init_child);
 #endif
-    rcu_init_complete();
+    rcu_init_complete(true);
 }


### PR DESCRIPTION
## Summary

- support CEF user, PID, network, and shared-filesystem namespace clone paths
- preserve and rebuild QEMU RCU state across fork and raw clone operations
- evaluate x86 seccomp-BPF programs at the guest syscall boundary
- provide complete SIGSYS metadata for CEF broker traps
- keep the implementation buildable with older seccomp UAPI headers

## Root cause

LATX rejected the namespace flags used by the CEF zygote before reaching the
host kernel. After namespace creation was enabled, CEF still could not install
its x86 seccomp filters because applying those filters to the LoongArch host
would inspect the wrong syscall ABI and could restrict translator helper
threads. Brokered `SECCOMP_RET_TRAP` actions also require the trap ID and guest
syscall context in `siginfo`.

This change creates the requested host namespaces while maintaining QEMU child
state, and interprets seccomp filters against guest syscall numbers and
arguments before syscall translation.

## Compatibility

`SECCOMP_RET_USER_NOTIF` is conditionally defined for Linux 4.19-era userspace
headers. User notification and listener FDs remain unsupported and return
`ENOSYS`; the fallback only provides the stable UAPI action value needed to
compile the existing unsupported-action path.

## Validation

- `./latxbuild/build64.sh`
- `./latxbuild/build32.sh`
- Linux 4.19 old-world `./latxbuild/build64.sh`
- old-world CEF application launch with `LATX_AOT=0 LATX_KZT=0`

The old-world run remained active for 20 seconds and created the expected
zygote, chrome-sandbox, and network-service processes. The logs contained no
clone `EINVAL`, debugger startup, rejected BPF filter, unexpected SIGSYS, or
startup SIGTRAP error.
