### PR TITLE
LATX, fix: match seccomp filter validation order

### DIFF
--- a/linux-user/guest-seccomp.c
+++ b/linux-user/guest-seccomp.c
@@ -244,15 +244,10 @@ static uint32_t seccomp_run_filter(const GuestSeccompFilter *filter,
     return SECCOMP_RET_KILL_THREAD;
 }
 
-static abi_long seccomp_load_filter(abi_ulong program,
-                                    GuestSeccompFilter **result)
+static abi_long seccomp_load_program(abi_ulong program, unsigned int *len,
+                                     abi_ulong *target_filter)
 {
     struct target_sock_fprog *target_program;
-    struct target_sock_filter *target_insns;
-    GuestSeccompFilter *filter;
-    abi_ulong target_filter;
-    unsigned int len;
-    unsigned int i;
 
     if (!program) {
         return -TARGET_EFAULT;
@@ -260,11 +255,25 @@ static abi_long seccomp_load_filter(abi_ulong program,
     if (!lock_user_struct(VERIFY_READ, target_program, program, 1)) {
         return -TARGET_EFAULT;
     }
-    len = tswap16(target_program->len);
-    target_filter = tswapal(target_program->filter);
+    *len = tswap16(target_program->len);
+    *target_filter = tswapal(target_program->filter);
     unlock_user_struct(target_program, program, 0);
 
-    if (len == 0 || len > BPF_MAXINSNS) {
+    if (*len == 0 || *len > BPF_MAXINSNS) {
+        return -TARGET_EINVAL;
+    }
+    return 0;
+}
+
+static abi_long seccomp_load_filter(abi_ulong target_filter,
+                                    unsigned int len,
+                                    GuestSeccompFilter **result)
+{
+    struct target_sock_filter *target_insns;
+    GuestSeccompFilter *filter;
+    unsigned int i;
+
+    if (!target_filter) {
         return -TARGET_EINVAL;
     }
     target_insns = lock_user(VERIFY_READ, target_filter,
@@ -301,15 +310,22 @@ static abi_long seccomp_install_filter(CPUArchState *env, abi_ulong flags,
     CPUState *cpu = env_cpu(env);
     TaskState *task = cpu->opaque;
     GuestSeccompFilter *filter;
+    abi_ulong target_filter;
+    unsigned int len;
     abi_long ret;
 
     if (flags & ~supported_flags) {
         return -TARGET_EINVAL;
     }
+    ret = seccomp_load_program(program, &len, &target_filter);
+    if (ret) {
+        return ret;
+    }
+    /* Linux validates the filter instructions only after this check. */
     if (prctl(PR_GET_NO_NEW_PRIVS, 0, 0, 0, 0) != 1) {
         return -TARGET_EACCES;
     }
-    ret = seccomp_load_filter(program, &filter);
+    ret = seccomp_load_filter(target_filter, len, &filter);
     if (ret) {
         return ret;
     }

--- a/tests/integration/meson.build
+++ b/tests/integration/meson.build
@@ -33,4 +33,15 @@ if host_machine.cpu_family() == 'loongarch64' and \
     suite: 'latx-integration',
     timeout: 30,
   )
+  test(
+    'test-seccomp-filter-ordering',
+    find_program('test-seccomp-filter-ordering.sh'),
+    args: [
+      emulators['latx-x86_64'],
+      files('seccomp-filter-ordering.S'),
+    ],
+    protocol: 'exitcode',
+    suite: 'latx-integration',
+    timeout: 30,
+  )
 endif

--- a/tests/integration/seccomp-filter-ordering.S
+++ b/tests/integration/seccomp-filter-ordering.S
@@ -1,0 +1,272 @@
+.equ __NR_prctl, 157
+.equ __NR_seccomp, 317
+.equ __NR_exit_group, 231
+
+.equ PR_GET_SECCOMP, 21
+.equ PR_SET_SECCOMP, 22
+.equ PR_SET_NO_NEW_PRIVS, 38
+.equ PR_GET_NO_NEW_PRIVS, 39
+
+.equ SECCOMP_MODE_FILTER, 2
+.equ SECCOMP_SET_MODE_FILTER, 1
+.equ SECCOMP_FILTER_FLAG_TSYNC, 1
+.equ SECCOMP_RET_ALLOW, 0x7fff0000
+
+.equ EACCES, 13
+.equ EFAULT, 14
+.equ EINVAL, 22
+
+.section .data
+.align 8
+zero_length_program:
+    .short 0
+    .zero 6
+    .quad allow_filter
+null_filter_program:
+    .short 1
+    .zero 6
+    .quad 0
+bad_filter_pointer_program:
+    .short 1
+    .zero 6
+    .quad 1
+invalid_filter_program:
+    .short 1
+    .zero 6
+    .quad invalid_filter
+allow_filter_program:
+    .short 1
+    .zero 6
+    .quad allow_filter
+
+.align 8
+invalid_filter:
+    .short 0xffff
+    .byte 0, 0
+    .long 0
+allow_filter:
+    .short 0x06
+    .byte 0, 0
+    .long SECCOMP_RET_ALLOW
+
+.section .text
+.global _start
+.type _start, @function
+_start:
+    mov $__NR_prctl, %eax
+    mov $PR_GET_NO_NEW_PRIVS, %edi
+    xor %esi, %esi
+    xor %edx, %edx
+    xor %r10d, %r10d
+    xor %r8d, %r8d
+    syscall
+    test %rax, %rax
+    jne skip
+
+    mov $__NR_seccomp, %eax
+    mov $SECCOMP_SET_MODE_FILTER, %edi
+    mov $0x80000000, %esi
+    xor %edx, %edx
+    syscall
+    cmp $-EINVAL, %rax
+    jne fail_invalid_flags
+
+    mov $__NR_prctl, %eax
+    mov $PR_SET_SECCOMP, %edi
+    mov $SECCOMP_MODE_FILTER, %esi
+    xor %edx, %edx
+    xor %r10d, %r10d
+    xor %r8d, %r8d
+    syscall
+    cmp $-EFAULT, %rax
+    jne fail_prctl_null_before_nnp
+
+    mov $__NR_seccomp, %eax
+    mov $SECCOMP_SET_MODE_FILTER, %edi
+    xor %esi, %esi
+    xor %edx, %edx
+    syscall
+    cmp $-EFAULT, %rax
+    jne fail_seccomp_null_before_nnp
+
+    mov $__NR_seccomp, %eax
+    mov $SECCOMP_SET_MODE_FILTER, %edi
+    mov $SECCOMP_FILTER_FLAG_TSYNC, %esi
+    xor %edx, %edx
+    syscall
+    cmp $-EFAULT, %rax
+    jne fail_tsync_null_before_nnp
+
+    mov $__NR_seccomp, %eax
+    mov $SECCOMP_SET_MODE_FILTER, %edi
+    xor %esi, %esi
+    lea zero_length_program(%rip), %rdx
+    syscall
+    cmp $-EINVAL, %rax
+    jne fail_zero_length_before_nnp
+
+    mov $__NR_seccomp, %eax
+    mov $SECCOMP_SET_MODE_FILTER, %edi
+    xor %esi, %esi
+    lea null_filter_program(%rip), %rdx
+    syscall
+    cmp $-EACCES, %rax
+    jne fail_null_filter_before_nnp
+
+    mov $__NR_seccomp, %eax
+    mov $SECCOMP_SET_MODE_FILTER, %edi
+    xor %esi, %esi
+    lea bad_filter_pointer_program(%rip), %rdx
+    syscall
+    cmp $-EACCES, %rax
+    jne fail_bad_filter_pointer_before_nnp
+
+    mov $__NR_seccomp, %eax
+    mov $SECCOMP_SET_MODE_FILTER, %edi
+    xor %esi, %esi
+    lea invalid_filter_program(%rip), %rdx
+    syscall
+    cmp $-EACCES, %rax
+    jne fail_invalid_filter_before_nnp
+
+    mov $__NR_prctl, %eax
+    mov $PR_SET_NO_NEW_PRIVS, %edi
+    mov $1, %esi
+    xor %edx, %edx
+    xor %r10d, %r10d
+    xor %r8d, %r8d
+    syscall
+    test %rax, %rax
+    jne fail_set_nnp
+
+    mov $__NR_prctl, %eax
+    mov $PR_SET_SECCOMP, %edi
+    mov $SECCOMP_MODE_FILTER, %esi
+    xor %edx, %edx
+    xor %r10d, %r10d
+    xor %r8d, %r8d
+    syscall
+    cmp $-EFAULT, %rax
+    jne fail_prctl_null_after_nnp
+
+    mov $__NR_seccomp, %eax
+    mov $SECCOMP_SET_MODE_FILTER, %edi
+    xor %esi, %esi
+    xor %edx, %edx
+    syscall
+    cmp $-EFAULT, %rax
+    jne fail_seccomp_null_after_nnp
+
+    mov $__NR_seccomp, %eax
+    mov $SECCOMP_SET_MODE_FILTER, %edi
+    xor %esi, %esi
+    lea null_filter_program(%rip), %rdx
+    syscall
+    cmp $-EINVAL, %rax
+    jne fail_null_filter_after_nnp
+
+    mov $__NR_seccomp, %eax
+    mov $SECCOMP_SET_MODE_FILTER, %edi
+    xor %esi, %esi
+    lea bad_filter_pointer_program(%rip), %rdx
+    syscall
+    cmp $-EFAULT, %rax
+    jne fail_bad_filter_pointer_after_nnp
+
+    mov $__NR_seccomp, %eax
+    mov $SECCOMP_SET_MODE_FILTER, %edi
+    xor %esi, %esi
+    lea invalid_filter_program(%rip), %rdx
+    syscall
+    cmp $-EINVAL, %rax
+    jne fail_invalid_filter_after_nnp
+
+    mov $__NR_seccomp, %eax
+    mov $SECCOMP_SET_MODE_FILTER, %edi
+    mov $SECCOMP_FILTER_FLAG_TSYNC, %esi
+    lea allow_filter_program(%rip), %rdx
+    syscall
+    test %rax, %rax
+    jne fail_tsync_install
+
+    mov $__NR_prctl, %eax
+    mov $PR_GET_SECCOMP, %edi
+    xor %esi, %esi
+    xor %edx, %edx
+    xor %r10d, %r10d
+    xor %r8d, %r8d
+    syscall
+    cmp $SECCOMP_MODE_FILTER, %rax
+    jne fail_get_seccomp
+
+    mov $__NR_prctl, %eax
+    mov $PR_SET_SECCOMP, %edi
+    mov $SECCOMP_MODE_FILTER, %esi
+    lea allow_filter_program(%rip), %rdx
+    xor %r10d, %r10d
+    xor %r8d, %r8d
+    syscall
+    test %rax, %rax
+    jne fail_prctl_install
+
+    xor %edi, %edi
+    jmp exit
+
+skip:
+    mov $77, %edi
+    jmp exit
+fail_invalid_flags:
+    mov $10, %edi
+    jmp exit
+fail_prctl_null_before_nnp:
+    mov $11, %edi
+    jmp exit
+fail_seccomp_null_before_nnp:
+    mov $12, %edi
+    jmp exit
+fail_tsync_null_before_nnp:
+    mov $13, %edi
+    jmp exit
+fail_zero_length_before_nnp:
+    mov $14, %edi
+    jmp exit
+fail_null_filter_before_nnp:
+    mov $15, %edi
+    jmp exit
+fail_invalid_filter_before_nnp:
+    mov $16, %edi
+    jmp exit
+fail_set_nnp:
+    mov $17, %edi
+    jmp exit
+fail_prctl_null_after_nnp:
+    mov $18, %edi
+    jmp exit
+fail_seccomp_null_after_nnp:
+    mov $19, %edi
+    jmp exit
+fail_null_filter_after_nnp:
+    mov $20, %edi
+    jmp exit
+fail_invalid_filter_after_nnp:
+    mov $21, %edi
+    jmp exit
+fail_tsync_install:
+    mov $22, %edi
+    jmp exit
+fail_get_seccomp:
+    mov $23, %edi
+    jmp exit
+fail_prctl_install:
+    mov $24, %edi
+    jmp exit
+fail_bad_filter_pointer_before_nnp:
+    mov $25, %edi
+    jmp exit
+fail_bad_filter_pointer_after_nnp:
+    mov $26, %edi
+
+exit:
+    mov $__NR_exit_group, %eax
+    syscall
+    hlt

--- a/tests/integration/test-seccomp-filter-ordering.sh
+++ b/tests/integration/test-seccomp-filter-ordering.sh
@@ -1,0 +1,91 @@
+#!/bin/sh
+set -eu
+
+emulator=$1
+source_file=$2
+workdir=$(mktemp -d)
+trap 'rm -rf "$workdir"' EXIT HUP INT TERM
+
+if command -v clang-19 >/dev/null 2>&1; then
+    clang=clang-19
+elif command -v clang >/dev/null 2>&1; then
+    clang=clang
+else
+    echo "SKIP: clang is required to build the x86_64 guest"
+    exit 77
+fi
+
+"$clang" --target=x86_64-linux-gnu -fuse-ld=lld -nostdlib -static \
+    -Wl,--build-id=none "$source_file" \
+    -o "$workdir/seccomp-filter-ordering"
+
+set +e
+LATX_AOT=0 LATX_KZT=0 \
+    "$emulator" "$workdir/seccomp-filter-ordering"
+ret=$?
+set -e
+
+case $ret in
+0)
+    echo "PASS: seccomp filter validation follows Linux ordering"
+    ;;
+10)
+    echo "FAIL: invalid seccomp flags did not return EINVAL" >&2
+    ;;
+11)
+    echo "FAIL: prctl null program before NNP did not return EFAULT" >&2
+    ;;
+12)
+    echo "FAIL: seccomp null program before NNP did not return EFAULT" >&2
+    ;;
+13)
+    echo "FAIL: TSYNC null program before NNP did not return EFAULT" >&2
+    ;;
+14)
+    echo "FAIL: zero-length program before NNP did not return EINVAL" >&2
+    ;;
+15)
+    echo "FAIL: null filter before NNP did not return EACCES" >&2
+    ;;
+16)
+    echo "FAIL: invalid filter before NNP did not return EACCES" >&2
+    ;;
+17)
+    echo "FAIL: PR_SET_NO_NEW_PRIVS failed" >&2
+    ;;
+18)
+    echo "FAIL: prctl null program after NNP did not return EFAULT" >&2
+    ;;
+19)
+    echo "FAIL: seccomp null program after NNP did not return EFAULT" >&2
+    ;;
+20)
+    echo "FAIL: null filter after NNP did not return EINVAL" >&2
+    ;;
+21)
+    echo "FAIL: invalid filter after NNP did not return EINVAL" >&2
+    ;;
+22)
+    echo "FAIL: TSYNC filter installation failed" >&2
+    ;;
+23)
+    echo "FAIL: PR_GET_SECCOMP did not report filter mode" >&2
+    ;;
+24)
+    echo "FAIL: prctl filter installation failed" >&2
+    ;;
+25)
+    echo "FAIL: bad filter pointer before NNP did not return EACCES" >&2
+    ;;
+26)
+    echo "FAIL: bad filter pointer after NNP did not return EFAULT" >&2
+    ;;
+77)
+    echo "SKIP: no_new_privs was already enabled"
+    ;;
+*)
+    echo "FAIL: unexpected guest exit status $ret" >&2
+    ;;
+esac
+
+exit "$ret"


