### PR TITLE
Add dependencies for the build-release.sh build to Fedora.

### DIFF
--- a/README.en.rst
+++ b/README.en.rst
@@ -194,7 +194,7 @@ STEP2:
 
 .. code-block:: bash
 
-    dnf install gcc g++ make git ninja-build meson openssl-devel glib2-devel
+    dnf install gcc g++ make git ninja-build meson openssl-devel glib2-devel tar
 
 STEP3:
 

--- a/README.rst
+++ b/README.rst
@@ -183,7 +183,7 @@ STEP2:
 
 .. code-block:: bash
 
-    dnf install gcc g++ make git ninja-build meson openssl-devel glib2-devel
+    dnf install gcc g++ make git ninja-build meson openssl-devel glib2-devel tar
 
 
 STEP3:


### PR DESCRIPTION
build-release.sh require tar package.