### PR TITLE
LATU: add a generic dual-translator status manager

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ on:
       - "meson.options"
       - "**/*.inc"
       - "**/*.yml"
+      - "runtime/**"
+      - "tests/runtime/**"
   pull_request:
     types: [assigned, opened, synchronize, reopened]
     paths:
@@ -25,6 +27,8 @@ on:
       - "meson.options"
       - "**/*.inc"
       - "**/*.yml"
+      - "runtime/**"
+      - "tests/runtime/**"
 
 jobs:
   build:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,8 @@ on:
       - "**/meson.build"
       - "meson_options.txt"
       - "configure"
+      - "runtime/**"
+      - "tests/runtime/**"
       - ".github/.ci/**"
       - ".github/workflows/tests.yml"
   pull_request:
@@ -26,6 +28,8 @@ on:
       - "**/meson.build"
       - "meson_options.txt"
       - "configure"
+      - "runtime/**"
+      - "tests/runtime/**"
       - ".github/.ci/**"
       - ".github/workflows/tests.yml"
 
@@ -34,10 +38,40 @@ permissions:
 
 # Test registration and suite selection rules are documented in tests/README.md.
 jobs:
+  latu-runtime-manager:
+    name: "latu runtime manager (${{ matrix.container.name }})"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    strategy:
+      fail-fast: false
+      matrix:
+        container:
+          - { name: "latx-runner-aosc", tag: "loong64" }
+          - { name: "latx-runner-debian", tag: "loong64" }
+          - { name: "latx-runner-fedora", tag: "loongarch64" }
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Run dual-translator status checks
+        run: |
+          docker run --rm \
+            --platform linux/loong64 \
+            --volume "$(pwd):/io" \
+            --workdir /io \
+            "ghcr.io/${{ github.repository_owner }}/${{ matrix.container.name }}:${{ matrix.container.tag }}" \
+            sh tests/runtime/test-latu-runtime-manager.sh
+
   meson-fast:
     name: "test (latx-runner-debian, lat-pr-fast)"
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
 
     steps:
       - uses: actions/checkout@v7

