### PR TITLE
LATX: support dual-target loader prefixes in release builds

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -582,24 +582,28 @@ foreach target : target_dirs
                  name_suffix: 'fa')
 
   if get_option('tests').enabled() and \
-     target == 'x86_64-linux-user' and \
+     target in ['x86_64-linux-user', 'i386-linux-user'] and \
      'CONFIG_LATX_O1' in config_host
     latx_config_regression_test = executable(
-      'test-latx-config-regression',
-      files('tests/latx-x86_64/latx-config-regression.c'),
+      'test-' + target + '-latx-config-regression',
+      files('tests/latx/latx-config-regression.c'),
       objects: lib.extract_objects(latx_string_utils),
       c_args: c_args,
       dependencies: [glib],
       include_directories: target_inc,
     )
     test(
-      'latx-config-regression',
+      target + '-latx-config-regression',
       latx_config_regression_test,
       suite: 'lat-pr-fast',
       env: ['ASAN_OPTIONS=detect_leaks=0'],
       timeout: 30,
     )
+  endif
 
+  if get_option('tests').enabled() and \
+     target == 'x86_64-linux-user' and \
+     'CONFIG_LATX_O1' in config_host
     smc_reload_test_c_args = c_args + [
       '-ffunction-sections',
       '-fvisibility=hidden',

--- a/target/i386/latx/include/latx-options.h
+++ b/target/i386/latx/include/latx-options.h
@@ -12,6 +12,14 @@
 #include "latx-disassemble-trace.h"
 #include "latx-debug.h"
 
+#ifdef TARGET_X86_64
+#define LATX_SYSTEM_CONFIG_FILE "/etc/latx-x86_64.conf"
+#define LATX_USER_CONFIG_FILE "latx-x86_64.conf"
+#else
+#define LATX_SYSTEM_CONFIG_FILE "/etc/latx-i386.conf"
+#define LATX_USER_CONFIG_FILE "latx-i386.conf"
+#endif
+
 #ifdef CONFIG_LATX_INSTS_PATTERN
 extern int option_instptn;
 #endif

--- a/target/i386/latx/include/latx-options.h
+++ b/target/i386/latx/include/latx-options.h
@@ -161,6 +161,9 @@ extern unsigned long long counter_mips_tr;
 #define ENVSUP_AOT
 #endif
 
+#define ENVSUP_RUNTIME \
+    ENVFUN(LAT_LD_PREFIX, handle_arg_ld_prefix)
+
 #if defined(CONFIG_LATX_DEBUG) || defined(CONFIG_DEBUG_TCG)
 #define ENVSUP_DEBUG \
     ENVFUN(LAT_GDB, handle_arg_gdb) \
@@ -182,7 +185,6 @@ extern unsigned long long counter_mips_tr;
     ENVFUN(LAT_STRACE_ERROR, handle_arg_strace_error) \
     ENVFUN(LAT_RAND_SEED, handle_arg_seed) \
     ENVFUN(LAT_TRACE, handle_arg_trace) \
-    ENVFUN(LAT_LD_PREFIX, handle_arg_ld_prefix) \
     ENVFUN(LAT_VERSION, handle_arg_version)
 #else
 #define ENVSUP_DEBUG
@@ -216,6 +218,7 @@ extern unsigned long long counter_mips_tr;
     ENVSUP_AVX \
     ENVSUP_KZT \
     ENVSUP_AOT \
+    ENVSUP_RUNTIME \
     ENVSUP_DEBUG \
     ENVSUP_LATX_DEBUG \
     ENVSUP_PLUGIN

--- a/target/i386/latx/include/latx-string-utils.h
+++ b/target/i386/latx/include/latx-string-utils.h
@@ -11,6 +11,11 @@
 
 char *latx_trim(char *s);
 int latx_option_line_init(char *line, char **name, char **value);
+int latx_user_config_home_is_safe(const char *home, uid_t real_uid,
+                                  uid_t effective_uid, gid_t real_gid,
+                                  gid_t effective_gid);
+int latx_user_config_path(char *buffer, size_t buffer_size,
+                          const char *home, const char *filename);
 /* filename and buffer must be non-NULL, and buffer_size must be positive. */
 void latx_extract_filename(const char *filename, char *buffer,
                            size_t buffer_size);

--- a/target/i386/latx/latx-options.c
+++ b/target/i386/latx/latx-options.c
@@ -189,11 +189,10 @@ void conf_init(char **argv)
 
     /* load /etc/latx-*.conf */
     load_conf_file(LATX_SYSTEM_CONFIG_FILE, program);
-    snprintf(path, PATH_MAX, "%s/.config/%s", home_path,
-             LATX_USER_CONFIG_FILE);
-
-    /* load ~/.config/latx-*.conf */
-    load_conf_file(path, program);
+    if (latx_user_config_path(path, sizeof(path), home_path,
+                              LATX_USER_CONFIG_FILE)) {
+        load_conf_file(path, program);
+    }
 }
 
 void options_init(void)

