### PR TITLE
ci: add fast Meson test gate

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,80 @@
+name: LAT Tests
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+    paths:
+      - "**/*.c"
+      - "**/*.h"
+      - "**/*.S"
+      - "**/*.inc"
+      - "**/*.py"
+      - "**/meson.build"
+      - "meson_options.txt"
+      - "configure"
+      - ".github/.ci/**"
+      - ".github/workflows/tests.yml"
+  pull_request:
+    paths:
+      - "**/*.c"
+      - "**/*.h"
+      - "**/*.S"
+      - "**/*.inc"
+      - "**/*.py"
+      - "**/meson.build"
+      - "meson_options.txt"
+      - "configure"
+      - ".github/.ci/**"
+      - ".github/workflows/tests.yml"
+
+permissions:
+  contents: read
+
+# Test registration and suite selection rules are documented in tests/README.md.
+jobs:
+  meson-fast:
+    name: "test (latx-runner-debian, lat-pr-fast)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          submodules: true
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Run fast Meson tests
+        run: |
+          docker run --rm \
+            --platform linux/loong64 \
+            --volume "$(pwd):/io" \
+            --workdir /io \
+            ghcr.io/lat-opensource/latx-runner-debian:loong64 \
+            sh -eux -c '
+              export CFLAGS="-Wno-error=unused-but-set-variable -Wno-error=unused-function -Wformat -Werror=format-y2k"
+              mkdir -p build64-tests
+              cd build64-tests
+              ../configure \
+                --target-list=x86_64-linux-user \
+                --enable-latx \
+                --enable-debug \
+                --enable-tests \
+                --enable-sanitizers \
+                --disable-werror \
+                --optimize-O1 \
+                --extra-ldflags=-ldl \
+                --disable-docs \
+                --with-git-submodules=ignore
+              cd ..
+              ASAN_OPTIONS=detect_leaks=0 \
+              UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 \
+                python3 -B meson/meson.py test \
+                  -C build64-tests \
+                  --suite lat-pr-fast \
+                  --print-errorlogs
+            '

--- a/meson.build
+++ b/meson.build
@@ -598,7 +598,7 @@ foreach target : target_dirs
         'target/i386/latx/sbt/smc_reload.c',
         'target/i386/latx/sbt/aot_smc_reload.c',
         'accel/tcg/tb-jump.c'
-      ) + genh,
+      ) + genh + tcg_trace_genh,
       c_args: smc_reload_test_c_args,
       dependencies: [glib],
       include_directories: target_inc,
@@ -618,7 +618,7 @@ foreach target : target_dirs
         'target/i386/latx/sbt/aot_smc_reload.c',
         'accel/tcg/tb-jump.c',
         'util/pagesize.c'
-      ) + genh,
+      ) + genh + tcg_trace_genh,
       c_args: smc_reload_test_c_args,
       dependencies: [glib],
       include_directories: target_inc,
@@ -636,7 +636,7 @@ foreach target : target_dirs
         'target/i386/latx/sbt/tests/tb-flush-smc-reload-async-test.c',
         'target/i386/latx/sbt/smc_reload.c',
         'accel/tcg/tb-flush.c'
-      ) + genh,
+      ) + genh + tcg_trace_genh,
       c_args: smc_reload_test_c_args,
       dependencies: [glib],
       include_directories: target_inc,
@@ -653,7 +653,7 @@ foreach target : target_dirs
       files(
         'target/i386/latx/sbt/tests/aot-file-publish-test.c',
         'target/i386/latx/sbt/file_ctx.c'
-      ) + genh,
+      ) + genh + tcg_trace_genh,
       c_args: smc_reload_test_c_args,
       dependencies: [glib],
       include_directories: target_inc,
@@ -674,7 +674,7 @@ foreach target : target_dirs
         'target/i386/latx/sbt/tests/aot-pe-load-address-test.c',
         'target/i386/latx/sbt/segment.c',
         'target/i386/latx/sbt/aot_lib.c'
-      ) + genh,
+      ) + genh + tcg_trace_genh,
       c_args: smc_reload_test_c_args,
       dependencies: [glib],
       include_directories: target_inc,

--- a/meson.build
+++ b/meson.build
@@ -526,6 +526,7 @@ foreach target : target_dirs
   arch = config_target['TARGET_BASE_ARCH']
   arch_srcs = [config_target_h[target]]
   arch_deps = []
+  syscall_nr_generated = []
   c_args = ['-DNEED_CPU_H',
             '-DCONFIG_TARGET="@0@-config-target.h"'.format(target),
             '-DCONFIG_DEVICES="@0@-config-devices.h"'.format(target)]