--- a/latxbuild/build-release.sh
+++ b/latxbuild/build-release.sh
@@ -86,6 +86,8 @@ package() {
     mkdir -p $pkgdir/$pkgname-$pkgver/usr/{bin,lib/binfmt.d,lib/sysctl.d}
     install -Dm755 -s $srcdir/build32/latx-i386 $pkgdir/$pkgname-$pkgver/usr/bin/latx-i386
     install -Dm755 -s $srcdir/build64/latx-x86_64 $pkgdir/$pkgname-$pkgver/usr/bin/latx-x86_64
+    install -Dm755 $srcdir/runtime/latu-runtime-manager \
+        $pkgdir/$pkgname-$pkgver/usr/bin/latu-runtime-manager
     cat >$pkgdir/$pkgname-$pkgver/usr/lib/binfmt.d/latx-i386.conf <<EOF
 :latx-i386:M::\x7fELF\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x03\x00:\xff\xff\xff\xff\xff\xfe\xfe\x00\x00\x00\xf4\xff\xff\xff\xff\xff\xfe\xff\xff\xff:/usr/bin/latx-i386:
 EOF

--- a/meson.build
+++ b/meson.build
@@ -755,6 +755,7 @@ endif
 
 subdir('scripts')
 subdir('docs')
+subdir('runtime')
 subdir('tests')
 
 #########################

--- a/runtime/latu-runtime-manager
+++ b/runtime/latu-runtime-manager
@@ -1,0 +1,76 @@
+#!/bin/sh
+set -u
+
+usage()
+{
+    echo 'usage: latu-runtime-manager status [--root ROOT]' >&2
+    exit 2
+}
+
+probe_translator()
+{
+    name=$1
+    if [ "$translator_dir_status" = unknown ]; then
+        echo unknown
+        return
+    fi
+    path=$translator_dir/$name
+
+    if [ ! -L "$path" ] && [ -f "$path" ] && [ -x "$path" ]; then
+        echo present
+    else
+        echo missing
+    fi
+}
+
+case "$#" in
+    1)
+        [ "$1" = status ] || usage
+        if ! translator_dir=$(CDPATH= cd -P -- "$(dirname -- "$0")" \
+            2>/dev/null && pwd); then
+            echo 'latu-runtime-manager: cannot locate its installation directory' >&2
+            exit 2
+        fi
+        translator_dir_status=known
+        ;;
+    3)
+        [ "$1" = status ] || usage
+        [ "$2" = --root ] || usage
+        [ -n "$3" ] || usage
+        if ! root=$(CDPATH= cd -P -- "$3" 2>/dev/null && pwd); then
+            echo "latu-runtime-manager: invalid root directory: $3" >&2
+            exit 2
+        fi
+
+        translator_dir=$root/usr/bin
+        translator_dir_status=known
+        if resolved_dir=$(CDPATH= cd -P -- "$translator_dir" \
+            2>/dev/null && pwd); then
+            case "$root" in
+                /)
+                    translator_dir=$resolved_dir
+                    ;;
+                *)
+                    case "$resolved_dir" in
+                        "$root"|"$root"/*)
+                            translator_dir=$resolved_dir
+                            ;;
+                        *)
+                            translator_dir_status=unknown
+                            ;;
+                    esac
+                    ;;
+            esac
+        elif [ -e "$translator_dir" ] || [ -L "$translator_dir" ]; then
+            translator_dir_status=unknown
+        elif [ -d "$root/usr" ] && [ ! -x "$root/usr" ]; then
+            translator_dir_status=unknown
+        fi
+        ;;
+    *)
+        usage
+        ;;
+esac
+
+printf 'translator_x86_64=%s\n' "$(probe_translator latx-x86_64)"
+printf 'translator_i386=%s\n' "$(probe_translator latx-i386)"

--- a/runtime/latu-runtime-manager
+++ b/runtime/latu-runtime-manager
@@ -16,7 +16,27 @@ probe_translator()
     fi
     path=$translator_dir/$name
 
-    if [ ! -L "$path" ] && [ -f "$path" ] && [ -x "$path" ]; then
+    if [ -L "$path" ]; then
+        if ! resolved_path=$(readlink -f -- "$path" 2>/dev/null); then
+            echo unknown
+            return
+        fi
+        case "$translator_root" in
+            /|'') ;;
+            *)
+                case "$resolved_path" in
+                    "$translator_root"|"$translator_root"/*) ;;
+                    *)
+                        echo unknown
+                        return
+                        ;;
+                esac
+                ;;
+        esac
+        path=$resolved_path
+    fi
+
+    if [ -f "$path" ] && [ -x "$path" ]; then
         echo present
     else
         echo missing
@@ -26,12 +46,29 @@ probe_translator()
 case "$#" in
     1)
         [ "$1" = status ] || usage
-        if ! translator_dir=$(CDPATH= cd -P -- "$(dirname -- "$0")" \
+        manager_path=$0
+        case "$manager_path" in
+            */*) ;;
+            *)
+                if ! manager_path=$(command -v "$manager_path" 2>/dev/null); then
+                    echo 'latu-runtime-manager: cannot locate its executable' >&2
+                    exit 2
+                fi
+                ;;
+        esac
+        if [ -L "$manager_path" ]; then
+            if ! manager_path=$(readlink -f -- "$manager_path" 2>/dev/null); then
+                echo 'latu-runtime-manager: cannot resolve its executable' >&2
+                exit 2
+            fi
+        fi
+        if ! translator_dir=$(CDPATH= cd -P -- "$(dirname -- "$manager_path")" \
             2>/dev/null && pwd); then
             echo 'latu-runtime-manager: cannot locate its installation directory' >&2
             exit 2
         fi
         translator_dir_status=known
+        translator_root=
         ;;
     3)
         [ "$1" = status ] || usage
@@ -44,6 +81,7 @@ case "$#" in
 
         translator_dir=$root/usr/bin
         translator_dir_status=known
