### PR TITLE
fix build error for glibc 2.43

### DIFF
--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -11681,8 +11681,8 @@ static int do_openat(void *cpu_env, int dirfd, const char *pathname, int flags, 
         const char *tmpdir;
         char filename[PATH_MAX];
         int fd, r;
-        char *latx_filename;
-        char *slash;
+        const char *latx_filename;
+        const char *slash;
 
         /* create temporary file to map stat to */
         tmpdir = getenv("TMPDIR");
@@ -11693,7 +11693,7 @@ static int do_openat(void *cpu_env, int dirfd, const char *pathname, int flags, 
         if (slash) {
             latx_filename = slash + 1;
         } else {
-            latx_filename = (char *)fake_open->filename;
+            latx_filename = fake_open->filename;
         }
         snprintf(filename, sizeof(filename), "%s/latxopen-%s.XXXXXX",
                     tmpdir, latx_filename);

--- a/target/i386/latx/context/elfloader.c
+++ b/target/i386/latx/context/elfloader.c
@@ -230,28 +230,33 @@ static char* GenPathList(char * rpath, const char* origin)
 {
     char *rpathref = rpath;
     while (strstr(rpath, "$ORIGIN")) {
-        char* p = strrchr(origin, '/');
+        char *origin_tmp = box_strdup(origin);
+        char* p = strrchr(origin_tmp, '/');
         if (p) *p = '\0';    // remove file name to have only full path, without last '/'
-        char* tmp = (char*)box_calloc(1, strlen(rpath)-strlen("$ORIGIN")+strlen(origin)+1);
+        char* tmp = (char*)box_calloc(1, strlen(rpath)-strlen("$ORIGIN")+strlen(origin_tmp)+1);
         p = strstr(rpath, "$ORIGIN");
         memcpy(tmp, rpath, p-rpath);
-        strcat(tmp, origin);
+        strcat(tmp, origin_tmp);
         strcat(tmp, p+strlen("$ORIGIN"));
         if (rpath!=rpathref)
             box_free(rpath);
         rpath = tmp;
+        box_free(origin_tmp);
     }
+
     while (strstr(rpath, "${ORIGIN}")) {
-        char* p = strrchr(origin, '/');
+        char* origin_tmp = box_strdup(origin);
+        char* p = strrchr(origin_tmp, '/');
         if (p) *p = '\0';    // remove file name to have only full path, without last '/'
-        char* tmp = (char*)box_calloc(1, strlen(rpath)-strlen("${ORIGIN}")+strlen(origin)+1);
+        char* tmp = (char*)box_calloc(1, strlen(rpath)-strlen("${ORIGIN}")+strlen(origin_tmp)+1);
         p = strstr(rpath, "${ORIGIN}");
         memcpy(tmp, rpath, p-rpath);
-        strcat(tmp, origin);
+        strcat(tmp, origin_tmp);
         strcat(tmp, p+strlen("${ORIGIN}"));
         if (rpath!=rpathref)
             box_free(rpath);
         rpath = tmp;
+        box_free(origin_tmp);
     }
     while (strstr(rpath, "${PLATFORM}")) {
         char* platform = box_strdup("x86_64");
@@ -439,7 +444,7 @@ static int isChromeApp(elfheader_t* h, int con_score)
         sym = h->DynSym+i;
         if (h->DynSym[i].st_shndx != SHN_UNDEF && sym->st_value) {
             int score = 0;
-            char *find_offset;
+            const char *find_offset;
             const char * symname = h->DynStr+sym->st_name;
             snprintf(symnamebuf, 1023, KEY_SPLIT"%s"KEY_SPLIT, symname);
             find_offset = strstr(chromekeys, symnamebuf);

--- a/target/i386/latx/context/library.c
+++ b/target/i386/latx/context/library.c
@@ -62,8 +62,9 @@ KHASH_MAP_IMPL_STR(datamap, uint64_t)
 char* Path2Name(const char* path)
 {
     char* name = (char*)box_calloc(1, MAX_PATH);
-    char* p = strrchr(path, '/');
-    strcpy(name, (p)?(p+1):path);
+    char* path_tmp = box_strdup(path);
+    char* p = strrchr(path_tmp, '/');
+    strcpy(name, (p)?(p+1):path_tmp);
     // name should be libXXX.so.A(.BB.CCCC)
     // so keep only 2 dot after ".so" (if any)
     p = strstr(name, ".so");
@@ -73,11 +74,12 @@ char* Path2Name(const char* path)
         if(p) p=strchr(p+1, '.');// this one is not
         if(p) *p = '\0';
     }
+    box_free(path_tmp);
     return name;
 }
 int NbDot(const char* name)
 {
-    char *p = strstr(name, ".so");
+    const char *p = strstr(name, ".so");
     if(!p)
         return -1;
     int ret = 0;

--- a/target/i386/latx/include/common.h
+++ b/target/i386/latx/include/common.h
@@ -45,22 +45,6 @@
 #define offsetof(st, m) __builtin_offsetof(st, m)
 #endif
 
-#ifndef _Bool
-#define _Bool char
-#endif
-
-#ifndef bool
-#define bool _Bool
-#endif
-
-#ifndef true
-#define true 1
-#endif
-
-#ifndef false
-#define false 0
-#endif
-
 enum {
     UNKNOWN_EXTENSION = 96,
     SIGN_EXTENSION,

--- a/target/i386/latx/latx-options.c
+++ b/target/i386/latx/latx-options.c
@@ -471,7 +471,7 @@ void options_parse_latx_disassemble_trace_cmp(const char *args)
     if (!args) {
         return;
     }
-    char *findSpil = strstr(args, ":");
+    const char *findSpil = strstr(args, ":");
     if (!findSpil) {
         lsassertm(0, "Can't find \':\' from args.\n");
         return;

--- a/util/log.c
+++ b/util/log.c
@@ -205,7 +205,7 @@ void qemu_set_log_filename(const char *filename, Error **errp)
     logfilename = NULL;
 
     if (filename) {
-            char *pidstr = strstr(filename, "%");
+            const char *pidstr = strstr(filename, "%");
             if (pidstr) {
                 /* We only accept one %d, no other format strings */
                 if (pidstr[1] != 'd' || strchr(pidstr + 2, '%')) {


### PR DESCRIPTION
解决在使用 glibc 2.43 + gcc 16.1.0 的时候会出现多个编译错误。

Signed-off-by: 孙海勇 <sunhaiyong@zdbr.net>