@@ -546,9 +547,12 @@ foreach target : target_dirs
       dir = base_dir / abi
       arch_srcs += files(dir / 'signal.c', dir / 'cpu_loop.c')
       if config_target.has_key('TARGET_SYSTBL_ABI')
-        arch_srcs += \
-          syscall_nr_generators[abi].process(base_dir / abi / config_target['TARGET_SYSTBL'],
-                                             extra_args : config_target['TARGET_SYSTBL_ABI'])
+        syscall_nr_generated = \
+          syscall_nr_generators[abi].process(
+            base_dir / abi / config_target['TARGET_SYSTBL'],
+            extra_args : config_target['TARGET_SYSTBL_ABI']
+          )
+        arch_srcs += syscall_nr_generated
       endif
     if 'CONFIG_LATX' in config_host
       if config_host['ARCH'] in ['loongarch64', 'loongarch']
@@ -598,7 +602,7 @@ foreach target : target_dirs
         'target/i386/latx/sbt/smc_reload.c',
         'target/i386/latx/sbt/aot_smc_reload.c',
         'accel/tcg/tb-jump.c'
-      ) + genh + tcg_trace_genh,
+      ) + genh + tcg_trace_genh + syscall_nr_generated,
       c_args: smc_reload_test_c_args,
       dependencies: [glib],
       include_directories: target_inc,
@@ -618,7 +622,7 @@ foreach target : target_dirs
         'target/i386/latx/sbt/aot_smc_reload.c',
         'accel/tcg/tb-jump.c',
         'util/pagesize.c'
-      ) + genh + tcg_trace_genh,
+      ) + genh + tcg_trace_genh + syscall_nr_generated,
       c_args: smc_reload_test_c_args,
       dependencies: [glib],
       include_directories: target_inc,
@@ -636,7 +640,7 @@ foreach target : target_dirs
         'target/i386/latx/sbt/tests/tb-flush-smc-reload-async-test.c',
         'target/i386/latx/sbt/smc_reload.c',
         'accel/tcg/tb-flush.c'
-      ) + genh + tcg_trace_genh,
+      ) + genh + tcg_trace_genh + syscall_nr_generated,
       c_args: smc_reload_test_c_args,
       dependencies: [glib],
       include_directories: target_inc,
@@ -653,7 +657,7 @@ foreach target : target_dirs
       files(
         'target/i386/latx/sbt/tests/aot-file-publish-test.c',
         'target/i386/latx/sbt/file_ctx.c'
-      ) + genh + tcg_trace_genh,
+      ) + genh + tcg_trace_genh + syscall_nr_generated,
       c_args: smc_reload_test_c_args,
       dependencies: [glib],
       include_directories: target_inc,
@@ -674,7 +678,7 @@ foreach target : target_dirs
         'target/i386/latx/sbt/tests/aot-pe-load-address-test.c',
         'target/i386/latx/sbt/segment.c',
         'target/i386/latx/sbt/aot_lib.c'
-      ) + genh + tcg_trace_genh,
+      ) + genh + tcg_trace_genh + syscall_nr_generated,
       c_args: smc_reload_test_c_args,
       dependencies: [glib],
       include_directories: target_inc,

--- a/meson.build
+++ b/meson.build
@@ -604,7 +604,11 @@ foreach target : target_dirs
       include_directories: target_inc,
       link_args: smc_reload_test_link_args
     )
-    test('latx-smc-reload-tu', smc_reload_tu_test)
+    test(
+      'latx-smc-reload-tu',
+      smc_reload_tu_test,
+      suite: 'lat-pr-fast',
+    )
 
     smc_reload_guest_base_test = executable(
       'test-latx-smc-reload-guest-base',
@@ -620,7 +624,11 @@ foreach target : target_dirs
       include_directories: target_inc,
       link_args: smc_reload_test_link_args + ['-Wl,--wrap=mprotect']
     )
-    test('latx-smc-reload-guest-base', smc_reload_guest_base_test)
+    test(
+      'latx-smc-reload-guest-base',
+      smc_reload_guest_base_test,
+      suite: 'lat-pr-fast',
+    )
 
     smc_reload_async_flush_test = executable(
       'test-latx-tb-flush-smc-reload-async',
@@ -634,7 +642,11 @@ foreach target : target_dirs
       include_directories: target_inc,
       link_args: smc_reload_test_link_args
     )
-    test('latx-tb-flush-smc-reload-async', smc_reload_async_flush_test)
+    test(
+      'latx-tb-flush-smc-reload-async',
+      smc_reload_async_flush_test,
+      suite: 'lat-pr-fast',
+    )
 
     aot_file_publish_test = executable(
       'test-latx-aot-file-publish',
@@ -650,7 +662,11 @@ foreach target : target_dirs
         '-Wl,--wrap=rename'
       ]
     )
