### PR TITLE
LATX, fix: Keep procfs outside the runtime prefix

### DIFF
--- a/tests/integration/meson.build
+++ b/tests/integration/meson.build
@@ -22,4 +22,15 @@ if host_machine.cpu_family() == 'loongarch64' and \
     suite: 'latx-integration',
     timeout: 30,
   )
+  test(
+    'test-proc-readdir',
+    find_program('test-proc-readdir.sh'),
+    args: [
+      emulators['latx-x86_64'],
+      files('proc-readdir.S'),
+    ],
+    protocol: 'exitcode',
+    suite: 'latx-integration',
+    timeout: 30,
+  )
 endif

--- a/tests/integration/proc-readdir.S
+++ b/tests/integration/proc-readdir.S
@@ -1,0 +1,88 @@
+.equ __NR_close, 3
+.equ __NR_exit_group, 231
+.equ __NR_getdents64, 217
+.equ __NR_openat, 257
+.equ AT_FDCWD, -100
+.equ O_DIRECTORY, 0x10000
+
+.section .rodata
+proc_path:
+    .asciz "/proc"
+
+.section .bss
+.align 16
+dirents:
+    .space 32768
+
+.section .text
+.global _start
+.type _start, @function
+_start:
+    mov $__NR_openat, %eax
+    mov $AT_FDCWD, %edi
+    lea proc_path(%rip), %rsi
+    mov $O_DIRECTORY, %edx
+    xor %r10d, %r10d
+    syscall
+    test %rax, %rax
+    js open_failed
+    mov %eax, %r12d
+
+read_dirents:
+    mov $__NR_getdents64, %eax
+    mov %r12d, %edi
+    lea dirents(%rip), %rsi
+    mov $32768, %edx
+    syscall
+    test %rax, %rax
+    js getdents_failed
+    jz no_numeric_entry
+
+    lea dirents(%rip), %r13
+    lea (%r13,%rax), %r14
+
+scan_dirents:
+    cmp %r14, %r13
+    jae read_dirents
+    movzwl 16(%r13), %ebx
+    cmp $19, %ebx
+    jbe malformed_dirent
+    movzbl 19(%r13), %ecx
+    cmp $'1', %cl
+    jb next_dirent
+    cmp $'9', %cl
+    jbe found_numeric_entry
+
+next_dirent:
+    add %rbx, %r13
+    jmp scan_dirents
+
+found_numeric_entry:
+    mov %r12d, %edi
+    mov $__NR_close, %eax
+    syscall
+    xor %edi, %edi
+    jmp exit
+
+open_failed:
+    mov $10, %edi
+    jmp exit
+
+getdents_failed:
+    mov $11, %edi
+    jmp exit
+
+no_numeric_entry:
+    mov $12, %edi
+    jmp exit
+
+malformed_dirent:
+    mov $13, %edi
+
+exit:
+    mov $__NR_exit_group, %eax
+    syscall
+    hlt
+.size _start, .-_start
+
+.section .note.GNU-stack,"",@progbits

--- a/tests/integration/test-proc-readdir.sh
+++ b/tests/integration/test-proc-readdir.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+set -eu
+
+emulator=$1
+source_file=$2
+workdir=$(mktemp -d)
+trap 'rm -rf "$workdir"' EXIT HUP INT TERM
+
+runtime_prefix="$workdir/runtime"
+mkdir -p "$runtime_prefix/proc"
+
+if command -v clang-19 >/dev/null 2>&1; then
+    clang=clang-19
+elif command -v clang >/dev/null 2>&1; then
+    clang=clang
+else
+    echo "SKIP: clang is required to build the x86_64 guest"
+    exit 77
+fi
+
+"$clang" --target=x86_64-linux-gnu -fuse-ld=lld -nostdlib -static -no-pie \
+    -Wl,--build-id=none "$source_file" -o "$workdir/proc-readdir"
+
+unset LATX_AOT LATX_TU LATX_KZT
+
+run_case()
+{
+    label=$1
+    shift
+
+    set +e
+    "$@" "$emulator" -L "$runtime_prefix" "$workdir/proc-readdir"
+    ret=$?
+    set -e
+
+    case $ret in
+    0)
+        echo "PASS: $label enumerated a numeric /proc entry"
+        ;;
+    10)
+        echo "FAIL: $label could not open /proc" >&2
+        ;;
+    11)
+        echo "FAIL: $label getdents64 failed" >&2
+        ;;
+    12)
+        echo "FAIL: $label found no numeric /proc entry" >&2
+        ;;
+    13)
+        echo "FAIL: $label received a malformed dirent" >&2
+        ;;
+    *)
+        echo "FAIL: $label returned unexpected status $ret" >&2
+        ;;
+    esac
+
+    if [ "$ret" -ne 0 ]; then
+        exit "$ret"
+    fi
+}
+
+run_case default env
+run_case non-tu env LATX_AOT=0 LATX_TU=0
+run_case tu env LATX_AOT=0 LATX_TU=1