### PR DESCRIPTION
## Summary

- Split guest `sock_fprog` header loading from BPF instruction loading.
- Match the Linux validation order: flags, program/header/length, permission,
  then filter pointer and BPF instructions.
- Add an x86_64 integration test for both `prctl` and `seccomp`, including
  NULL pointers, invalid pointers, invalid programs, real filter installation,
  and TSYNC.

## Testing

- `./latxbuild/build64.sh -c`
- `meson test -C build64 test-seccomp-filter-ordering --print-errorlogs`
- `meson test -C build64 --suite latx-integration --print-errorlogs` (4/4)
- `meson test -C build64 --suite lat-pr-fast --print-errorlogs` (9/9)
- The static regression binary passed natively on x86_64 and under LATX.
- Chromium 125 `SandboxBPF.CallSupports`, `CallSupportsTwice`, and `Tsync`
  passed when this commit was validated together with PR #363.
- `SandboxBPF.Tsync` passed 100/100 repeated runs.
- The full Chromium sandbox suite reached 324 successes out of 355 tests;
  capability-probe failures were eliminated. The remaining failures exercise
  separate broker, signal, thread-visibility, and seccomp behavior already
  tracked or recorded as follow-up work.

The Chromium validation used PR #363 only to keep the translator helper thread
from masking the seccomp path. This change itself is based on and independent
of `master`.