+        translator_root=$root
         if resolved_dir=$(CDPATH= cd -P -- "$translator_dir" \
             2>/dev/null && pwd); then
             case "$root" in

--- a/runtime/meson.build
+++ b/runtime/meson.build
@@ -1,0 +1,5 @@
+install_data(
+  'latu-runtime-manager',
+  install_dir: get_option('bindir'),
+  install_mode: 'rwxr-xr-x',
+)

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -3,4 +3,27 @@ if not get_option('tests').enabled()
 endif
 
 subdir('unit')
+
+test(
+  'test-latu-runtime-manager',
+  find_program('runtime/test-latu-runtime-manager.sh'),
+  protocol: 'exitcode',
+  suite: 'lat-pr-fast',
+)
+
+latu_install_depends = []
+foreach name, emulator : emulators
+  latu_install_depends += emulator
+endforeach
+
+test(
+  'test-latu-install',
+  find_program('runtime/test-latu-install.sh'),
+  args: [python.full_path(), meson.source_root() / 'meson' / 'meson.py',
+         meson.build_root(), get_option('prefix')],
+  depends: latu_install_depends,
+  protocol: 'exitcode',
+  suite: 'lat-pr-fast',
+)
+
 subdir('integration')

--- a/tests/runtime/test-latu-install.sh
+++ b/tests/runtime/test-latu-install.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+set -eu
+
+[ "$#" -eq 4 ] || {
+    echo "usage: $0 PYTHON MESON_PY BUILD_DIR PREFIX" >&2
+    exit 2
+}
+
+python=$1
+meson_py=$2
+builddir=$3
+prefix=$4
+workdir=$(mktemp -d)
+trap 'rm -rf "$workdir"' EXIT HUP INT TERM
+
+fail()
+{
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+destdir=$workdir/dest
+install_log=$workdir/install.log
+if [ -f "$meson_py" ]; then
+    "$python" "$meson_py" install -C "$builddir" --no-rebuild \
+        --destdir "$destdir" > "$install_log" 2>&1
+else
+    "$python" -m mesonbuild.mesonmain install -C "$builddir" \
+        --no-rebuild --destdir "$destdir" > "$install_log" 2>&1
+fi || {
+        cat "$install_log" >&2
+        fail 'meson install into DESTDIR failed'
+    }
+
+manager=$destdir$prefix/bin/latu-runtime-manager
+[ -x "$manager" ] ||
+    fail "installed runtime manager is not executable: $manager"
+[ ! -e "$destdir$prefix/bin/latu" ] ||
+    fail 'runtime manager installation created an overlapping latu command'
+
+x86_64_status=missing
+i386_status=missing
+[ ! -x "$destdir$prefix/bin/latx-x86_64" ] || x86_64_status=present
+[ ! -x "$destdir$prefix/bin/latx-i386" ] || i386_status=present
+expected_default="translator_x86_64=$x86_64_status
+translator_i386=$i386_status"
+actual=$("$manager" status) ||
+    fail 'installed runtime manager default status failed'
+[ "$actual" = "$expected_default" ] || {
+    echo 'FAIL: installed runtime manager did not probe its siblings' >&2
+    echo 'expected:' >&2
+    printf '%s\n' "$expected_default" >&2
+    echo 'actual:' >&2
+    printf '%s\n' "$actual" >&2
+    exit 1
+}
+
+root=$workdir/example-root
+mkdir -p "$root/usr/bin"
+: > "$root/usr/bin/latx-x86_64"
+: > "$root/usr/bin/latx-i386"
+chmod +x "$root/usr/bin/latx-x86_64" "$root/usr/bin/latx-i386"
+
+expected='translator_x86_64=present
+translator_i386=present'
+actual=$("$manager" status --root "$root") ||
+    fail 'installed runtime manager status failed'
+[ "$actual" = "$expected" ] || {
+    echo 'FAIL: installed runtime manager produced unexpected output' >&2
+    echo 'expected:' >&2
+    printf '%s\n' "$expected" >&2
+    echo 'actual:' >&2
+    printf '%s\n' "$actual" >&2
+    exit 1
+}
+
+echo 'PASS: installed independent LATU runtime manager'

--- a/tests/runtime/test-latu-runtime-manager.sh
+++ b/tests/runtime/test-latu-runtime-manager.sh
@@ -65,6 +65,8 @@ neither='translator_x86_64=missing
 translator_i386=missing'
 unknown='translator_x86_64=unknown
 translator_i386=unknown'
+x86_64_unknown='translator_x86_64=unknown
+translator_i386=missing'
 
 root=$workdir/both
 install_translator "$root" latx-x86_64
@@ -101,6 +103,26 @@ run_status "$root"
 assert_status 0 "$status_code" 'non-executable files'
 assert_output "$neither" "$status_output" 'non-executable files'
 
+root=$workdir/translator-symlink
+mkdir -p "$root/usr/libexec/latu" "$root/usr/bin"
+: > "$root/usr/libexec/latu/latx-x86_64"
+chmod +x "$root/usr/libexec/latu/latx-x86_64"
+ln -s ../libexec/latu/latx-x86_64 "$root/usr/bin/latx-x86_64"
+run_status "$root"
+assert_status 0 "$status_code" 'translator symlink inside root'
+assert_output "$x86_64_only" "$status_output" \
+    'translator symlink inside root'
+
+outside=$workdir/translator-outside
+root=$workdir/translator-symlink-escape
+install_translator "$outside" latx-x86_64
+mkdir -p "$root/usr/bin"
+ln -s "$outside/usr/bin/latx-x86_64" "$root/usr/bin/latx-x86_64"
+run_status "$root"
+assert_status 0 "$status_code" 'translator symlink escapes root'
+assert_output "$x86_64_unknown" "$status_output" \
+    'translator symlink escapes root'
+
 outside=$workdir/outside
 root=$workdir/symlink-escape
 install_translator "$outside" latx-x86_64
@@ -136,6 +158,35 @@ case "$default_output" in
 translator_i386='*) ;;
     *) fail 'default status output does not contain both translators' ;;
 esac