--- a/tests/unit/meson.build
+++ b/tests/unit/meson.build
@@ -24,3 +24,18 @@ test(
   test_exclusive_timeout,
   suite: 'lat-pr-fast',
 )
+
+if 'CONFIG_LATX' in config_host
+  test_util_path = executable(
+    'test-util-path',
+    files('test-util-path.c'),
+    dependencies: [glib, qemuutil],
+    build_by_default: false,
+  )
+
+  test(
+    'test-util-path',
+    test_util_path,
+    suite: 'lat-pr-fast',
+  )
+endif

--- a/tests/unit/test-util-path.c
+++ b/tests/unit/test-util-path.c
@@ -1,0 +1,156 @@
+#include "qemu/osdep.h"
+#include <glib/gstdio.h>
+
+#include "qemu/path.h"
+
+static char *prefix;
+
+static char *create_prefixed_file(const char *name)
+{
+    char *full = g_build_filename(prefix, name, NULL);
+    char *parent = g_path_get_dirname(full);
+    GError *error = NULL;
+
+    g_assert_cmpint(g_mkdir_with_parents(parent, 0700), ==, 0);
+    g_assert_true(g_file_set_contents(full, "", 0, &error));
+    g_assert_no_error(error);
+    g_free(parent);
+    return full;
+}
+
+static void remove_tree(const char *name)
+{
+    GDir *directory = g_dir_open(name, 0, NULL);
+    const char *entry;
+
+    g_assert_nonnull(directory);
+    while ((entry = g_dir_read_name(directory))) {
+        char *child = g_build_filename(name, entry, NULL);
+
+        if (g_file_test(child, G_FILE_TEST_IS_DIR)) {
+            remove_tree(child);
+        } else {
+            g_assert_cmpint(g_remove(child), ==, 0);
+        }
+        g_free(child);
+    }
+    g_dir_close(directory);
+    g_assert_cmpint(g_rmdir(name), ==, 0);
+}
+
+static void test_regular_path_uses_prefix(void)
+{
+    const char *names[] = {
+        "/dev/null",
+        "/home/guest",
+        "/lib/guest.so",
+        "/run/user/1000/bus",
+        "/sys/devices/system/cpu/online",
+        "/tmp/guest",
+        "/var/lock/guest.lock",
+        "/var/run/guest.sock",
+    };
+    size_t i;
+
+    for (i = 0; i < ARRAY_SIZE(names); i++) {
+        char *expected = g_build_filename(prefix, names[i], NULL);
+
+        g_assert_cmpstr(path(names[i]), ==, expected);
+        g_free(expected);
+    }
+}
+
+static void test_proc_namespace_ignores_prefix(void)
+{
+    const char *names[] = {
+        "/proc",
+        "/proc/self/status",
+    };
+    size_t i;
+
+    for (i = 0; i < ARRAY_SIZE(names); i++) {
+        g_assert_cmpstr(path(names[i]), ==, names[i]);
+    }
+}
+
+static void test_proc_namespace_boundaries(void)
+{
+    const char *similar_names[] = {
+        "/procedure",
+    };
+    char *escaped = g_build_filename(prefix, "proc", "..", "lib",
+                                     "guest.so", NULL);
+    char *indirect_proc = g_build_filename(prefix, "lib", "..", "proc",
+                                           "self", "status", NULL);
+    char *indirect_run = g_build_filename(prefix, "var", "tmp", "..", "run",
+                                          "guest.sock", NULL);
+    char *var_tmp = g_build_filename(prefix, "var", "run", "..", "tmp",
+                                     "guest", NULL);
+    size_t i;
+
+    g_assert_cmpstr(path("/proc/"), ==, "/proc/");
+    g_assert_cmpstr(path("/proc///./self/status"), ==,
+                    "/proc///./self/status");
+    g_assert_cmpstr(path("/lib/../proc/self/status"), ==, indirect_proc);
+    g_assert_cmpstr(path("/var/tmp/../run/guest.sock"), ==, indirect_run);
+    g_assert_cmpstr(path("/proc/../lib/guest.so"), ==, escaped);
+    g_assert_cmpstr(path("/var/run/../tmp/guest"), ==, var_tmp);
+
+    for (i = 0; i < ARRAY_SIZE(similar_names); i++) {
+        char *expected = g_build_filename(prefix, similar_names[i], NULL);
+
+        g_assert_cmpstr(path(similar_names[i]), ==, expected);
+        g_free(expected);
+    }
+
+    g_free(var_tmp);
+    g_free(indirect_run);
+    g_free(indirect_proc);
+    g_free(escaped);
+}
+
+int main(int argc, char **argv)
+{
+    GError *error = NULL;
+    const char *files[] = {
+        "dev/null",
+        "home/guest",
+        "lib/guest.so",
+        "proc/self/status",
+        "procedure",
+        "run/guest.sock",
+        "run/user/1000/bus",
+        "sys/devices/system/cpu/online",
+        "tmp/guest",
+        "var/lock/guest.lock",
+        "var/run/guest.sock",
+        "var/tmp/guest",
+    };
+    size_t i;
+    int ret;
+
+    g_test_init(&argc, &argv, NULL);
+
+    prefix = g_dir_make_tmp("test-util-path-XXXXXX", &error);
+    g_assert_no_error(error);
+    g_assert_nonnull(prefix);
+
+    for (i = 0; i < ARRAY_SIZE(files); i++) {
+        g_free(create_prefixed_file(files[i]));
+    }
+    init_paths(prefix);
+
+    g_test_add_func("/util/path/regular-uses-prefix",
+                    test_regular_path_uses_prefix);
+    g_test_add_func("/util/path/proc-namespace-ignores-prefix",
+                    test_proc_namespace_ignores_prefix);
+    g_test_add_func("/util/path/proc-namespace-boundaries",
+                    test_proc_namespace_boundaries);
+
+    ret = g_test_run();
+
+    remove_tree(prefix);
+    g_free(prefix);
+
+    return ret;
+}