--- a/target/i386/latx/latx-options.c
+++ b/target/i386/latx/latx-options.c
@@ -187,14 +187,10 @@ void conf_init(char **argv)
     char *program = guest_program(argv);
     const char *home_path = getenv("HOME");
 
-#ifdef TARGET_X86_64
     /* load /etc/latx-*.conf */
-    load_conf_file("/etc/latx-x86_64.conf", program);
-    snprintf(path, PATH_MAX, "%s/.config/latx-x86_64.conf", home_path);
-#else
-    load_conf_file("/etc/latx-i386.conf", program);
-    snprintf(path, PATH_MAX, "%s/.config/latx-i386.conf", home_path);
-#endif
+    load_conf_file(LATX_SYSTEM_CONFIG_FILE, program);
+    snprintf(path, PATH_MAX, "%s/.config/%s", home_path,
+             LATX_USER_CONFIG_FILE);
 
     /* load ~/.config/latx-*.conf */
     load_conf_file(path, program);

--- a/target/i386/latx/latx-string-utils.c
+++ b/target/i386/latx/latx-string-utils.c
@@ -48,6 +48,37 @@ int latx_option_line_init(char *line, char **name, char **value)
     return true;
 }
 
+int latx_user_config_home_is_safe(const char *home, uid_t real_uid,
+                                  uid_t effective_uid, gid_t real_gid,
+                                  gid_t effective_gid)
+{
+    return home != NULL && home[0] == '/' && real_uid == effective_uid &&
+           real_gid == effective_gid;
+}
+
+int latx_user_config_path(char *buffer, size_t buffer_size,
+                          const char *home, const char *filename)
+{
+    int length;
+
+    if (buffer == NULL || buffer_size == 0) {
+        return false;
+    }
+    buffer[0] = '\0';
+    if (filename == NULL || filename[0] == '\0' ||
+        !latx_user_config_home_is_safe(home, getuid(), geteuid(),
+                                       getgid(), getegid())) {
+        return false;
+    }
+
+    length = snprintf(buffer, buffer_size, "%s/.config/%s", home, filename);
+    if (length < 0 || (size_t)length >= buffer_size) {
+        buffer[0] = '\0';
+        return false;
+    }
+    return true;
+}
+
 void latx_extract_filename(const char *filename, char *buffer,
                            size_t buffer_size)
 {

--- a/tests/latx/latx-config-regression.c
+++ b/tests/latx/latx-config-regression.c
@@ -11,7 +11,7 @@
 
 static void test_empty_config_value(void)
 {
-    char line[] = "LATX_CLOSE_PARALLEL=   \n";
+    char line[] = "LATX_CLOSE_PARALLEL=\n";
     char *name = NULL;
     char *value = NULL;
 

--- a/tests/latx/latx-config-regression.c
+++ b/tests/latx/latx-config-regression.c
@@ -8,6 +8,35 @@
 #include <glib.h>
 
 #include "latx-string-utils.h"
+#include "latx-options.h"
+
+static bool config_option_registered(const char *expected)
+{
+#define ENVFUN(NAME, handler) \
+    if (g_str_equal(expected, #NAME)) { \
+        return true; \
+    }
+    ENVS
+#undef ENVFUN
+    return false;
+}
+
+static void test_target_config_files(void)
+{
+#ifdef TARGET_X86_64
+    g_assert_cmpstr(LATX_SYSTEM_CONFIG_FILE, ==,
+                    "/etc/latx-x86_64.conf");
+    g_assert_cmpstr(LATX_USER_CONFIG_FILE, ==, "latx-x86_64.conf");
+#else
+    g_assert_cmpstr(LATX_SYSTEM_CONFIG_FILE, ==, "/etc/latx-i386.conf");
+    g_assert_cmpstr(LATX_USER_CONFIG_FILE, ==, "latx-i386.conf");
+#endif
+}
+
+static void test_release_loader_prefix_config(void)
+{
+    g_assert_true(config_option_registered("LAT_LD_PREFIX"));
+}
 
 static void test_empty_config_value(void)
 {
@@ -80,6 +109,10 @@ int main(int argc, char **argv)
                     test_single_byte_filename_buffer);
     g_test_add_func("/latx/config/filename-path-and-extension",
                     test_filename_path_and_extension);
+    g_test_add_func("/latx/config/target-config-files",
+                    test_target_config_files);
+    g_test_add_func("/latx/config/release-loader-prefix",
+                    test_release_loader_prefix_config);
 
     return g_test_run();
 }

--- a/tests/latx/latx-config-regression.c
+++ b/tests/latx/latx-config-regression.c
@@ -38,6 +38,45 @@ static void test_release_loader_prefix_config(void)
     g_assert_true(config_option_registered("LAT_LD_PREFIX"));
 }
 
+static void test_user_config_path(void)
+{
+    char expected[PATH_MAX];
+    char path[PATH_MAX] = "must be cleared";
+    char truncated[8] = "unclear";
+
+    g_assert_true(latx_user_config_home_is_safe("/home/test", 1000, 1000,
+                                                1000, 1000));
+    g_assert_false(latx_user_config_home_is_safe("/home/test", 1000, 0,
+                                                 1000, 1000));
+    g_assert_false(latx_user_config_home_is_safe("/home/test", 1000, 1000,
+                                                 1000, 0));
+    g_assert_false(latx_user_config_home_is_safe("relative/home", 1000, 1000,
+                                                 1000, 1000));
+
+    g_assert_cmpint(snprintf(expected, sizeof(expected),
+                             "/home/test/.config/%s",
+                             LATX_USER_CONFIG_FILE), >, 0);
+    g_assert_true(latx_user_config_path(path, sizeof(path), "/home/test",
+                                       LATX_USER_CONFIG_FILE));
+    g_assert_cmpstr(path, ==, expected);
+
+    g_assert_false(latx_user_config_path(path, sizeof(path), NULL,
+                                        LATX_USER_CONFIG_FILE));
+    g_assert_cmpstr(path, ==, "");
+    g_assert_false(latx_user_config_path(path, sizeof(path), "relative/home",
+                                        LATX_USER_CONFIG_FILE));
+    g_assert_cmpstr(path, ==, "");
+    g_assert_false(latx_user_config_path(truncated, sizeof(truncated),
+                                        "/home/test",
+                                        LATX_USER_CONFIG_FILE));
+    g_assert_cmpstr(truncated, ==, "");
+    g_assert_false(latx_user_config_path(path, sizeof(path), "/home/test",
+                                        NULL));
+    g_assert_cmpstr(path, ==, "");
+    g_assert_false(latx_user_config_path(NULL, 0, "/home/test",
+                                        LATX_USER_CONFIG_FILE));
+}
+
 static void test_empty_config_value(void)
 {
     char line[] = "LATX_CLOSE_PARALLEL=\n";
@@ -113,6 +152,8 @@ int main(int argc, char **argv)
                     test_target_config_files);
     g_test_add_func("/latx/config/release-loader-prefix",
                     test_release_loader_prefix_config);
+    g_test_add_func("/latx/config/user-config-path",
+                    test_user_config_path);
 
     return g_test_run();
 }