+
+real_bin=$workdir/real-bin
+alias_bin=$workdir/alias-bin
+mkdir -p "$real_bin" "$alias_bin"
+cp "$manager" "$real_bin/latu-runtime-manager"
+: > "$real_bin/latx-x86_64"
+: > "$real_bin/latx-i386"
+chmod +x "$real_bin/latx-x86_64" "$real_bin/latx-i386"
+ln -s "$real_bin/latu-runtime-manager" "$alias_bin/latu-runtime-manager"
+set +e
+symlink_output=$("$alias_bin/latu-runtime-manager" status \
+    2> "$workdir/symlink.stderr")
+symlink_status=$?
+set -e
+assert_status 0 "$symlink_status" 'manager invoked through symlink'
+assert_output "$both" "$symlink_output" 'manager invoked through symlink'
+
+alternatives_bin=$workdir/alternatives-bin
+mkdir -p "$alternatives_bin"
+mv "$real_bin/latx-x86_64" "$alternatives_bin/latx-x86_64"
+ln -s "$alternatives_bin/latx-x86_64" "$real_bin/latx-x86_64"
+set +e
+alternatives_output=$("$real_bin/latu-runtime-manager" status \
+    2> "$workdir/alternatives.stderr")
+alternatives_status=$?
+set -e
+assert_status 0 "$alternatives_status" 'translator installed via symlink'
+assert_output "$both" "$alternatives_output" \
+    'translator installed via symlink'
 
 set +e
 "$manager" doctor > "$workdir/usage.stdout" 2> "$workdir/usage.stderr"

