### PR TITLE
LATX, fix: free expanded KZT RPATH

### DIFF
--- a/target/i386/latx/context/elfloader.c
+++ b/target/i386/latx/context/elfloader.c
@@ -467,6 +467,7 @@ static int isChromeApp(elfheader_t* h, int con_score)
 int CheckEnableKZT(elfheader_t* h, char** target_argv, int target_argc)
 {
     path_collection_t   lib_path = {0,0,0};
+    char *rpathref;
     char *rpath;
 
     int needlibcnt = 0;
@@ -476,10 +477,13 @@ int CheckEnableKZT(elfheader_t* h, char** target_argv, int target_argc)
         switch(h->Dynamic[i].d_tag) {
             case DT_RPATH:
             case DT_RUNPATH:
-                rpath =  h->DynStrTab+h->Dynamic[i].d_un.d_val + h->delta;
-                    printf_log(LOG_INFO, "RPATH : %s\n", rpath);
-                rpath = GenPathList(rpath, h->path);
+                rpathref = h->DynStrTab+h->Dynamic[i].d_un.d_val + h->delta;
+                    printf_log(LOG_INFO, "RPATH : %s\n", rpathref);
+                rpath = GenPathList(rpathref, h->path);
                 AppendListExistAndNotSys(&lib_path, rpath, 1);
+                if (rpath != rpathref) {
+                    box_free(rpath);
+                }
                 break;
             case DT_NEEDED:
                 if (strstr(h->DynStrTab+h->delta+h->Dynamic[i].d_un.d_val, "libgtk-3.so")||//skip gtk


### PR DESCRIPTION
## Summary / 变更说明

`CheckEnableKZT()` receives either the borrowed RPATH pointer or a newly
allocated expanded string from `GenPathList()`. It previously overwrote the
borrowed pointer and lost the ownership information, leaking the final
expanded string.

Keep the original RPATH pointer, append the expanded paths, and free the
expanded result only when it differs from the borrowed pointer. The path
collection already owns its own copies at that point.

This change is limited to that ownership issue and does not include nearby
pre-existing leak candidates.

## Validation / 验证

- Focused baseline RED on l1 with `${PLATFORM}` RPATH:
  `check_returned=True path_appended=True freed=False`, test failed.
- Focused GREEN after rebasing onto current `master`:
  observed `RPATH_ALLOC`, `RPATH_APPEND paths=['x86_64/']`, and
  `RPATH_FREE`; `RPATH_OWNERSHIP_TEST=PASS`.
- Incremental affected-object build:
  `ninja -C build libqemu-x86_64-linux-user.fa.p/target_i386_latx_context_elfloader.c.o`
- Incremental product link: `ninja -C build latx-x86_64`
- Final product build: `ninja -C build` (`no work to do`)

## Checklist / 检查项

- [x] I have read `CONTRIBUTING.md`. / 我已阅读 `CONTRIBUTING.md`。
- [x] Every commit contains a DCO sign-off (`git commit -s`). /
      每个提交都包含 DCO 签署（`git commit -s`）。
- [x] I have included relevant build or test results, or explained why they
      are not applicable. /
      我已提供相关构建或测试结果，或说明了不适用的原因。