### PR DESCRIPTION
## Runtime usability series

This is PR1, the translator-side foundation for the LATU runtime usability work. It is intentionally independent of the runtime manager: it makes persistent runtime selection work for both translators before higher-level tooling writes or manages that configuration.

Related: #369 is PR2, the independent distribution-neutral status foundation. #370 is PR3; it builds on this PR and uses the manager command introduced by #369 in its recovery guidance.

## Summary

- give `latx-x86_64` and `latx-i386` explicit system and per-user configuration filenames
- classify `LAT_LD_PREFIX` as a runtime option so release builds accept it from configuration files
- ignore per-user configuration when `HOME` is unset, relative, truncated, or used across a real/effective UID or GID transition
- run the focused configuration regression for both x86 targets without enabling the existing x86_64-only tests for i386

## Why

`LAT_LD_PREFIX` was registered under the debug-only option group. Release builds accepted the environment variable and `-L`, but silently ignored the same setting in LATX configuration files. The configuration regression also covered only `latx-x86_64`.

That prevented users and future management tools from persistently selecting separate x86-64 and i386 runtimes while retaining transparent `binfmt_misc` execution.

## User-visible behavior

An unprivileged user can configure the two translators independently:

```ini
# $HOME/.config/latx-x86_64.conf
LAT_LD_PREFIX=/home/user/.local/share/latu/runtimes/x86_64/rootfs
```

```ini
# $HOME/.config/latx-i386.conf
LAT_LD_PREFIX=/home/user/.local/share/latu/runtimes/i386/rootfs
```

The system-wide equivalents remain `/etc/latx-x86_64.conf` and `/etc/latx-i386.conf`. Existing precedence is preserved: command line, environment, user configuration, system configuration, then the compiled default. The compiled defaults and installed `binfmt_misc` registration are unchanged.

## Commit structure

1. share the configuration plumbing and dual-target regression harness without changing translator behavior
2. make `LAT_LD_PREFIX` available to release configuration parsing
3. harden per-user configuration path construction and credential-transition handling

## Validation

On a native LoongArch new-world host:

- release product builds: `latx-x86_64` and `latx-i386` passed
- focused suites: x86-64 11/11 passed; i386 5/5 passed
- deterministic RED/GREEN: temporarily reversing only the release-registration hunk failed both target regressions; restoring it passed both
- direct execution: both translators selected their configured runtime; an invalid environment override failed; a valid `-L` override recovered, confirming precedence
- unsafe `HOME`: relative homes containing deliberately invalid configuration were ignored by both translators
- isolated `binfmt_misc`: entries pinned the newly built translators; invalid per-user prefixes failed for both architectures with exit 255, and valid prefixes passed with exit 0
- `git diff --check origin/master...HEAD`
- `scripts/checkpatch.pl --no-tree --terse --branch origin/master..HEAD`: 0 errors; one expected file-move/MAINTAINERS warning