--- a/tests/runtime/test-latu-runtime-manager.sh
+++ b/tests/runtime/test-latu-runtime-manager.sh
@@ -1,0 +1,148 @@
+#!/bin/sh
+set -eu
+
+srcdir=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+manager=$srcdir/runtime/latu-runtime-manager
+workdir=$(mktemp -d)
+trap 'rm -rf "$workdir"' EXIT HUP INT TERM
+
+fail()
+{
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+assert_status()
+{
+    expected=$1
+    actual=$2
+    context=$3
+    [ "$actual" -eq "$expected" ] ||
+        fail "$context: expected status $expected, got $actual"
+}
+
+assert_output()
+{
+    expected=$1
+    actual=$2
+    context=$3
+    [ "$actual" = "$expected" ] || {
+        echo "FAIL: $context: unexpected output" >&2
+        echo 'expected:' >&2
+        printf '%s\n' "$expected" >&2
+        echo 'actual:' >&2
+        printf '%s\n' "$actual" >&2
+        exit 1
+    }
+}
+
+install_translator()
+{
+    install_root=$1
+    install_name=$2
+    mkdir -p "$install_root/usr/bin"
+    : > "$install_root/usr/bin/$install_name"
+    chmod +x "$install_root/usr/bin/$install_name"
+}
+
+run_status()
+{
+    status_root=$1
+    set +e
+    status_output=$("$manager" status --root "$status_root" \
+        2> "$workdir/stderr")
+    status_code=$?
+    set -e
+}
+
+both='translator_x86_64=present
+translator_i386=present'
+x86_64_only='translator_x86_64=present
+translator_i386=missing'
+i386_only='translator_x86_64=missing
+translator_i386=present'
+neither='translator_x86_64=missing
+translator_i386=missing'
+unknown='translator_x86_64=unknown
+translator_i386=unknown'
+
+root=$workdir/both
+install_translator "$root" latx-x86_64
+install_translator "$root" latx-i386
+run_status "$root"
+assert_status 0 "$status_code" 'both translators installed'
+assert_output "$both" "$status_output" 'both translators installed'
+
+root=$workdir/x86-64-only
+install_translator "$root" latx-x86_64
+run_status "$root"
+assert_status 0 "$status_code" 'only x86-64 translator installed'
+assert_output "$x86_64_only" "$status_output" \
+    'only x86-64 translator installed'
+
+root=$workdir/i386-only
+install_translator "$root" latx-i386
+run_status "$root"
+assert_status 0 "$status_code" 'only i386 translator installed'
+assert_output "$i386_only" "$status_output" \
+    'only i386 translator installed'
+
+root=$workdir/neither
+mkdir -p "$root/usr/bin"
+run_status "$root"
+assert_status 0 "$status_code" 'neither translator installed'
+assert_output "$neither" "$status_output" 'neither translator installed'
+
+root=$workdir/not-executable
+mkdir -p "$root/usr/bin"
+: > "$root/usr/bin/latx-x86_64"
+: > "$root/usr/bin/latx-i386"
+run_status "$root"
+assert_status 0 "$status_code" 'non-executable files'
+assert_output "$neither" "$status_output" 'non-executable files'
+
+outside=$workdir/outside
+root=$workdir/symlink-escape
+install_translator "$outside" latx-x86_64
+mkdir -p "$root"
+ln -s "$outside/usr" "$root/usr"
+run_status "$root"
+assert_status 0 "$status_code" 'root symlink escape'
+assert_output "$unknown" "$status_output" 'root symlink escape'
+
+root=$workdir/invalid-layout
+mkdir -p "$root/usr"
+: > "$root/usr/bin"
+run_status "$root"
+assert_status 0 "$status_code" 'uninspectable translator directory'
+assert_output "$unknown" "$status_output" \
+    'uninspectable translator directory'
+
+invalid_root=$workdir/not-a-directory
+: > "$invalid_root"
+run_status "$invalid_root"
+assert_status 2 "$status_code" 'invalid root'
+assert_output '' "$status_output" 'invalid root'
+grep -F "invalid root directory: $invalid_root" "$workdir/stderr" \
+    > /dev/null || fail 'invalid root diagnostic missing'
+
+set +e
+default_output=$("$manager" status 2> "$workdir/default.stderr")
+default_status=$?
+set -e
+assert_status 0 "$default_status" 'default root'
+case "$default_output" in
+    'translator_x86_64='*'
+translator_i386='*) ;;
+    *) fail 'default status output does not contain both translators' ;;
+esac
+
+set +e
+"$manager" doctor > "$workdir/usage.stdout" 2> "$workdir/usage.stderr"
+usage_status=$?
+set -e
+assert_status 2 "$usage_status" 'unsupported subcommand'
+grep -F 'usage: latu-runtime-manager status [--root ROOT]' \
+    "$workdir/usage.stderr" > /dev/null || fail 'usage diagnostic missing'
+
+echo 'PASS: distribution-neutral dual-translator status'