-    test('latx-aot-file-publish', aot_file_publish_test)
+    test(
+      'latx-aot-file-publish',
+      aot_file_publish_test,
+      suite: 'lat-pr-fast',
+    )
 
     aot_pe_load_address_test = executable(
       'test-latx-aot-pe-load-address',
@@ -664,7 +680,11 @@ foreach target : target_dirs
       include_directories: target_inc,
       link_args: smc_reload_test_link_args
     )
-    test('latx-aot-pe-load-address', aot_pe_load_address_test)
+    test(
+      'latx-aot-pe-load-address',
+      aot_pe_load_address_test,
+      suite: 'lat-pr-fast',
+    )
   endif
 
     execs = [{

--- a/meson.build
+++ b/meson.build
@@ -598,7 +598,7 @@ foreach target : target_dirs
         'target/i386/latx/sbt/smc_reload.c',
         'target/i386/latx/sbt/aot_smc_reload.c',
         'accel/tcg/tb-jump.c'
-      ),
+      ) + genh,
       c_args: smc_reload_test_c_args,
       dependencies: [glib],
       include_directories: target_inc,
@@ -618,7 +618,7 @@ foreach target : target_dirs
         'target/i386/latx/sbt/aot_smc_reload.c',
         'accel/tcg/tb-jump.c',
         'util/pagesize.c'
-      ),
+      ) + genh,
       c_args: smc_reload_test_c_args,
       dependencies: [glib],
       include_directories: target_inc,
@@ -636,7 +636,7 @@ foreach target : target_dirs
         'target/i386/latx/sbt/tests/tb-flush-smc-reload-async-test.c',
         'target/i386/latx/sbt/smc_reload.c',
         'accel/tcg/tb-flush.c'
-      ),
+      ) + genh,
       c_args: smc_reload_test_c_args,
       dependencies: [glib],
       include_directories: target_inc,
@@ -653,7 +653,7 @@ foreach target : target_dirs
       files(
         'target/i386/latx/sbt/tests/aot-file-publish-test.c',
         'target/i386/latx/sbt/file_ctx.c'
-      ),
+      ) + genh,
       c_args: smc_reload_test_c_args,
       dependencies: [glib],
       include_directories: target_inc,
@@ -674,7 +674,7 @@ foreach target : target_dirs
         'target/i386/latx/sbt/tests/aot-pe-load-address-test.c',
         'target/i386/latx/sbt/segment.c',
         'target/i386/latx/sbt/aot_lib.c'
-      ),
+      ) + genh,
       c_args: smc_reload_test_c_args,
       dependencies: [glib],
       include_directories: target_inc,

--- a/target/i386/latx/sbt/tests/aot-pe-load-address-test.c
+++ b/target/i386/latx/sbt/tests/aot-pe-load-address-test.c
@@ -5,6 +5,8 @@
 #include "segment.h"
 
 int qemu_loglevel;
+int option_aot_pe_profile;
+const char *aot_process_profile = "browser";
 
 int qemu_log(const char *fmt G_GNUC_UNUSED, ...)
 {

--- a/tests/README.md
+++ b/tests/README.md
@@ -53,6 +53,8 @@ test_program = executable(
 ```
 
 If those headers also include TCG trace helpers, add `tcg_trace_genh` as well.
+Tests that include generated Linux-user syscall headers must also add the
+target's `syscall_nr_generated` sources.
 
 ## Run the suites
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,62 @@
+# LAT Meson tests
+
+LAT tests are registered with Meson and are configured only when
+`--enable-tests` is passed to `configure`.
+
+## Choose a test suite
+
+- `lat-pr-fast`: deterministic, self-contained regression tests that need no
+  network access, elevated privileges, namespaces, or other special host
+  setup. These tests must be fast enough to run on every pull request.
+- `latx-integration`: tests that depend on kernel features, namespaces,
+  external programs, special host setup, or substantially longer execution
+  time. These tests are not part of the fast pull-request gate.
+
+Do not add a test-specific GitHub Actions step or target. Register the test in
+the appropriate suite; the workflow selects the suite automatically.
+
+## Register a test
+
+Put ordinary unit tests in `tests/unit/meson.build` and environment-dependent
+tests in `tests/integration/meson.build`. A test that must use target-specific
+build objects may be registered in the top-level `meson.build`, guarded by
+`get_option('tests').enabled()`.
+
+For example:
+
+```meson
+test_program = executable(
+  'test-example',
+  files('test-example.c'),
+  dependencies: glib,
+)
+
+test(
+  'example',
+  test_program,
+  suite: 'lat-pr-fast',
+  timeout: 30,
+)
+```
+
+Use `suite: 'latx-integration'` instead when the test needs special host
+facilities.
+
+## Run the suites
+
+Configure the build with `--enable-tests`, then run:
+
+```sh
+python3 -B meson/meson.py test \
+  -C build64-tests \
+  --suite lat-pr-fast \
+  --print-errorlogs
+```
+
+To run the integration suite, replace `lat-pr-fast` with
+`latx-integration`.
+
+Before submitting a new test target, verify both of these:
+
+1. A normal product build without `--enable-tests` does not build the test.
+2. A build configured with `--enable-tests` builds and runs the selected suite.

--- a/tests/README.md
+++ b/tests/README.md
@@ -52,6 +52,8 @@ test_program = executable(
 )
 ```
 
+If those headers also include TCG trace helpers, add `tcg_trace_genh` as well.
+
 ## Run the suites
 
 Configure the build with `--enable-tests`, then run:

--- a/tests/README.md
+++ b/tests/README.md
@@ -42,6 +42,16 @@ test(
 Use `suite: 'latx-integration'` instead when the test needs special host
 facilities.
 
+If the test includes QEMU headers that refer to generated QAPI headers, add
+`genh` to the executable sources so Meson records the generator dependency:
+
+```meson
+test_program = executable(
+  'test-example',
+  files('test-example.c') + genh,
+)
+```
+
 ## Run the suites
 
 Configure the build with `--enable-tests`, then run:

--- a/tests/integration/meson.build
+++ b/tests/integration/meson.build
@@ -8,6 +8,7 @@ if host_machine.cpu_family() == 'loongarch64' and \
       files('cef-userns-nested.S'),
     ],
     protocol: 'exitcode',
+    suite: 'latx-integration',
     timeout: 30,
   )
   test(
@@ -18,6 +19,7 @@ if host_machine.cpu_family() == 'loongarch64' and \
       files('cef-userns-exec.S'),
     ],
     protocol: 'exitcode',
+    suite: 'latx-integration',
     timeout: 30,
   )
 endif

