### PR TITLE
LATX, fix: preserve namespace isolation across clone and setns

### DIFF
--- a/linux-user/qemu.h
+++ b/linux-user/qemu.h
@@ -122,6 +122,8 @@ typedef struct TaskState {
     uint32_t v86flags;
     uint32_t v86mask;
     abi_ulong child_tidptr;
+    /* A detached helper must not outlive an isolated IPC namespace. */
+    bool ipc_namespace_isolated;
     /* Immutable seccomp filter chain inherited by guest threads. */
     struct GuestSeccompFilter *seccomp_filter;
 #ifdef TARGET_M68K

--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -17852,7 +17852,23 @@ defined(__loongarch__)
 
 #if defined(TARGET_NR_setns) && defined(CONFIG_SETNS)
     case TARGET_NR_setns:
-        return get_errno(setns(arg1, arg2));
+        {
+            bool joins_ipc_namespace = (arg2 & CLONE_NEWIPC) != 0;
+
+            if (arg2 == 0) {
+                int namespace_type = ioctl(arg1, NS_GET_NSTYPE);
+
+                if (namespace_type >= 0) {
+                    joins_ipc_namespace = namespace_type == CLONE_NEWIPC;
+                }
+            }
+
+            ret = get_errno(setns(arg1, arg2));
+            if (ret == 0 && joins_ipc_namespace) {
+                ((TaskState *)cpu->opaque)->ipc_namespace_isolated = true;
+            }
+            return ret;
+        }
 #endif
 #ifdef TARGET_NR_seccomp
     case TARGET_NR_seccomp:

--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -435,10 +435,12 @@ static void latx_wine_pe_prefer_image_base(int fd, void *buffer, abi_long len)
 
 /* Flags for fork which we can implement within QEMU itself */
 #define CLONE_FORK_NAMESPACE_FLAGS \
-    (CLONE_NEWUSER | CLONE_NEWPID | CLONE_NEWNET)
+    (CLONE_NEWNS | CLONE_NEWUTS | CLONE_NEWIPC | CLONE_NEWUSER | \
+     CLONE_NEWPID | CLONE_NEWNET)
 
 #define CLONE_DIRECT_FORK_FLAGS \
-    (CLONE_NEWUSER | CLONE_NEWPID | CLONE_NEWNET | CLONE_FS)
+    (CLONE_NEWNS | CLONE_NEWUTS | CLONE_NEWIPC | CLONE_NEWUSER | \
+     CLONE_NEWPID | CLONE_NEWNET | CLONE_FS)
 
 #define CLONE_OPTIONAL_FORK_FLAGS               \
     (CLONE_SETTLS | CLONE_PARENT_SETTID |       \
@@ -459,13 +461,13 @@ static void latx_wine_pe_prefer_image_base(int fd, void *buffer, abi_long len)
 
 /* CLONE_VFORK is special cased early in do_fork(). The other flag bits
  * have almost all been allocated. We cannot support any of
- * CLONE_NEWNS, CLONE_NEWCGROUP, CLONE_NEWUTS, CLONE_NEWIPC,
- * CLONE_PTRACE, CLONE_UNTRACED.
+ * CLONE_NEWCGROUP, CLONE_PTRACE, CLONE_UNTRACED.
  * The checks against the invalid thread masks above will catch these.
  * (The one remaining unallocated bit is 0x1000 which used to be CLONE_PID.)
- * Fork-like CLONE_NEWUSER is applied in the single-threaded child. PID,
- * network, and shared-fs clone flags require a deferred single-thread child
- * and use the libc clone wrapper so the kernel creates the requested state.
+ * Fork-like CLONE_NEWUSER is applied in the single-threaded child. Mount, UTS,
+ * IPC, PID, network, and shared-fs clone flags require a deferred
+ * single-thread child and use the libc clone wrapper so the kernel creates the
+ * requested state.
  */
 
 /* Define DEBUG_ERESTARTSYS to force every syscall to be restarted
@@ -9334,7 +9336,7 @@ static int do_fork(CPUArchState *env, unsigned int flags, abi_ulong newsp,
     if (flags & CLONE_VFORK)
         flags &= ~(CLONE_VFORK | CLONE_VM);
 
-    direct_fork_flags = flags & (CLONE_NEWPID | CLONE_NEWNET | CLONE_FS);
+    direct_fork_flags = flags & (CLONE_DIRECT_FORK_FLAGS & ~CLONE_NEWUSER);
     userns_via_unshare = namespace_flags == CLONE_NEWUSER &&
                          !direct_fork_flags;
 

--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -9379,6 +9379,7 @@ static int do_fork(CPUArchState *env, unsigned int flags, abi_ulong newsp,
         ts->info = parent_ts->info;
         ts->signal_mask = parent_ts->signal_mask;
         ts->seccomp_filter = parent_ts->seccomp_filter;
+        ts->ipc_namespace_isolated = parent_ts->ipc_namespace_isolated;
 
         if (flags & CLONE_CHILD_CLEARTID) {
             ts->child_tidptr = child_tidptr;
@@ -9505,6 +9506,9 @@ static int do_fork(CPUArchState *env, unsigned int flags, abi_ulong newsp,
             if (flags & CLONE_PARENT_SETTID)
                 put_user_u32(sys_gettid(), parent_tidptr);
             ts = (TaskState *)cpu->opaque;
+            if (flags & CLONE_NEWIPC) {
+                ts->ipc_namespace_isolated = true;
+            }
             if (flags & CLONE_SETTLS)
                 cpu_set_tls (env, newtls);
             if (flags & CLONE_CHILD_CLEARTID)
@@ -17857,6 +17861,9 @@ defined(__loongarch__)
 #if defined(TARGET_NR_unshare) && defined(CONFIG_SETNS)
     case TARGET_NR_unshare:
         ret = get_errno(unshare(arg1));
+        if (ret == 0 && (arg1 & CLONE_NEWIPC)) {
+            ((TaskState *)cpu->opaque)->ipc_namespace_isolated = true;
+        }
         if (arg1 & CLONE_NEWUSER) {
             rcu_start_deferred_thread();
         }

--- a/meson.build
+++ b/meson.build
@@ -688,6 +688,22 @@ foreach target : target_dirs
       suite: 'lat-pr-fast',
     )
 
+    aot_exit_worker_test = executable(
+      'test-latx-aot-exit-worker',
+      files(
+        'target/i386/latx/sbt/tests/aot-exit-worker-test.c'
+      ) + genh + tcg_trace_genh + syscall_nr_generated,
+      c_args: smc_reload_test_c_args,
+      dependencies: [glib],
+      include_directories: target_inc,
+      link_args: smc_reload_test_link_args
+    )
+    test(
+      'latx-aot-exit-worker',
+      aot_exit_worker_test,
+      suite: 'lat-pr-fast',
+    )
+
     aot_pe_load_address_test = executable(
       'test-latx-aot-pe-load-address',
       files(

--- a/target/i386/latx/include/aot_exit.h
+++ b/target/i386/latx/include/aot_exit.h
@@ -1,0 +1,15 @@
+/*
+ * SPDX-License-Identifier: GPL-2.0-only
+ *
+ * AOT exit worker policy.
+ */
+#ifndef LATX_AOT_EXIT_H
+#define LATX_AOT_EXIT_H
+
+static inline bool aot_exit_worker_should_daemonize(
+    bool ipc_namespace_isolated)
+{
+    return !ipc_namespace_isolated;
+}
+
+#endif

--- a/target/i386/latx/sbt/aot.c
+++ b/target/i386/latx/sbt/aot.c
@@ -13,6 +13,7 @@
 #include "qemu-def.h"
 #include "segment.h"
 #include "aot.h"
+#include "aot_exit.h"
 #include <stdlib.h>
 #include <math.h>
 #include "latx-options.h"
@@ -1848,6 +1849,10 @@ static void creat_daemon(bool is_end)
 
 void aot_exit_entry(CPUState *cpu, AOTExitReason reason)
 {
+    TaskState *ts = cpu->opaque;
+    bool daemonize = aot_exit_worker_should_daemonize(
+        ts && ts->ipc_namespace_isolated);
+
     if (!option_aot) {
         return;
     }
@@ -1931,7 +1936,11 @@ parent_exit:
         return;
     }
 
-    creat_daemon(reason == AOT_EXIT_FINAL);
+    if (daemonize) {
+        creat_daemon(reason == AOT_EXIT_FINAL);
+    } else {
+        close_all_fd();
+    }
 
     aot_generate(cpu);
     _exit(EXIT_SUCCESS);

--- a/target/i386/latx/sbt/tests/aot-exit-worker-test.c
+++ b/target/i386/latx/sbt/tests/aot-exit-worker-test.c
@@ -1,0 +1,13 @@
+/*
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+#include "qemu/osdep.h"
+
+#include "aot_exit.h"
+
+int main(void)
+{
+    g_assert(aot_exit_worker_should_daemonize(false));
+    g_assert(!aot_exit_worker_should_daemonize(true));
+    return 0;
+}

--- a/tests/integration/clone-namespaces.S
+++ b/tests/integration/clone-namespaces.S
@@ -1,0 +1,158 @@
+.equ __NR_newfstatat, 262
+.equ __NR_clone, 56
+.equ __NR_wait4, 61
+.equ __NR_exit, 60
+.equ AT_FDCWD, -100
+.equ CLONE_NEWNS, 0x00020000
+.equ CLONE_NEWUTS, 0x04000000
+.equ CLONE_NEWIPC, 0x08000000
+.equ CLONE_NEWUSER, 0x10000000
+.equ CLONE_NEWNS_IPC_UTS, (CLONE_NEWNS | CLONE_NEWIPC | CLONE_NEWUTS)
+.equ CLONE_NAMESPACE_FLAGS, (CLONE_NEWUSER | CLONE_NEWNS_IPC_UTS)
+.equ SIGCHLD, 17
+
+.section .rodata
+mnt_ns:
+    .asciz "/proc/self/ns/mnt"
+ipc_ns:
+    .asciz "/proc/self/ns/ipc"
+uts_ns:
+    .asciz "/proc/self/ns/uts"
+
+.section .bss
+.align 8
+parent_mnt_stat:
+    .space 144
+parent_ipc_stat:
+    .space 144
+parent_uts_stat:
+    .space 144
+child_stat:
+    .space 144
+status:
+    .long 0
+
+.section .text
+.global _start
+.type _start, @function
+_start:
+    lea mnt_ns(%rip), %rsi
+    lea parent_mnt_stat(%rip), %rdx
+    call stat_namespace
+    test %rax, %rax
+    js parent_stat_failed
+
+    lea ipc_ns(%rip), %rsi
+    lea parent_ipc_stat(%rip), %rdx
+    call stat_namespace
+    test %rax, %rax
+    js parent_stat_failed
+
+    lea uts_ns(%rip), %rsi
+    lea parent_uts_stat(%rip), %rdx
+    call stat_namespace
+    test %rax, %rax
+    js parent_stat_failed
+
+    mov $__NR_clone, %eax
+    mov $(CLONE_NAMESPACE_FLAGS | SIGCHLD), %edi
+    xor %esi, %esi
+    xor %edx, %edx
+    xor %r10d, %r10d
+    xor %r8d, %r8d
+    syscall
+    test %rax, %rax
+    js clone_failed
+    jz child
+
+    mov %rax, %rdi
+    lea status(%rip), %rsi
+    xor %edx, %edx
+    xor %r10d, %r10d
+    mov $__NR_wait4, %eax
+    syscall
+    test %rax, %rax
+    js wait_failed
+
+    mov status(%rip), %edi
+    test $0x7f, %edi
+    jnz child_signaled
+    shr $8, %edi
+    and $0xff, %edi
+    jmp exit
+
+child:
+    lea mnt_ns(%rip), %rsi
+    lea child_stat(%rip), %rdx
+    call stat_namespace
+    test %rax, %rax
+    js child_stat_failed
+    mov parent_mnt_stat+8(%rip), %rax
+    cmp child_stat+8(%rip), %rax
+    je mnt_unchanged
+
+    lea ipc_ns(%rip), %rsi
+    lea child_stat(%rip), %rdx
+    call stat_namespace
+    test %rax, %rax
+    js child_stat_failed
+    mov parent_ipc_stat+8(%rip), %rax
+    cmp child_stat+8(%rip), %rax
+    je ipc_unchanged
+
+    lea uts_ns(%rip), %rsi
+    lea child_stat(%rip), %rdx
+    call stat_namespace
+    test %rax, %rax
+    js child_stat_failed
+    mov parent_uts_stat+8(%rip), %rax
+    cmp child_stat+8(%rip), %rax
+    je uts_unchanged
+
+    xor %edi, %edi
+    jmp exit
+
+stat_namespace:
+    mov $__NR_newfstatat, %eax
+    mov $AT_FDCWD, %edi
+    xor %r10d, %r10d
+    syscall
+    ret
+
+parent_stat_failed:
+    mov $10, %edi
+    jmp exit
+
+clone_failed:
+    mov $20, %edi
+    jmp exit
+
+child_stat_failed:
+    mov $30, %edi
+    jmp exit
+
+mnt_unchanged:
+    mov $31, %edi
+    jmp exit
+
+ipc_unchanged:
+    mov $32, %edi
+    jmp exit
+
+uts_unchanged:
+    mov $33, %edi
+    jmp exit
+
+wait_failed:
+    mov $40, %edi
+    jmp exit
+
+child_signaled:
+    mov $41, %edi
+
+exit:
+    mov $__NR_exit, %eax
+    syscall
+.size _start, .-_start
+
+.section .note.GNU-stack,"",@progbits

--- a/tests/integration/exec-with-pidfd.py
+++ b/tests/integration/exec-with-pidfd.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+import os
+import sys
+
+
+def main() -> None:
+    if len(sys.argv) != 4:
+        raise SystemExit("usage: exec-with-pidfd.py PID EMULATOR GUEST")
+
+    pidfd = os.pidfd_open(int(sys.argv[1]))
+    os.dup2(pidfd, 9, inheritable=True)
+    env = os.environ.copy()
+    env["LATX_AOT"] = "0"
+    env["LATX_KZT"] = "0"
+    os.execve(sys.argv[2], [sys.argv[2], sys.argv[3]], env)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/meson.build
+++ b/tests/integration/meson.build
@@ -33,4 +33,15 @@ if host_machine.cpu_family() == 'loongarch64' and \
     suite: 'latx-integration',
     timeout: 30,
   )
+  test(
+    'test-rcu-thread-visibility',
+    find_program('test-rcu-thread-visibility.sh'),
+    args: [
+      emulators['latx-x86_64'],
+      files('rcu-thread-visibility.S'),
+    ],
+    protocol: 'exitcode',
+    suite: 'latx-integration',
+    timeout: 30,
+  )
 endif

--- a/tests/integration/meson.build
+++ b/tests/integration/meson.build
@@ -44,4 +44,15 @@ if host_machine.cpu_family() == 'loongarch64' and \
     suite: 'latx-integration',
     timeout: 30,
   )
+  test(
+    'test-clone-namespaces',
+    find_program('test-clone-namespaces.sh'),
+    args: [
+      emulators['latx-x86_64'],
+      files('clone-namespaces.S'),
+    ],
+    protocol: 'exitcode',
+    suite: 'latx-integration',
+    timeout: 30,
+  )
 endif

--- a/tests/integration/meson.build
+++ b/tests/integration/meson.build
@@ -55,4 +55,16 @@ if host_machine.cpu_family() == 'loongarch64' and \
     suite: 'latx-integration',
     timeout: 30,
   )
+  test(
+    'test-setns-ipc-mqueue',
+    find_program('test-setns-ipc-mqueue.sh'),
+    args: [
+      emulators['latx-x86_64'],
+      files('setns-ipc-mqueue.S'),
+      files('exec-with-pidfd.py'),
+    ],
+    protocol: 'exitcode',
+    suite: 'latx-integration',
+    timeout: 30,
+  )
 endif

--- a/tests/integration/rcu-thread-visibility.S
+++ b/tests/integration/rcu-thread-visibility.S
@@ -1,0 +1,57 @@
+.equ __NR_getpid, 39
+.equ __NR_setpgid, 109
+.equ __NR_getpgid, 121
+.equ __NR_exit, 60
+.equ SCAN_LIMIT, 128
+
+.section .text
+.global _start
+.type _start, @function
+_start:
+    mov $__NR_setpgid, %eax
+    xor %edi, %edi
+    xor %esi, %esi
+    syscall
+    test %rax, %rax
+    js setup_failed
+
+    mov $__NR_getpid, %eax
+    syscall
+    mov %eax, %r12d
+
+    mov $__NR_getpgid, %eax
+    xor %edi, %edi
+    syscall
+    test %rax, %rax
+    js setup_failed
+    mov %eax, %r13d
+
+    lea 1(%r12), %r14d
+    lea SCAN_LIMIT(%r14), %r15d
+
+scan_next:
+    mov $__NR_getpgid, %eax
+    mov %r14d, %edi
+    syscall
+    cmp %r13d, %eax
+    je internal_thread_visible
+    inc %r14d
+    cmp %r15d, %r14d
+    jl scan_next
+
+    xor %edi, %edi
+    jmp exit
+
+setup_failed:
+    mov $11, %edi
+    jmp exit
+
+internal_thread_visible:
+    mov $10, %edi
+
+exit:
+    mov $__NR_exit, %eax
+    syscall
+.size _start, .-_start
+
+.section .note.GNU-stack,"",@progbits

--- a/tests/integration/setns-ipc-mqueue.S
+++ b/tests/integration/setns-ipc-mqueue.S
@@ -1,0 +1,82 @@
+.equ __NR_close, 3
+.equ __NR_mount, 165
+.equ __NR_exit_group, 231
+.equ __NR_setns, 308
+
+#ifndef SETNS_FD
+#define SETNS_FD 9
+#endif
+
+#ifndef EXPECT_SETNS_ERRNO
+#define EXPECT_SETNS_ERRNO 0
+#endif
+
+#ifndef SETNS_ONLY
+#define SETNS_ONLY 0
+#endif
+
+.section .rodata
+mq_source:
+    .asciz "mqueue"
+mq_target:
+    .asciz "mqueue"
+mq_type:
+    .asciz "mqueue"
+
+.section .text
+.global _start
+.type _start, @function
+_start:
+    mov $__NR_setns, %eax
+    mov $SETNS_FD, %edi
+    mov $SETNS_FLAGS, %esi
+    syscall
+#if EXPECT_SETNS_ERRNO
+    cmp $-EXPECT_SETNS_ERRNO, %rax
+    jne setns_error_mismatch
+    xor %edi, %edi
+    jmp exit
+#else
+    test %rax, %rax
+    js setns_failed
+
+    mov $__NR_close, %eax
+    mov $SETNS_FD, %edi
+    syscall
+
+#if SETNS_ONLY
+    xor %edi, %edi
+    jmp exit
+#endif
+
+    mov $__NR_mount, %eax
+    lea mq_source(%rip), %rdi
+    lea mq_target(%rip), %rsi
+    lea mq_type(%rip), %rdx
+    xor %r10d, %r10d
+    xor %r8d, %r8d
+    syscall
+    test %rax, %rax
+    js mount_failed
+
+    xor %edi, %edi
+    jmp exit
+#endif
+
+setns_failed:
+    mov $10, %edi
+    jmp exit
+
+setns_error_mismatch:
+    mov $11, %edi
+    jmp exit
+
+mount_failed:
+    mov $20, %edi
+
+exit:
+    mov $__NR_exit_group, %eax
+    syscall
+.size _start, .-_start
+
+.section .note.GNU-stack,"",@progbits

--- a/tests/integration/test-clone-namespaces.sh
+++ b/tests/integration/test-clone-namespaces.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+set -eu
+
+emulator=$1
+source_file=$2
+workdir=$(mktemp -d)
+trap 'rm -rf "$workdir"' EXIT HUP INT TERM
+
+if ! command -v unshare >/dev/null 2>&1 || ! unshare -Ur true 2>/dev/null; then
+    echo "SKIP: unprivileged user namespaces are unavailable"
+    exit 77
+fi
+
+if command -v clang-19 >/dev/null 2>&1; then
+    clang=clang-19
+elif command -v clang >/dev/null 2>&1; then
+    clang=clang
+else
+    echo "SKIP: clang is required to build the x86_64 guest"
+    exit 77
+fi
+
+"$clang" --target=x86_64-linux-gnu -fuse-ld=lld -nostdlib -static \
+    -Wl,--build-id=none "$source_file" -o "$workdir/clone-namespaces"
+
+set +e
+LATX_AOT=0 LATX_KZT=0 "$emulator" "$workdir/clone-namespaces"
+ret=$?
+set -e
+
+case $ret in
+0)
+    echo "PASS: clone created distinct mount, IPC, and UTS namespaces"
+    ;;
+10)
+    echo "FAIL: parent namespace stat failed" >&2
+    ;;
+20)
+    echo "FAIL: combined namespace clone failed" >&2
+    ;;
+30)
+    echo "FAIL: child namespace stat failed" >&2
+    ;;
+31)
+    echo "FAIL: mount namespace was not created" >&2
+    ;;
+32)
+    echo "FAIL: IPC namespace was not created" >&2
+    ;;
+33)
+    echo "FAIL: UTS namespace was not created" >&2
+    ;;
+40)
+    echo "FAIL: wait4 failed" >&2
+    ;;
+41)
+    echo "FAIL: namespace child was killed by a signal" >&2
+    ;;
+*)
+    echo "FAIL: unexpected guest exit status $ret" >&2
+    ;;
+esac
+
+exit "$ret"

--- a/tests/integration/test-rcu-thread-visibility.sh
+++ b/tests/integration/test-rcu-thread-visibility.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+set -eu
+
+emulator=$1
+source_file=$2
+workdir=$(mktemp -d)
+trap 'rm -rf "$workdir"' EXIT HUP INT TERM
+
+if command -v clang-19 >/dev/null 2>&1; then
+    clang=clang-19
+elif command -v clang >/dev/null 2>&1; then
+    clang=clang
+else
+    echo "SKIP: clang is required to build the x86_64 guest"
+    exit 77
+fi
+
+"$clang" --target=x86_64-linux-gnu -fuse-ld=lld -nostdlib -static \
+    -Wl,--build-id=none "$source_file" -o "$workdir/rcu-thread-visibility"
+
+set +e
+LATX_AOT=0 LATX_KZT=0 "$emulator" "$workdir/rcu-thread-visibility"
+ret=$?
+set -e
+
+case $ret in
+0)
+    echo "PASS: no internal LATX thread is visible through getpgid"
+    ;;
+10)
+    echo "FAIL: an internal LATX thread is visible through getpgid" >&2
+    ;;
+11)
+    echo "FAIL: process-group setup failed" >&2
+    ;;
+*)
+    echo "FAIL: unexpected guest exit status $ret" >&2
+    ;;
+esac
+
+exit "$ret"

--- a/tests/integration/test-setns-ipc-mqueue.sh
+++ b/tests/integration/test-setns-ipc-mqueue.sh
@@ -1,0 +1,159 @@
+#!/bin/sh
+set -eu
+
+emulator=$(cd "$(dirname "$1")" && pwd)/$(basename "$1")
+source_file=$2
+pidfd_runner=$3
+workdir=$(mktemp -d)
+trap 'rm -rf "$workdir"' EXIT HUP INT TERM
+
+if ! command -v unshare >/dev/null 2>&1 ||
+   ! unshare -Urm true 2>/dev/null; then
+    echo "SKIP: unprivileged user and mount namespaces are unavailable"
+    exit 77
+fi
+
+compile_guest()
+{
+    output=$1
+    shift
+    "$clang" --target=x86_64-linux-gnu -fuse-ld=lld -nostdlib -static \
+        -Wl,--build-id=none "$@" "$source_file" -o "$output"
+}
+
+run_invalid_fd_case()
+{
+    guest="$workdir/setns-invalid-fd"
+
+    compile_guest "$guest" -DSETNS_FLAGS=0 -DSETNS_FD=-1 \
+        -DEXPECT_SETNS_ERRNO=9
+    LATX_AOT=0 LATX_KZT=0 "$emulator" "$guest"
+    echo "PASS: invalid namespace fd returned EBADF"
+}
+
+run_pidfd_case()
+{
+    guest="$workdir/setns-ipc-pidfd"
+
+    if ! command -v python3 >/dev/null 2>&1 ||
+       ! python3 -c 'import os; fd = os.pidfd_open(os.getpid()); os.close(fd)';
+    then
+        echo "SKIP: pidfd support is unavailable"
+        return
+    fi
+
+    compile_guest "$guest" -DSETNS_FLAGS=134217728 -DSETNS_ONLY=1
+    unshare -Ur sh -eu -c '
+        emulator=$1
+        guest=$2
+        pidfd_runner=$3
+
+        unshare -i sh -c "exec sleep 300" &
+        holder=$!
+        current_ipc=$(readlink /proc/self/ns/ipc)
+        namespace_ready=false
+        attempts=0
+        while [ "$attempts" -lt 100 ]; do
+            if [ -r "/proc/$holder/ns/ipc" ] &&
+               [ "$(readlink "/proc/$holder/ns/ipc")" != "$current_ipc" ]; then
+                namespace_ready=true
+                break
+            fi
+            attempts=$((attempts + 1))
+            sleep 0.01
+        done
+        if [ "$namespace_ready" != true ]; then
+            kill "$holder" 2>/dev/null || true
+            wait "$holder" 2>/dev/null || true
+            echo "FAIL: pidfd IPC namespace holder did not start" >&2
+            exit 30
+        fi
+
+        set +e
+        "$pidfd_runner" "$holder" "$emulator" "$guest"
+        ret=$?
+        set -e
+        kill "$holder" 2>/dev/null || true
+        wait "$holder" 2>/dev/null || true
+        if [ "$ret" -ne 0 ]; then
+            echo "FAIL: pidfd setns guest exited with status $ret" >&2
+            exit "$ret"
+        fi
+        echo "PASS: pidfd joined the IPC namespace"
+    ' sh "$emulator" "$guest" "$pidfd_runner"
+}
+
+if command -v clang-19 >/dev/null 2>&1; then
+    clang=clang-19
+elif command -v clang >/dev/null 2>&1; then
+    clang=clang
+else
+    echo "SKIP: clang is required to build the x86_64 guest"
+    exit 77
+fi
+
+run_case()
+{
+    setns_flags=$1
+    case_name=$2
+    guest="$workdir/setns-ipc-mqueue-$case_name"
+    mkdir "$workdir/$case_name"
+
+    compile_guest "$guest" -DSETNS_FLAGS="$setns_flags"
+
+    unshare -Urm sh -eu -c '
+        emulator=$1
+        guest=$2
+        case_name=$3
+        workdir=$4
+        cd "$workdir"
+        mkdir mqueue
+        mount --make-rprivate /
+        trap "umount mqueue 2>/dev/null || true" EXIT HUP INT TERM
+
+        unshare -i sh -c "exec sleep 300" &
+        holder=$!
+        current_ipc=$(readlink /proc/self/ns/ipc)
+        namespace_ready=false
+        attempts=0
+        while [ "$attempts" -lt 100 ]; do
+            if [ -r "/proc/$holder/ns/ipc" ] &&
+               [ "$(readlink "/proc/$holder/ns/ipc")" != "$current_ipc" ]; then
+                namespace_ready=true
+                break
+            fi
+            attempts=$((attempts + 1))
+            sleep 0.01
+        done
+        if [ "$namespace_ready" != true ]; then
+            kill "$holder" 2>/dev/null || true
+            wait "$holder" 2>/dev/null || true
+            echo "FAIL: IPC namespace holder did not start" >&2
+            exit 30
+        fi
+
+        exec 9<"/proc/$holder/ns/ipc"
+        kill "$holder"
+        wait "$holder" 2>/dev/null || true
+
+        LATX_AOT=1 LATX_KZT=0 "$emulator" "$guest" &
+        emulator_pid=$!
+        exec 9<&-
+        wait "$emulator_pid" || {
+            ret=$?
+            echo "FAIL: $case_name guest exited with status $ret" >&2
+            exit "$ret"
+        }
+
+        if touch mqueue/MQ2 2>/dev/null; then
+            echo "FAIL: $case_name left the IPC namespace alive" >&2
+            exit 40
+        fi
+        echo "PASS: $case_name released the IPC namespace"
+    ' sh "$emulator" "$guest" "$case_name" "$workdir/$case_name"
+}
+
+run_invalid_fd_case
+run_pidfd_case
+run_case 134217728 explicit-CLONE_NEWIPC
+run_case 0 inferred-from-fd

--- a/tests/unit/meson.build
+++ b/tests/unit/meson.build
@@ -39,3 +39,16 @@ if 'CONFIG_LATX' in config_host
     suite: 'lat-pr-fast',
   )
 endif
+
+test_rcu_lazy_thread = executable(
+  'test-rcu-lazy-thread',
+  files('test-rcu-lazy-thread.c'),
+  include_directories: include_directories('../..'),
+  dependencies: [glib, qemuutil],
+)
+
+test(
+  'test-rcu-lazy-thread',
+  test_rcu_lazy_thread,
+  suite: 'lat-pr-fast',
+)

--- a/tests/unit/test-rcu-lazy-thread.c
+++ b/tests/unit/test-rcu-lazy-thread.c
@@ -1,0 +1,33 @@
+#include "qemu/osdep.h"
+
+#include "qemu/rcu.h"
+#include "qemu/thread.h"
+
+typedef struct TestRcuCallback {
+    struct rcu_head rcu;
+    QemuEvent done;
+} TestRcuCallback;
+
+static void test_callback(struct rcu_head *head)
+{
+    TestRcuCallback *callback = container_of(head, TestRcuCallback, rcu);
+
+    qemu_event_set(&callback->done);
+}
+
+int main(void)
+{
+    TestRcuCallback callback;
+
+#ifdef CONFIG_LATX
+    g_assert_false(rcu_call_thread_is_running());
+#endif
+
+    qemu_event_init(&callback.done, false);
+    call_rcu1(&callback.rcu, test_callback);
+    qemu_event_wait(&callback.done);
+    g_assert_true(rcu_call_thread_is_running());
+    qemu_event_destroy(&callback.done);
+
+    return 0;
+}

--- a/util/rcu.c
+++ b/util/rcu.c
@@ -182,6 +182,10 @@ static struct rcu_head dummy;
 static struct rcu_head *head = &dummy, **tail = &dummy.next;
 static int rcu_call_count;
 static QemuEvent rcu_call_ready_event;
+static bool atfork_child_deferred;
+static bool call_rcu_thread_started;
+
+static void rcu_start_call_thread(void);
 
 static void enqueue(struct rcu_head *node)
 {
@@ -290,6 +294,9 @@ void call_rcu1(struct rcu_head *node, void (*func)(struct rcu_head *node))
     node->func = func;
     enqueue(node);
     qatomic_inc(&rcu_call_count);
+    if (!atfork_child_deferred) {
+        rcu_start_call_thread();
+    }
     qemu_event_set(&rcu_call_ready_event);
 }
 
@@ -367,12 +374,17 @@ static void rcu_start_call_thread(void)
 {
     QemuThread thread;
 
+    if (qatomic_cmpxchg(&call_rcu_thread_started, false, true)) {
+        return;
+    }
+
     qemu_thread_create(&thread, "call_rcu", call_rcu_thread,
                        NULL, QEMU_THREAD_DETACHED);
 }
 
 static void rcu_init_complete(bool start_thread)
 {
+    qatomic_set(&call_rcu_thread_started, false);
     qemu_mutex_init(&rcu_registry_lock);
     qemu_mutex_init(&rcu_sync_lock);
     qemu_event_init(&rcu_gp_event, true);
@@ -387,7 +399,6 @@ static void rcu_init_complete(bool start_thread)
 }
 
 static int atfork_depth = 1;
-static bool atfork_child_deferred;
 
 void rcu_enable_atfork(void)
 {
@@ -422,7 +433,7 @@ void rcu_start_deferred_thread(void)
 
 bool rcu_call_thread_is_running(void)
 {
-    return !atfork_child_deferred;
+    return qatomic_read(&call_rcu_thread_started);
 }
 
 #ifdef CONFIG_POSIX
@@ -457,7 +468,11 @@ static void rcu_init_child(void)
     }
 
     memset(&registry, 0, sizeof(registry));
+#ifdef CONFIG_LATX
+    rcu_init_complete(false);
+#else
     rcu_init_complete(!atfork_child_deferred);
+#endif
 }
 
 void rcu_raw_clone_prepare(void)
@@ -484,10 +499,14 @@ static void __attribute__((__constructor__)) rcu_init(void)
 #endif
 #ifdef CONFIG_LATX
     /*
-     * Chromium execs its PID namespace child before entering the nested user
-     * namespace.  Keep that child single-threaded until the guest unshare.
+     * Keep translator-only threads out of a single-threaded guest until RCU
+     * work actually needs a consumer.  Chromium additionally defers that
+     * on-demand start until its namespace child enters the nested user
+     * namespace.
      */
     atfork_child_deferred = g_strcmp0(g_getenv("SBX_USER_NS"), "1") == 0;
+    rcu_init_complete(false);
+#else
+    rcu_init_complete(true);
 #endif
-    rcu_init_complete(!atfork_child_deferred);
 }


### PR DESCRIPTION
## Summary / 变更说明

- Lazily start the internal RCU callback consumer so namespace syscalls see
  the guest's actual single-threaded state.
- Pass mount, IPC, and UTS namespace flags through fork-like guest clone
  operations.
- Track IPC namespace membership established by clone, unshare, and both
  explicit and descriptor-inferred setns calls.
- Keep final AOT generation synchronous for IPC-isolated processes so a
  detached worker cannot extend the namespace or mqueue lifetime.
- Add focused unit and integration coverage for RCU visibility, namespace
  clone behavior, and setns plus mqueue cleanup.

## Validation / 验证

- `./latxbuild/build64.sh`: passed.
- `lat-pr-fast`: 11 passed, 0 failed/skipped/timeouts.
- `latx-integration`: 6 passed, 0 failed/skipped/timeouts.
- Focused time namespace LTP: 38 passed, no non-pass result.
- Focused user namespace LTP: 5 passed, no non-pass result.
- All mqueue namespace LTP: 18 passed, no non-pass result.
- Full LTP containers selection: 237 passed, no non-pass result.
- `scripts/checkpatch.pl`: 0 errors; only the generic MAINTAINERS warning for
  newly added test files.

## Checklist / 检查项

- [x] I have read `CONTRIBUTING.md`. / 我已阅读 `CONTRIBUTING.md`。
- [x] Every commit contains a DCO sign-off (`git commit -s`). /
      每个提交都包含 DCO 签署（`git commit -s`）。
- [x] I have included relevant build or test results, or explained why they
      are not applicable. /
      我已提供相关构建或测试结果，或说明了不适用的原因。