### PR DESCRIPTION
## Summary

- add an independent `latu-runtime-manager` command; no overlapping `latu` wrapper is installed
- report `latx-x86_64` and `latx-i386` separately through a stable, distribution-neutral status contract
- support translators installed through alternatives or other valid executable symlinks
- keep this layer limited to translator facts; runtime readiness, catalog selection, and provisioning remain follow-up work
- install the manager through Meson and exercise it in every existing LoongArch CI container

## Behavior

```console
$ latu-runtime-manager status
translator_x86_64=present
translator_i386=missing
```

Each value is `present`, `missing`, or `unknown`. `unknown` means the selected translator path could not be inspected safely, such as a root escape. `status` exits successfully when either translator is absent or unknown because those are query results, not command failures. Invalid arguments or an invalid `--root` return status 2. `--root ROOT` exists for inspecting a filesystem tree and tests; normal host use does not require it.

In normal host mode, the manager resolves its own final symlink before probing sibling translators, so invocation through `/usr/local/bin` or an alternatives-style link still inspects the actual installation directory. A translator symlink is `present` when its resolved target is a regular executable file.

In `--root` mode, translator symlinks are followed only when their resolved targets remain inside the selected root. A symlink that escapes the root or cannot be resolved safely is reported as `unknown`, not `missing` or `present`.

The implementation does not read `os-release`, branch on `ID` or `ID_LIKE`, contain a distribution allowlist, or infer runtime readiness from translator presence. Distribution names occur only in the existing CI image matrix, where they identify test environments.

## Series

- PR1: #365 — user-scoped loader-prefix configuration for both translators
- PR2: this PR — independent dual-translator status foundation
- PR3: #370 — translator runtime information and missing-runtime guidance

PR1 and PR2 can be reviewed and merged in either order. PR3 is now published as a draft for early review; it should not be merged until both foundations are accepted.

## Commit structure

1. `runtime: report both LATX translators` — command contract and focused source-tree matrix
2. `build: install and exercise the runtime manager` — Meson installation, installed-layout regression, and CI wiring
3. `runtime: support symlinked translator installs` — alternatives-compatible probing, root containment, and manager-symlink discovery

## Validation

- deterministic RED: valid translator symlink was reported `missing`
- deterministic RED: a translator symlink escaping `--root` was incorrectly reported `present`
- deterministic RED: manager invocation through a symlink probed the alias directory instead of the actual installation directory
- GREEN on macOS: complete source-tree dual-translator matrix passed, including all three symlink regressions
- GREEN on native LoongArch: source-tree matrix passed at commit `4bc4146f89a`
- native LoongArch product builds with tests disabled: `latx-x86_64` and `latx-i386` passed
- native LoongArch installed-layout tests passed for both x86_64 and i386 build trees
- native LoongArch focused Meson tests: 2/2 passed for both x86_64 and i386 build trees
- native LoongArch `lat-pr-fast`: x86_64 13/13 and i386 6/6 passed
- installed-layout tests verify the configured bindir, sibling discovery, both output keys, and absence of a generated `latu` command
- native release packaging passed; the archive contains `latu-runtime-manager`, `latx-x86_64`, and `latx-i386`
- `sh -n runtime/latu-runtime-manager tests/runtime/test-latu-runtime-manager.sh`
- `git diff --check`
- checkpatch: 0 errors; only the expected new-file/MAINTAINERS warnings