--- a/tests/unit/meson.build
+++ b/tests/unit/meson.build
@@ -5,7 +5,11 @@ test_elfload_pagesize = executable(
   dependencies: glib,
 )
 
-test('test-elfload-pagesize', test_elfload_pagesize)
+test(
+  'test-elfload-pagesize',
+  test_elfload_pagesize,
+  suite: 'lat-pr-fast',
+)
 
 test_exclusive_timeout = executable(
   'test-exclusive-timeout',
@@ -15,4 +19,8 @@ test_exclusive_timeout = executable(
   dependencies: [glib, qemuutil, qom],
 )
 
-test('test-exclusive-timeout', test_exclusive_timeout)
+test(
+  'test-exclusive-timeout',
+  test_exclusive_timeout,
+  suite: 'lat-pr-fast',
+)

--- a/trace/meson.build
+++ b/trace/meson.build
@@ -61,6 +61,7 @@ trace_events_all = custom_target('trace-events-all',
                                  install: false,
                                  install_dir: qemu_datadir)
 
+tcg_trace_genh = []
 foreach d : [
   ['generated-tcg-tracers.h', 'tcg-h'],
   ['generated-helpers.c', 'tcg-helper-c'],
@@ -73,6 +74,9 @@ foreach d : [
                 command: [ tracetool, '--group=root', '--format=@0@'.format(d[1]), '@INPUT@', '@OUTPUT@' ],
                 depend_files: tracetool_depends)
   specific_ss.add(when: 'CONFIG_TCG', if_true: gen)
+  if d[0].endswith('.h')
+    tcg_trace_genh += gen
+  endif
 endforeach
 
 if 'CONFIG_TRACE_UST' in config_host


### PR DESCRIPTION
## Summary / 变更说明

- Classify seven deterministic Meson tests as `lat-pr-fast`.
- Keep the two namespace-dependent CEF tests in `latx-integration`.
- Document how contributors choose a suite, register a test, and run it locally.
- Add a pull-request workflow that runs the fast suite in the LoongArch Debian container using the repository's vendored `meson/meson.py`.

New tests join CI by selecting the appropriate Meson suite; contributors do not need to add test-specific workflow targets.

## Validation / 验证

- `git diff --check`
- Parsed `.github/workflows/tests.yml` successfully.
- Checked the outer GitHub Actions shell and inner container shell syntax.
- Verified seven `lat-pr-fast` registrations and two `latx-integration` registrations.
- Runtime LoongArch CI validation is delegated to this PR; no local LoongArch build or test run was performed.

## Checklist / 检查项

- [x] I have read `CONTRIBUTING.md`. / 我已阅读 `CONTRIBUTING.md`。
- [x] Every commit contains a DCO sign-off (`git commit -s`). / 每个提交都包含 DCO 签署（`git commit -s`）。
- [x] I have included relevant build or test results, or explained why they are not applicable. / 我已提供相关构建或测试结果，或说明了不适用的原因。