### PR TITLE
docs: add DCO contributor onboarding

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Summary / 变更说明
+
+<!-- What does this change do and why? / 这项变更做了什么，为什么需要？ -->
+
+## Validation / 验证
+
+<!-- List the builds and tests you ran, or explain why they are not applicable.
+请列出执行过的构建和测试；如不适用，请说明原因。 -->
+
+## Checklist / 检查项
+
+- [ ] I have read `CONTRIBUTING.md`. / 我已阅读 `CONTRIBUTING.md`。
+- [ ] Every commit contains a DCO sign-off (`git commit -s`). /
+      每个提交都包含 DCO 签署（`git commit -s`）。
+- [ ] I have included relevant build or test results, or explained why they
+      are not applicable. /
+      我已提供相关构建或测试结果，或说明了不适用的原因。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,108 @@
+# Contributing to LAT / 参与 LAT 贡献
+
+## DCO / Commit sign-off
+
+Every commit must include a Developer Certificate of Origin (DCO) sign-off. By
+signing off, you certify the statements in
+[DCO 1.1](https://developercertificate.org/), including that you have the right
+to submit the contribution under the project's open source license.
+
+Create a signed-off commit with:
+
+```console
+git commit -s -m "your commit message"
+```
+
+The `-s` option adds a trailer like this to the commit message:
+
+```text
+Signed-off-by: Name <email@example.com>
+```
+
+The name and email in `Signed-off-by` must match the commit author. A DCO
+sign-off is an author attestation and is different from GPG or SSH
+cryptographic commit signing.
+
+Automation and AI assistants must not add `Signed-off-by` without your explicit
+confirmation and authorization. You must review the contribution, take
+responsibility for it, and explicitly authorize the signed commit or commits.
+
+To add a sign-off to the latest commit:
+
+```console
+git commit --amend --signoff
+git push --force-with-lease
+```
+
+The push is needed only if the original commit was already pushed. To add
+sign-offs to multiple commits on a branch:
+
+```console
+git fetch origin
+git rebase --signoff origin/master
+git push --force-with-lease
+```
+
+The command adds your sign-off to every rebased commit. Use it only when you
+authored or otherwise have the right to certify every commit being rebased, and
+do not remove existing sign-offs. Rebasing rewrites commit history, so
+coordinate with anyone else using the branch before rebasing or force-pushing
+it.
+
+每个提交都必须包含开发者原创声明（Developer Certificate of Origin，DCO）
+签署。签署表示你确认 [DCO 1.1](https://developercertificate.org/) 中的声明，
+包括你有权按照项目的开源许可证提交该贡献。
+
+请使用以下命令创建带签署的提交：
+
+```console
+git commit -s -m "提交说明"
+```
+
+`-s` 选项会在提交说明末尾添加类似下面的内容：
+
+```text
+Signed-off-by: 姓名 <email@example.com>
+```
+
+`Signed-off-by` 中的姓名和邮箱必须与提交作者一致。DCO 签署是作者对提交
+来源和授权的声明，与 GPG 或 SSH 的密码学提交签名不同。
+
+未经你明确确认和授权，自动化工具和 AI 助手不得添加 `Signed-off-by`。
+你必须审阅贡献、承担责任，并明确授权需要签署的一个或多个提交。
+
+如果最新的提交忘记签署，可以执行：
+
+```console
+git commit --amend --signoff
+git push --force-with-lease
+```
+
+只有原提交已经推送到远端时才需要再次推送。如果分支上的多个提交都
+需要补充签署，可以执行：
+
+```console
+git fetch origin
+git rebase --signoff origin/master
+git push --force-with-lease
+```
+
+该命令会为所有被 rebase 的提交添加你的签署。只有当每个提交都是你
+创作的，或者你有权对其作出认证时，才能使用该命令；同时不要删除已有
+签署。rebase 会改写提交历史，因此在 rebase 或强制推送前，请先与同样
+使用该分支的其他贡献者协调。
+
+## Before opening a pull request / 提交 Pull Request 前
+
+- Keep each change focused and follow the relevant
+  [commit convention](COMMIT_CONVENTION.en.md).
+- Build or test the affected functionality and describe the validation in the
+  pull request, or explain why validation is not applicable.
+- Confirm that every commit in the pull request contains a `Signed-off-by`
+  trailer.
+
+- 请保持每项变更内容集中，并遵循相关的
+  [提交规范](COMMIT_CONVENTION.md)。
+- 请构建或测试受影响的功能并在 Pull Request 中说明结果；如不适用，请说明
+  原因。
+- 请确认 Pull Request 中的每个提交都包含 `Signed-off-by`。

--- a/README.en.rst
+++ b/README.en.rst
@@ -19,6 +19,14 @@ the box64 project.
 
 `中文版本点击这里 >> <README.rst>`_
 
+Contributing
+============
+
+Before opening a pull request, read the
+`contribution guide <CONTRIBUTING.md>`_. Every commit must include a DCO
+``Signed-off-by`` trailer.
+
+
 Commit Convention
 ========
 

--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,13 @@ LATX 基于 QEMU 6 版本开发并进行了深度优化，性能相比原生 QEM
 
 `See the English Version Here >> <README.en.rst>`_
 
+参与贡献
+========
+
+提交 Pull Request 前，请阅读 `贡献指南 <CONTRIBUTING.md>`_。每个提交都必须
+包含 DCO ``Signed-off-by`` 签署。
+
+
 提交规范
 ========
 


### PR DESCRIPTION
## Summary

- add a bilingual `CONTRIBUTING.md` that explains the DCO requirement, commit sign-off, and safe repair workflows
- link the contribution guide from both README files
- add a bilingual pull request template with DCO and validation checks

## Validation

- `git diff --check origin/master..HEAD`
- verified all referenced repository files exist
- verified `.github/pull_request_template.md` is in GitHub's supported location
- documentation and template changes only; no LoongArch build is required

## Policy scope

This PR intentionally does not add `.github/dco.yml` or change repository settings. The existing strict per-commit DCO behavior remains unchanged.