--- a/util/path.c
+++ b/util/path.c
@@ -14,6 +14,32 @@ static const char *base;
 static GHashTable *hash;
 static QemuMutex lock;
 
+#ifdef CONFIG_LATX
+static bool path_is_proc_namespace(const char *name)
+{
+    static const char proc_root[] = "/proc";
+    const char *component;
+    size_t length = sizeof(proc_root) - 1;
+
+    if (strncmp(name, proc_root, length) ||
+        (name[length] && name[length] != '/')) {
+        return false;
+    }
+
+    component = name + length;
+    while (*component) {
+        component += strspn(component, "/");
+        if (component[0] == '.' && component[1] == '.' &&
+            (component[2] == '\0' || component[2] == '/')) {
+            return false;
+        }
+        component += strcspn(component, "/");
+    }
+
+    return true;
+}
+#endif
+
 void init_paths(const char *prefix)
 {
     if (prefix[0] == '\0' || !strcmp(prefix, "/")) {
@@ -43,6 +69,17 @@ const char *path(const char *name)
             || (name[0]  == '/' && name[1] == '\0')) {
         return name;
     }
+
+#ifdef CONFIG_LATX
+    /*
+     * LAT's packaged x86 runtime may contain an inert /proc mount point.
+     * Resolve procfs in the calling task's current namespace instead of
+     * letting that directory shadow the live filesystem.
+     */
+    if (path_is_proc_namespace(name)) {
+        return name;
+    }
+#endif
 
     qemu_mutex_lock(&lock);
 


### PR DESCRIPTION
## Summary

- keep `/proc` paths outside the packaged x86 runtime prefix
- resolve procfs through the calling task's current namespace
- reject parent traversal before bypassing the prefix
- add focused path-policy and syscall regression coverage

Fixes #359.

## Root cause

The x86 runtime prefix can contain an inert `/proc` mount-point directory.
The prefix lookup therefore treats `/proc` as a runtime path, and
`getdents64()` correctly enumerates that empty directory instead of the live
procfs.

The change is intentionally limited to `/proc`; `/dev`, `/sys`, `/run`,
`/tmp`, and other runtime-prefix paths retain their existing behavior.

## Validation

Local checks:

- `git diff --check`
- shell syntax check for the integration runner
- checkpatch for the new C and assembly tests
- deterministic regression setup using `-L` with an explicitly empty runtime
  `/proc`

CI:

- DCO passed
- `lat-pr-fast` passed
- all AOSC, Debian, and Fedora LoongArch build jobs passed

Reporter validation on LoongArch 3A6000 using commit `5857652989a`:

- `latx-x86_64` built successfully
- PR regression test passed in default, non-TU, and TU modes
- original C reproducer passed in all three LATX modes
- explicit empty runtime-prefix `/proc` reproducer passed in all three modes

Original reproducer results:

| Mode | `/proc` entries | `/tmp` entries | Exit |
|---|---:|---:|---:|
| Native | 338 | 90 | 0 |
| LATX default | 338 | 57 | 0 |
| LATX `LATX_AOT=0 LATX_TU=0` | 339 | 57 | 0 |
| LATX `LATX_AOT=0 LATX_TU=1` | 339 | 57 | 0 |

See the [target validation result](https://github.com/lat-opensource/lat/issues/359#issuecomment-5141426744).
