### PR TITLE
LATX: report runtime selection and guide loader failures

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -105,6 +105,7 @@ jobs:
                 --disable-docs \
                 --with-git-submodules=ignore
               cd ..
+              export LATX_RUNTIME_TEST_SKIP_GUEST_EXECUTION=1
               ASAN_OPTIONS=detect_leaks=0 \
               UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 \
                 python3 -B meson/meson.py test \

--- a/accel/tcg/cpu-exec.c
+++ b/accel/tcg/cpu-exec.c
@@ -44,7 +44,6 @@
 #include "fileutils.h"
 #include "bridge_private.h"
 void *getAlternate(void *addr);
-extern const char *interp_prefix;
 extern struct elfheader_s * elf_header;
 #endif
 #if defined(TARGET_I386) && !defined(CONFIG_USER_ONLY)

--- a/include/qemu/path.h
+++ b/include/qemu/path.h
@@ -3,6 +3,8 @@
 
 void init_paths(const char *prefix);
 const char *path(const char *pathname);
+/* The caller owns the returned configured path. */
+char *path_get_prefixed(const char *pathname);
 void path_fork_start(void);
 void path_fork_end(int child);
 

--- a/linux-user/elfload.c
+++ b/linux-user/elfload.c
@@ -2970,25 +2970,85 @@ static bool load_elf_image(const char *image_name, const ImageSource *src,
     exit(-1);
 }
 
+#ifdef CONFIG_LATX
+static void latx_report_runtime_loader_failure(const char *filename,
+                                               const char *configured_path,
+                                               const char *attempted_path,
+                                               const char *reason,
+                                               const char *detail)
+{
+    g_autofree char *escaped_abi = NULL;
+    g_autofree char *escaped_interp = NULL;
+    g_autofree char *escaped_root = NULL;
+    g_autofree char *escaped_configured = NULL;
+    g_autofree char *escaped_attempted = NULL;
+    g_autofree char *escaped_detail = NULL;
+
+    escaped_abi = g_strescape(latx_runtime_guest_abi(), NULL);
+    escaped_interp = g_strescape(filename, NULL);
+    escaped_root = g_strescape(interp_prefix, NULL);
+    escaped_configured = g_strescape(configured_path, NULL);
+    escaped_attempted = g_strescape(attempted_path, NULL);
+    escaped_detail = g_strescape(detail, NULL);
+
+    error_report("LATU: guest runtime loader failure");
+    error_printf("  guest ABI: %s\n"
+                 "  PT_INTERP: %s\n"
+                 "  runtime root: %s\n"
+                 "  runtime source: %s\n"
+                 "  configured loader: %s\n"
+                 "  attempted loader: %s\n"
+                 "  failure reason: %s\n"
+                 "  detail: %s\n"
+                 "  next step: run 'latu-runtime-manager status'\n",
+                 escaped_abi, escaped_interp, escaped_root,
+                 latx_runtime_prefix_source_name(), escaped_configured,
+                 escaped_attempted, reason, escaped_detail);
+}
+#endif
+
 static void load_elf_interp(const char *filename, struct image_info *info,
                             char bprm_buf[BPRM_BUF_SIZE])
 {
     struct elfhdr ehdr;
     ImageSource src;
+    const char *loader_path = path(filename);
     int fd, retval;
     Error *err = NULL;
+#ifdef CONFIG_LATX
+    g_autofree char *configured_path = path_get_prefixed(filename);
+    bool header_valid = false;
+#endif
 
-    fd = open(path(filename), O_RDONLY);
+    fd = open(loader_path, O_RDONLY);
     if (fd < 0) {
+#ifdef CONFIG_LATX
+        int saved_errno = errno;
+
+        latx_report_runtime_loader_failure(
+            filename, configured_path, loader_path,
+            latx_runtime_loader_errno_name(saved_errno),
+            strerror(saved_errno));
+#else
         error_setg_file_open(&err, errno, filename);
         error_report_err(err);
+#endif
         exit(-1);
     }
 
     retval = read(fd, bprm_buf, BPRM_BUF_SIZE);
     if (retval < 0) {
+#ifdef CONFIG_LATX
+        int saved_errno = errno;
+
+        latx_report_runtime_loader_failure(
+            filename, configured_path, loader_path,
+            latx_runtime_loader_errno_name(saved_errno),
+            strerror(saved_errno));
+#else
         error_setg_errno(&err, errno, "Error reading file header");
         error_reportf_err(err, "%s: ", filename);
+#endif
         exit(-1);
     }
 
@@ -2996,8 +3056,27 @@ static void load_elf_interp(const char *filename, struct image_info *info,
     src.cache = bprm_buf;
     src.cache_size = retval;
 
+#ifdef CONFIG_LATX
+    if ((size_t)retval >= sizeof(ehdr)) {
+        memcpy(&ehdr, bprm_buf, sizeof(ehdr));
+        header_valid = elf_check_ident(&ehdr);
+        if (header_valid) {
+            bswap_ehdr(&ehdr);
+            header_valid = elf_check_ehdr(&ehdr);
+        }
+    }
+#endif
+
     if (!load_elf_image(filename, &src, info, &ehdr, NULL, &err)) {
+#ifdef CONFIG_LATX
+        latx_report_runtime_loader_failure(
+            filename, configured_path, loader_path,
+            header_valid ? "load_error" : "invalid_elf",
+            error_get_pretty(err));
+        error_free(err);
+#else
         error_reportf_err(err, "%s: ", filename);
+#endif
         exit(-1);
     }
     close(fd);

--- a/linux-user/elfload.c
+++ b/linux-user/elfload.c
@@ -2644,18 +2644,20 @@ static bool parse_elf_properties(const ImageSource *src,
  * @info: info collected from the loaded image.
  * @ehdr: the ELF header, not yet bswapped.
  * @pinterp_name: record any PT_INTERP string found.
+ * @errp: optionally return an error instead of terminating the process.
  *
- * On return: @info values will be filled in, as necessary or available.
+ * On success, @info values will be filled in, as necessary or available.
  */
 
-static void load_elf_image(const char *image_name, const ImageSource *src,
+static bool load_elf_image(const char *image_name, const ImageSource *src,
                            struct image_info *info, struct elfhdr *ehdr,
-                           char **pinterp_name)
+                           char **pinterp_name, Error **errp)
 {
     g_autofree struct elf_phdr *phdr = NULL;
     g_autofree ElfLoadMapRange *load_segments = NULL;
     abi_ulong load_addr, load_bias, loaddr, hiaddr, error, len;
     int i, prot_exec;
+    bool mmap_locked = false;
     Error *err = NULL;
 
     /*
@@ -2689,6 +2691,7 @@ static void load_elf_image(const char *image_name, const ImageSource *src,
     info->pt_dynamic_addr = 0;
 
     mmap_lock();
+    mmap_locked = true;
 
     /*
      * Find the maximum size of the image and allocate an appropriate
@@ -2948,13 +2951,21 @@ static void load_elf_image(const char *image_name, const ImageSource *src,
     }
 
     mmap_unlock();
+    mmap_locked = false;
 
-    return;
+    return true;
 
  exit_mmap:
     error_setg_errno(&err, errno, "Error mapping file");
     goto exit_errmsg;
  exit_errmsg:
+    if (mmap_locked) {
+        mmap_unlock();
+    }
+    if (errp) {
+        error_propagate(errp, err);
+        return false;
+    }
     error_reportf_err(err, "%s: ", image_name);
     exit(-1);
 }
@@ -2985,7 +2996,10 @@ static void load_elf_interp(const char *filename, struct image_info *info,
     src.cache = bprm_buf;
     src.cache_size = retval;
 
-    load_elf_image(filename, &src, info, &ehdr, NULL);
+    if (!load_elf_image(filename, &src, info, &ehdr, NULL, &err)) {
+        error_reportf_err(err, "%s: ", filename);
+        exit(-1);
+    }
     close(fd);
 }
 
@@ -3006,7 +3020,7 @@ static void load_elf_vdso(struct image_info *info, const VdsoImageInfo *vdso)
     src.cache = vdso->image;
     src.cache_size = vdso->image_size;
 
-    load_elf_image("<internal-vdso>", &src, info, &ehdr, NULL);
+    load_elf_image("<internal-vdso>", &src, info, &ehdr, NULL, NULL);
     load_addr = info->load_addr;
     load_bias = info->load_bias;
 
@@ -3251,7 +3265,8 @@ int load_elf_binary(struct linux_binprm *bprm, struct image_info *info)
 
     info->start_mmap = (abi_ulong)ELF_START_MMAP;
 
-    load_elf_image(bprm->filename, &bprm->src, info, &ehdr, &elf_interpreter);
+    load_elf_image(bprm->filename, &bprm->src, info, &ehdr,
+                   &elf_interpreter, NULL);
 #if !(defined(CONFIG_LATX_KZT) && defined(TARGET_X86_64))
     close(bprm->src.fd);
 #else

--- a/linux-user/main.c
+++ b/linux-user/main.c
@@ -37,6 +37,8 @@
 #include "qemu/cutils.h"
 #include "qemu/error-report.h"
 #include "qemu/help_option.h"
+#include "qapi/qmp/qdict.h"
+#include "qapi/qmp/qjson.h"
 #include "qemu/module.h"
 #include "qemu/plugin.h"
 #include "exec/exec-all.h"
@@ -54,6 +56,7 @@ int mydebug = 1;
 #ifdef CONFIG_LATX
 #include "latx-config.h"
 #include "latx-options.h"
+#include "latx-runtime.h"
 #include "aot.h"
 #include <openssl/evp.h>
 #endif
@@ -186,6 +189,7 @@ static void usage(int exitcode);
 
 const char *interp_prefix = CONFIG_QEMU_INTERP_PREFIX;
 const char *qemu_uname_release;
+static bool runtime_info_requested;
 
 /* XXX: on x86 MAP_GROWSDOWN only works if ESP <= address + 32, so
    we allocate a bigger stack. Need a better solution, for example
@@ -604,9 +608,15 @@ static void handle_arg_version(const char *arg)
     exit(EXIT_SUCCESS);
 }
 
+static void handle_arg_runtime_info(const char *arg)
+{
+    runtime_info_requested = true;
+}
+
 static void handle_arg_ld_prefix(const char *arg)
 {
     interp_prefix = strdup(arg);
+    latx_runtime_prefix_selected();
 }
 
 static void handle_arg_optimize(const char *arg)
@@ -994,6 +1004,8 @@ static const struct qemu_argument arg_table[] = {
 #endif
     {"L",          "LAT_LD_PREFIX",   true,  handle_arg_ld_prefix,
      "path",       "set the elf interpreter prefix to 'path'"},
+    {"runtime-info", NULL,             false, handle_arg_runtime_info,
+     "",           "display selected guest runtime information and exit"},
     {"version",    "LAT_VERSION",     false, handle_arg_version,
      "",           "display version information and exit"},
     {NULL, NULL, false, NULL, NULL, NULL}
@@ -1082,6 +1094,10 @@ static int arg_count = 0;
 
 void find_option(const char* key, const char* val)
 {
+    if (runtime_info_requested && strcmp(key, "LAT_LD_PREFIX")) {
+        return;
+    }
+
 #define ENVFUN(NAME, name) \
     else if (!strcmp(key, #NAME)) { \
         name(val); \
@@ -1090,8 +1106,15 @@ void find_option(const char* key, const char* val)
     ENVS
 #undef ENVFUN
     else {
-        printf("no option %s\n", key);
+        error_report("no option %s", key);
     }
+}
+
+static bool runtime_info_option_applies(const struct qemu_argument *arginfo)
+{
+    /* A runtime query must not execute unrelated option side effects. */
+    return arginfo->handle_opt == handle_arg_runtime_info ||
+           arginfo->handle_opt == handle_arg_ld_prefix;
 }
 
 static void options_set(char **target_argv)
@@ -1103,8 +1126,14 @@ static void options_set(char **target_argv)
     const struct qemu_argument *arginfo;
 
     /* set env */
+    latx_runtime_option_source_set(LATX_RUNTIME_SOURCE_ENVIRONMENT);
     for (arginfo = arg_table; arginfo->handle_opt != NULL; arginfo++) {
         if (arginfo->env == NULL) {
+            continue;
+        }
+
+        if (runtime_info_requested &&
+            !runtime_info_option_applies(arginfo)) {
             continue;
         }
 
@@ -1115,18 +1144,38 @@ static void options_set(char **target_argv)
     }
 
     /* set argv */
+    latx_runtime_option_source_set(LATX_RUNTIME_SOURCE_COMMAND_LINE);
     for (int i = 0; i < arg_count; i++) {
         for (arginfo = arg_table; arginfo->handle_opt != NULL; arginfo++) {
             if (!strcmp(parse_options[i].opt_name, arginfo->argv)) {
-                if (arginfo->has_arg) {
-                    arginfo->handle_opt(parse_options[i].opt_arg);
-                } else {
-                    arginfo->handle_opt(NULL);
+                if (!runtime_info_requested ||
+                    runtime_info_option_applies(arginfo)) {
+                    if (arginfo->has_arg) {
+                        arginfo->handle_opt(parse_options[i].opt_arg);
+                    } else {
+                        arginfo->handle_opt(NULL);
+                    }
                 }
                 break;
             }
         }
     }
+}
+
+static void print_runtime_info(void)
+{
+    QDict *info = qdict_new();
+    g_autoptr(GString) json = NULL;
+
+    qdict_put_int(info, "schema_version", 1);
+    qdict_put_str(info, "guest_abi", latx_runtime_guest_abi());
+    qdict_put_str(info, "runtime_root", interp_prefix);
+    qdict_put_str(info, "runtime_source",
+                  latx_runtime_prefix_source_name());
+
+    json = qobject_to_json(QOBJECT(info));
+    printf("%s\n", json->str);
+    qobject_unref(info);
 }
 
 static int parse_args(int argc, char **argv)
@@ -1166,10 +1215,17 @@ static int parse_args(int argc, char **argv)
                     parse_options[arg_count].opt_arg = argv[optind];
                     optind++;
                 } else {
-					if (!strcmp(r, "version") || !strcmp(r, "h")
-							|| !strcmp(r, "help")) {
-						arginfo->handle_opt(NULL);
-					}
+                    if (!strcmp(r, "version") || !strcmp(r, "h")
+                        || !strcmp(r, "help")
+                        || !strcmp(r, "runtime-info")) {
+                        /*
+                         * runtime-info must take effect here so it can be used
+                         * without a guest.  options_set() intentionally
+                         * replays its idempotent handler with the other
+                         * command-line options.
+                         */
+                        arginfo->handle_opt(NULL);
+                    }
                     parse_options[arg_count].opt_name = arginfo->argv;
                     parse_options[arg_count].opt_arg = NULL;
                 }
@@ -1185,13 +1241,15 @@ static int parse_args(int argc, char **argv)
         }
     }
 
-    if (optind >= argc) {
+    if (optind >= argc && !runtime_info_requested) {
         (void) fprintf(stderr, "no user program specified\n");
         exit(EXIT_FAILURE);
     }
 
-    exec_path = argv[optind];
-    real_path = realpath(exec_path, (char *)malloc(MAX_PATH));
+    if (optind < argc) {
+        exec_path = argv[optind];
+        real_path = realpath(exec_path, (char *)malloc(MAX_PATH));
+    }
 
     return optind;
 }
@@ -1301,6 +1359,11 @@ int main(int argc, char **argv, char **envp)
 
     /* set environment variables */
     options_set(target_argv);
+
+    if (runtime_info_requested) {
+        print_runtime_info();
+        return EXIT_SUCCESS;
+    }
 
     error_init(argv[0]);
     module_call_init(MODULE_INIT_TRACE);

--- a/linux-user/qemu.h
+++ b/linux-user/qemu.h
@@ -169,6 +169,7 @@ typedef struct TaskState {
 
 extern char *exec_path;
 extern char *real_path;
+extern const char *interp_prefix;
 void init_task_state(TaskState *ts);
 void task_settid(TaskState *);
 void stop_all_tasks(void);

--- a/meson.build
+++ b/meson.build
@@ -587,7 +587,7 @@ foreach target : target_dirs
     latx_config_regression_test = executable(
       'test-' + target + '-latx-config-regression',
       files('tests/latx/latx-config-regression.c'),
-      objects: lib.extract_objects(latx_string_utils),
+      objects: lib.extract_objects(latx_string_utils, latx_runtime),
       c_args: c_args,
       dependencies: [glib],
       include_directories: target_inc,
@@ -747,6 +747,19 @@ foreach target : target_dirs
                gui_app: exe['gui'])
 
     emulators += {exe['name']: emulator}
+
+    if get_option('tests').enabled() and \
+       'CONFIG_LATX' in config_target
+      test(
+        target + '-latx-runtime-info',
+        find_program('tests/runtime/test-latx-runtime-info.sh'),
+        args: [python.full_path(), emulator.full_path(), target_name],
+        depends: emulator,
+        protocol: 'exitcode',
+        suite: 'lat-pr-fast',
+        timeout: 300,
+      )
+    endif
 
   endforeach
 endforeach

--- a/target/i386/latx/include/latx-options.h
+++ b/target/i386/latx/include/latx-options.h
@@ -11,6 +11,7 @@
 #include "optimize-config.h"
 #include "latx-disassemble-trace.h"
 #include "latx-debug.h"
+#include "latx-runtime.h"
 
 #ifdef TARGET_X86_64
 #define LATX_SYSTEM_CONFIG_FILE "/etc/latx-x86_64.conf"
@@ -237,6 +238,7 @@ uint8 options_to_save(void);
 void options_parse_latx_disassemble_trace_cmp(const char *args);
 void conf_init(char **target_argv);
 char* guest_program(char **argv);
-void load_conf_file(const char *file, char* program);
+void load_conf_file(const char *file, const char *program,
+                    LatxRuntimeSource runtime_source);
 void find_option(const char *name, const char *val);
 #endif

--- a/target/i386/latx/include/latx-runtime.h
+++ b/target/i386/latx/include/latx-runtime.h
@@ -1,0 +1,24 @@
+/*
+ * SPDX-FileCopyrightText: 2026 LAT Project Authors
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#ifndef LATX_RUNTIME_H
+#define LATX_RUNTIME_H
+
+typedef enum LatxRuntimeSource {
+    LATX_RUNTIME_SOURCE_DEFAULT,
+    LATX_RUNTIME_SOURCE_SYSTEM_CONFIG,
+    LATX_RUNTIME_SOURCE_USER_CONFIG,
+    LATX_RUNTIME_SOURCE_ENVIRONMENT,
+    LATX_RUNTIME_SOURCE_COMMAND_LINE,
+} LatxRuntimeSource;
+
+void latx_runtime_reset(void);
+void latx_runtime_option_source_set(LatxRuntimeSource source);
+void latx_runtime_prefix_selected(void);
+const char *latx_runtime_prefix_source_name(void);
+const char *latx_runtime_guest_abi(void);
+
+#endif

--- a/target/i386/latx/include/latx-runtime.h
+++ b/target/i386/latx/include/latx-runtime.h
@@ -20,5 +20,6 @@ void latx_runtime_option_source_set(LatxRuntimeSource source);
 void latx_runtime_prefix_selected(void);
 const char *latx_runtime_prefix_source_name(void);
 const char *latx_runtime_guest_abi(void);
+const char *latx_runtime_loader_errno_name(int errnum);
 
 #endif

--- a/target/i386/latx/include/myalign.h
+++ b/target/i386/latx/include/myalign.h
@@ -19,7 +19,6 @@
 #include "callback.h"
 
 extern elfheader_t* elf_header;
-extern const char *interp_prefix;
 extern int latx_wine;
 extern int is_user_map;
 #define M_F_FD_WINE 0

--- a/target/i386/latx/latx-options.c
+++ b/target/i386/latx/latx-options.c
@@ -9,6 +9,7 @@
 #include "qemu/cutils.h"
 #include "reg-alloc.h"
 #include "latx-debug.h"
+#include "latx-runtime.h"
 #include "latx-string-utils.h"
 #include "translate.h"
 
@@ -111,15 +112,19 @@ unsigned long long counter_tb_tr;
 unsigned long long counter_ir1_tr;
 unsigned long long counter_mips_tr;
 
-void load_conf_file(const char *file, char *program)
+void load_conf_file(const char *file, const char *program,
+                    LatxRuntimeSource runtime_source)
 {
     FILE *fp = fopen(file, "r");
-    if (!program || !fp)
-        return;
-
     char *line = NULL;
     size_t len = 0;
     int flag = 0;
+
+    if (!fp) {
+        return;
+    }
+
+    latx_runtime_option_source_set(runtime_source);
 
     while(getline(&line, &len, fp) != -1) {
         char *option_name, *option_value;
@@ -134,6 +139,11 @@ void load_conf_file(const char *file, char *program)
             if(!end) continue;
             if (flag == 2)
                 break;
+            if (!program) {
+                /* Without a guest name, only global options apply. */
+                flag = 1;
+                continue;
+            }
             size_t size = end - line;
             line[size] = '\0';
             if (!strcmp(line + 1, program)) {
@@ -188,15 +198,17 @@ void conf_init(char **argv)
     const char *home_path = getenv("HOME");
 
     /* load /etc/latx-*.conf */
-    load_conf_file(LATX_SYSTEM_CONFIG_FILE, program);
+    load_conf_file(LATX_SYSTEM_CONFIG_FILE, program,
+                   LATX_RUNTIME_SOURCE_SYSTEM_CONFIG);
     if (latx_user_config_path(path, sizeof(path), home_path,
                               LATX_USER_CONFIG_FILE)) {
-        load_conf_file(path, program);
+        load_conf_file(path, program, LATX_RUNTIME_SOURCE_USER_CONFIG);
     }
 }
 
 void options_init(void)
 {
+    latx_runtime_reset();
     option_debug_lative = 0;
     option_save_xmm = 0xff;
     option_dump_host = 0;

--- a/target/i386/latx/latx-runtime.c
+++ b/target/i386/latx/latx-runtime.c
@@ -52,3 +52,15 @@ const char *latx_runtime_guest_abi(void)
     return "i386";
 #endif
 }
+
+const char *latx_runtime_loader_errno_name(int errnum)
+{
+    switch (errnum) {
+    case ENOENT:
+        return "not_found";
+    case EACCES:
+        return "permission_denied";
+    default:
+        return "io_error";
+    }
+}

--- a/target/i386/latx/latx-runtime.c
+++ b/target/i386/latx/latx-runtime.c
@@ -1,0 +1,54 @@
+/*
+ * SPDX-FileCopyrightText: 2026 LAT Project Authors
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#include "qemu/osdep.h"
+#include "latx-runtime.h"
+
+static LatxRuntimeSource option_source = LATX_RUNTIME_SOURCE_DEFAULT;
+static LatxRuntimeSource prefix_source = LATX_RUNTIME_SOURCE_DEFAULT;
+
+void latx_runtime_reset(void)
+{
+    option_source = LATX_RUNTIME_SOURCE_DEFAULT;
+    prefix_source = LATX_RUNTIME_SOURCE_DEFAULT;
+}
+
+void latx_runtime_option_source_set(LatxRuntimeSource source)
+{
+    option_source = source;
+}
+
+void latx_runtime_prefix_selected(void)
+{
+    prefix_source = option_source;
+}
+
+const char *latx_runtime_prefix_source_name(void)
+{
+    switch (prefix_source) {
+    case LATX_RUNTIME_SOURCE_SYSTEM_CONFIG:
+        return "system_config";
+    case LATX_RUNTIME_SOURCE_USER_CONFIG:
+        return "user_config";
+    case LATX_RUNTIME_SOURCE_ENVIRONMENT:
+        return "environment";
+    case LATX_RUNTIME_SOURCE_COMMAND_LINE:
+        return "command_line";
+    case LATX_RUNTIME_SOURCE_DEFAULT:
+        return "default";
+    }
+
+    g_assert_not_reached();
+}
+
+const char *latx_runtime_guest_abi(void)
+{
+#ifdef TARGET_X86_64
+    return "x86_64";
+#else
+    return "i386";
+#endif
+}

--- a/target/i386/latx/meson.build
+++ b/target/i386/latx/meson.build
@@ -62,6 +62,7 @@ if cs_latx_debug or cs_git
 endif
 
 latx_string_utils = files('latx-string-utils.c')
+latx_runtime = files('latx-runtime.c')
 
 i386_ss.add(when: 'CONFIG_LATX', if_true: files(
   'error.c',
@@ -72,7 +73,7 @@ i386_ss.add(when: 'CONFIG_LATX', if_true: files(
   'latx-name-demangling.cpp',
   'latx-special-args.c',
   'latx-signal.c',
-) + latx_string_utils)
+) + latx_string_utils + latx_runtime)
 
 lazydis_lib = static_library('lazydis',
                          build_by_default: false,

--- a/tests/latx/latx-config-regression.c
+++ b/tests/latx/latx-config-regression.c
@@ -9,6 +9,7 @@
 
 #include "latx-string-utils.h"
 #include "latx-options.h"
+#include "latx-runtime.h"
 
 static bool config_option_registered(const char *expected)
 {
@@ -36,6 +37,35 @@ static void test_target_config_files(void)
 static void test_release_loader_prefix_config(void)
 {
     g_assert_true(config_option_registered("LAT_LD_PREFIX"));
+}
+
+static void test_runtime_prefix_source(void)
+{
+    latx_runtime_reset();
+    g_assert_cmpstr(latx_runtime_prefix_source_name(), ==, "default");
+
+    latx_runtime_option_source_set(LATX_RUNTIME_SOURCE_SYSTEM_CONFIG);
+    latx_runtime_prefix_selected();
+    g_assert_cmpstr(latx_runtime_prefix_source_name(), ==,
+                    "system_config");
+
+    latx_runtime_option_source_set(LATX_RUNTIME_SOURCE_USER_CONFIG);
+    latx_runtime_prefix_selected();
+    g_assert_cmpstr(latx_runtime_prefix_source_name(), ==, "user_config");
+
+    latx_runtime_option_source_set(LATX_RUNTIME_SOURCE_ENVIRONMENT);
+    latx_runtime_prefix_selected();
+    g_assert_cmpstr(latx_runtime_prefix_source_name(), ==, "environment");
+
+    latx_runtime_option_source_set(LATX_RUNTIME_SOURCE_COMMAND_LINE);
+    latx_runtime_prefix_selected();
+    g_assert_cmpstr(latx_runtime_prefix_source_name(), ==, "command_line");
+
+#ifdef TARGET_X86_64
+    g_assert_cmpstr(latx_runtime_guest_abi(), ==, "x86_64");
+#else
+    g_assert_cmpstr(latx_runtime_guest_abi(), ==, "i386");
+#endif
 }
 
 static void test_user_config_path(void)
@@ -152,6 +182,8 @@ int main(int argc, char **argv)
                     test_target_config_files);
     g_test_add_func("/latx/config/release-loader-prefix",
                     test_release_loader_prefix_config);
+    g_test_add_func("/latx/config/runtime-prefix-source",
+                    test_runtime_prefix_source);
     g_test_add_func("/latx/config/user-config-path",
                     test_user_config_path);
 

--- a/tests/latx/latx-config-regression.c
+++ b/tests/latx/latx-config-regression.c
@@ -66,6 +66,11 @@ static void test_runtime_prefix_source(void)
 #else
     g_assert_cmpstr(latx_runtime_guest_abi(), ==, "i386");
 #endif
+
+    g_assert_cmpstr(latx_runtime_loader_errno_name(ENOENT), ==, "not_found");
+    g_assert_cmpstr(latx_runtime_loader_errno_name(EACCES), ==,
+                    "permission_denied");
+    g_assert_cmpstr(latx_runtime_loader_errno_name(EIO), ==, "io_error");
 }
 
 static void test_user_config_path(void)

--- a/tests/runtime/test-latx-runtime-info.sh
+++ b/tests/runtime/test-latx-runtime-info.sh
@@ -1,0 +1,85 @@
+#!/bin/sh
+set -eu
+
+[ "$#" -eq 3 ] || {
+    echo "usage: $0 PYTHON TRANSLATOR GUEST_ABI" >&2
+    exit 2
+}
+
+python=$1
+translator=$2
+guest_abi=$3
+workdir=$(mktemp -d)
+trap 'rm -rf "$workdir"' EXIT HUP INT TERM
+
+fail()
+{
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+assert_info()
+{
+    expected_root=$1
+    expected_source=$2
+    actual=$3
+
+    "$python" -c '
+import json
+import sys
+
+actual = json.loads(sys.argv[1])
+expected = {
+    "schema_version": 1,
+    "guest_abi": sys.argv[2],
+    "runtime_root": sys.argv[3],
+    "runtime_source": sys.argv[4],
+}
+if actual != expected:
+    raise SystemExit(f"unexpected runtime info: {actual!r} != {expected!r}")
+' "$actual" "$guest_abi" "$expected_root" "$expected_source" ||
+        fail "unexpected $expected_source runtime information"
+}
+
+case "$guest_abi" in
+    x86_64) config_name=latx-x86_64.conf ;;
+    i386) config_name=latx-i386.conf ;;
+    *) fail "unsupported test guest ABI: $guest_abi" ;;
+esac
+
+test_home=$workdir/home
+mkdir -p "$test_home/.config"
+cat > "$test_home/.config/$config_name" <<EOF
+UNKNOWN_RUNTIME_TEST_OPTION=ignored
+LAT_LD_PREFIX=$workdir/global-root
+[app]
+LAT_LD_PREFIX=$workdir/app-root
+EOF
+
+output=$(HOME=$test_home "$translator" --runtime-info \
+    2> "$workdir/user.stderr") || fail 'user runtime info failed'
+assert_info "$workdir/global-root" user_config "$output"
+
+output=$(HOME=$test_home "$translator" --runtime-info /usr/bin/app \
+    2> "$workdir/program.stderr") || fail 'program runtime info failed'
+assert_info "$workdir/app-root" user_config "$output"
+
+environment_root="$workdir/environment
+root"
+output=$(HOME=$test_home LAT_LD_PREFIX=$environment_root \
+    "$translator" --runtime-info 2> "$workdir/environment.stderr") ||
+    fail 'environment runtime info failed'
+assert_info "$environment_root" environment "$output"
+
+output=$(HOME=$test_home LAT_LD_PREFIX=$workdir/environment-root \
+    "$translator" --runtime-info -L "$workdir/command-line-root" \
+    2> "$workdir/command-line.stderr") ||
+    fail 'command-line runtime info failed'
+assert_info "$workdir/command-line-root" command_line "$output"
+
+output=$(HOME=$test_home LAT_VERSION=1 LATX_AVX_CPUID=1 \
+    "$translator" --runtime-info 2> "$workdir/noisy-option.stderr") ||
+    fail 'runtime info with a diagnostic option failed'
+assert_info "$workdir/global-root" user_config "$output"
+
+echo "PASS: $guest_abi runtime selection information"

--- a/tests/runtime/test-latx-runtime-info.sh
+++ b/tests/runtime/test-latx-runtime-info.sh
@@ -41,6 +41,82 @@ if actual != expected:
         fail "unexpected $expected_source runtime information"
 }
 
+assert_stderr()
+{
+    expected=$1
+    stderr_file=$2
+    context=$3
+
+    grep -F -- "$expected" "$stderr_file" > /dev/null ||
+        fail "$context: missing '$expected'"
+}
+
+make_elf()
+{
+    elf_kind=$1
+    elf_path=$2
+    elf_interp=$3
+    elf_base=$4
+
+    "$python" - "$guest_abi" "$elf_kind" "$elf_path" \
+        "$elf_interp" "$elf_base" <<'PY'
+import struct
+import sys
+
+abi, kind, output, interpreter, base_arg = sys.argv[1:]
+base = int(base_arg, 0)
+elf_type = 3 if kind == "loader" else 2
+
+if abi == "x86_64":
+    elf_class = 2
+    machine = 62
+    ehsize = 64
+    phentsize = 56
+    code = bytes.fromhex("b83c00000031ff0f05")
+    pack_ehdr = lambda ident, entry, phnum: struct.pack(
+        "<16sHHIQQQIHHHHHH", ident, elf_type, machine, 1, entry, ehsize, 0,
+        0, ehsize, phentsize, phnum, 0, 0, 0)
+    pack_load = lambda size: struct.pack(
+        "<IIQQQQQQ", 1, 5, 0, base, base, size, size, 0x1000)
+    pack_interp = lambda offset, size: struct.pack(
+        "<IIQQQQQQ", 3, 4, offset, 0, 0, size, size, 1)
+elif abi == "i386":
+    elf_class = 1
+    machine = 3
+    ehsize = 52
+    phentsize = 32
+    code = bytes.fromhex("b80100000031dbcd80")
+    pack_ehdr = lambda ident, entry, phnum: struct.pack(
+        "<16sHHIIIIIHHHHHH", ident, elf_type, machine, 1, entry, ehsize, 0,
+        0, ehsize, phentsize, phnum, 0, 0, 0)
+    pack_load = lambda size: struct.pack(
+        "<IIIIIIII", 1, 0, base, base, size, size, 5, 0x1000)
+    pack_interp = lambda offset, size: struct.pack(
+        "<IIIIIIII", 3, offset, 0, 0, size, size, 4, 1)
+else:
+    raise SystemExit(f"unsupported guest ABI: {abi}")
+
+ident = b"\x7fELF" + bytes([elf_class, 1, 1, 0]) + bytes(8)
+interp_data = interpreter.encode() + b"\0" if kind == "dynamic" else b""
+phnum = 2 if interp_data else 1
+interp_offset = ehsize + phentsize * phnum
+code_offset = interp_offset + len(interp_data)
+total_size = code_offset + len(code)
+
+ehdr = pack_ehdr(ident, base + code_offset, phnum)
+phdrs = pack_load(total_size)
+if interp_data:
+    phdrs += pack_interp(interp_offset, len(interp_data))
+
+with open(output, "wb") as f:
+    if kind == "truncated":
+        f.write(ehdr)
+    else:
+        f.write(ehdr + phdrs + interp_data + code)
+PY
+    chmod +x "$elf_path"
+}
+
 case "$guest_abi" in
     x86_64) config_name=latx-x86_64.conf ;;
     i386) config_name=latx-i386.conf ;;
@@ -82,4 +158,139 @@ output=$(HOME=$test_home LAT_VERSION=1 LATX_AVX_CPUID=1 \
     fail 'runtime info with a diagnostic option failed'
 assert_info "$workdir/global-root" user_config "$output"
 
-echo "PASS: $guest_abi runtime selection information"
+case "$guest_abi" in
+    x86_64)
+        main_base=0x400000
+        ;;
+    i386)
+        main_base=0x08048000
+        ;;
+esac
+
+empty_home=$workdir/empty-home
+mkdir -p "$empty_home"
+guest_loader=/latu-test/actual-$guest_abi-loader.so
+dynamic_guest=$workdir/dynamic-$guest_abi
+static_guest=$workdir/static-$guest_abi
+make_elf dynamic "$dynamic_guest" "$guest_loader" "$main_base"
+make_elf static "$static_guest" '' "$main_base"
+
+missing_root=$workdir/missing-root
+mkdir -p "$missing_root"
+set +e
+HOME=$empty_home "$translator" -L "$missing_root" "$dynamic_guest" \
+    > "$workdir/missing.stdout" 2> "$workdir/missing.stderr"
+missing_status=$?
+set -e
+[ "$missing_status" -ne 0 ] || fail 'missing loader unexpectedly succeeded'
+assert_stderr 'LATU: guest runtime loader failure' \
+    "$workdir/missing.stderr" 'missing loader'
+assert_stderr "guest ABI: $guest_abi" \
+    "$workdir/missing.stderr" 'missing loader'
+assert_stderr "PT_INTERP: $guest_loader" \
+    "$workdir/missing.stderr" 'missing loader'
+assert_stderr "runtime root: $missing_root" \
+    "$workdir/missing.stderr" 'missing loader'
+assert_stderr 'runtime source: command_line' \
+    "$workdir/missing.stderr" 'missing loader'
+assert_stderr "configured loader: $missing_root$guest_loader" \
+    "$workdir/missing.stderr" 'missing loader'
+assert_stderr "attempted loader: $guest_loader" \
+    "$workdir/missing.stderr" 'missing loader'
+assert_stderr 'failure reason: not_found' \
+    "$workdir/missing.stderr" 'missing loader'
+assert_stderr "next step: run 'latu-runtime-manager status'" \
+    "$workdir/missing.stderr" 'missing loader'
+
+relative_loader=latu-test/missing-$guest_abi-loader.so
+relative_guest=$workdir/relative-$guest_abi
+make_elf dynamic "$relative_guest" "$relative_loader" "$main_base"
+set +e
+(
+    cd "$workdir"
+    HOME=$empty_home "$translator" -L "$missing_root" "$relative_guest"
+) > "$workdir/relative.stdout" 2> "$workdir/relative.stderr"
+relative_status=$?
+set -e
+[ "$relative_status" -ne 0 ] || fail 'relative loader unexpectedly succeeded'
+assert_stderr "PT_INTERP: $relative_loader" \
+    "$workdir/relative.stderr" 'relative loader'
+assert_stderr "configured loader: $relative_loader" \
+    "$workdir/relative.stderr" 'relative loader'
+assert_stderr "attempted loader: $relative_loader" \
+    "$workdir/relative.stderr" 'relative loader'
+assert_stderr 'failure reason: not_found' \
+    "$workdir/relative.stderr" 'relative loader'
+
+corrupt_root=$workdir/corrupt-root
+mkdir -p "$corrupt_root$(dirname "$guest_loader")"
+printf 'not an ELF loader\n' > "$corrupt_root$guest_loader"
+set +e
+HOME=$empty_home "$translator" -L "$corrupt_root" "$dynamic_guest" \
+    > "$workdir/corrupt.stdout" 2> "$workdir/corrupt.stderr"
+corrupt_status=$?
+set -e
+[ "$corrupt_status" -ne 0 ] || fail 'corrupt loader unexpectedly succeeded'
+assert_stderr "PT_INTERP: $guest_loader" \
+    "$workdir/corrupt.stderr" 'corrupt loader'
+assert_stderr "configured loader: $corrupt_root$guest_loader" \
+    "$workdir/corrupt.stderr" 'corrupt loader'
+assert_stderr "attempted loader: $corrupt_root$guest_loader" \
+    "$workdir/corrupt.stderr" 'corrupt loader'
+assert_stderr 'failure reason: invalid_elf' \
+    "$workdir/corrupt.stderr" 'corrupt loader'
+
+load_error_root=$workdir/load-error-root
+mkdir -p "$load_error_root$(dirname "$guest_loader")"
+make_elf truncated "$load_error_root$guest_loader" '' 0
+set +e
+HOME=$empty_home "$translator" -L "$load_error_root" "$dynamic_guest" \
+    > "$workdir/load-error.stdout" 2> "$workdir/load-error.stderr"
+load_error_status=$?
+set -e
+[ "$load_error_status" -ne 0 ] || fail 'truncated loader unexpectedly succeeded'
+assert_stderr "attempted loader: $load_error_root$guest_loader" \
+    "$workdir/load-error.stderr" 'truncated loader'
+assert_stderr 'failure reason: load_error' \
+    "$workdir/load-error.stderr" 'truncated loader'
+
+permission_root=$workdir/permission-root
+mkdir -p "$permission_root$(dirname "$guest_loader")"
+: > "$permission_root$guest_loader"
+chmod 000 "$permission_root$guest_loader"
+if [ "$(id -u)" -ne 0 ]; then
+    set +e
+    HOME=$empty_home "$translator" -L "$permission_root" "$dynamic_guest" \
+        > "$workdir/permission.stdout" 2> "$workdir/permission.stderr"
+    permission_status=$?
+    set -e
+    [ "$permission_status" -ne 0 ] ||
+        fail 'unreadable loader unexpectedly succeeded'
+    assert_stderr 'failure reason: permission_denied' \
+        "$workdir/permission.stderr" 'unreadable loader'
+fi
+
+if [ "${LATX_RUNTIME_TEST_SKIP_GUEST_EXECUTION:-0}" = 1 ]; then
+    echo "SKIP: $guest_abi translated guest execution"
+else
+    success_root=$workdir/success-root
+    mkdir -p "$success_root$(dirname "$guest_loader")"
+    make_elf loader "$success_root$guest_loader" '' 0
+    HOME=$empty_home "$translator" -L "$success_root" "$dynamic_guest" \
+        > "$workdir/success.stdout" 2> "$workdir/success.stderr" ||
+        fail 'valid runtime loader failed'
+    if grep -F 'LATU: guest runtime loader failure' \
+            "$workdir/success.stderr" > /dev/null; then
+        fail 'valid runtime loader emitted failure guidance'
+    fi
+
+    HOME=$empty_home "$translator" -L "$missing_root" "$static_guest" \
+        > "$workdir/static.stdout" 2> "$workdir/static.stderr" ||
+        fail 'static guest failed without a runtime'
+    if grep -F 'LATU: guest runtime loader failure' \
+            "$workdir/static.stderr" > /dev/null; then
+        fail 'static guest emitted runtime failure guidance'
+    fi
+fi
+
+echo "PASS: $guest_abi runtime selection and loader guidance"

--- a/tests/unit/test-util-path.c
+++ b/tests/unit/test-util-path.c
@@ -109,6 +109,23 @@ static void test_proc_namespace_boundaries(void)
     g_free(escaped);
 }
 
+static void test_configured_path(void)
+{
+    const char *absolute = "/lib/missing-loader.so";
+    const char *relative = "lib/missing-loader.so";
+    char *expected = g_build_filename(prefix, absolute, NULL);
+    g_autofree char *absolute_configured = path_get_prefixed(absolute);
+    g_autofree char *relative_configured = path_get_prefixed(relative);
+    g_autofree char *proc_configured = path_get_prefixed("/proc/self/status");
+
+    g_assert_cmpstr(absolute_configured, ==, expected);
+    g_assert_cmpstr(path(absolute), ==, absolute);
+    g_assert_cmpstr(relative_configured, ==, relative);
+    g_assert_cmpstr(path(relative), ==, relative);
+    g_assert_cmpstr(proc_configured, ==, "/proc/self/status");
+    g_free(expected);
+}
+
 int main(int argc, char **argv)
 {
     GError *error = NULL;
@@ -146,6 +163,7 @@ int main(int argc, char **argv)
                     test_proc_namespace_ignores_prefix);
     g_test_add_func("/util/path/proc-namespace-boundaries",
                     test_proc_namespace_boundaries);
+    g_test_add_func("/util/path/configured-path", test_configured_path);
 
     ret = g_test_run();
 

--- a/util/path.c
+++ b/util/path.c
@@ -58,6 +58,31 @@ void init_paths(const char *prefix)
     qemu_mutex_init(&lock);
 }
 
+static bool path_has_prefix(const char *name)
+{
+    if (!base || !name || name[0] != '/' || name[1] == '\0') {
+        return false;
+    }
+
+#ifdef CONFIG_LATX
+    /* Keep live procfs visible even when the runtime contains /proc. */
+    if (path_is_proc_namespace(name)) {
+        return false;
+    }
+#endif
+
+    return true;
+}
+
+char *path_get_prefixed(const char *name)
+{
+    if (!path_has_prefix(name)) {
+        return g_strdup(name);
+    }
+
+    return g_build_filename(base, name, NULL);
+}
+
 /* Look for path in emulation dir, otherwise return name. */
 const char *path(const char *name)
 {
@@ -65,21 +90,9 @@ const char *path(const char *name)
     const char *ret;
 
     /* Only do absolute paths: quick and dirty, but should mostly be OK.  */
-    if (!base || !name || name[0] != '/'
-            || (name[0]  == '/' && name[1] == '\0')) {
+    if (!path_has_prefix(name)) {
         return name;
     }
-
-#ifdef CONFIG_LATX
-    /*
-     * LAT's packaged x86 runtime may contain an inert /proc mount point.
-     * Resolve procfs in the calling task's current namespace instead of
-     * letting that directory shadow the live filesystem.
-     */
-    if (path_is_proc_namespace(name)) {
-        return name;
-    }
-#endif
 
     qemu_mutex_lock(&lock);
 
@@ -88,7 +101,7 @@ const char *path(const char *name)
         ret = value ? value : name;
     } else {
         char *save = g_strdup(name);
-        char *full = g_build_filename(base, name, NULL);
+        char *full = path_get_prefixed(name);
 
         /* Look for the path; record the result, pass or fail.  */
         if (access(full, F_OK) == 0) {


### PR DESCRIPTION
## Series

This is PR 3 in the LATU runtime usability series.

- #365 (PR 1) is the required base: dual-target loader-prefix configuration.
- #369 (PR 2) provides the companion `latu-runtime-manager status` command.
- This PR adds translator-side runtime metadata and actionable loader-failure guidance.

Because #365 is a cross-fork PR, GitHub cannot use its head as this PR's base.
Until #365 is merged, **Files changed** also contains the three PR 1 commits.
The PR 3 delta is the final three commits in this branch and can be reviewed
directly in this comparison:
https://github.com/LaurenIsACoder/lat/compare/lauren/latu-user-loader-prefix...lauren/latu-runtime-guidance-pr

This PR should be merged only after both #365 and #369. PR #369 provides the
command named in the runtime-failure guidance.

## Summary

- add `--runtime-info` to both `latx-x86_64` and `latx-i386`
- report the selected runtime root, guest ABI, and selection source as
  versioned JSON
- preserve the actual ELF `PT_INTERP` value when reporting loader failures
- show both the configured loader path and the path actually attempted after
  QEMU path fallback
- distinguish missing, unreadable, I/O, invalid-header, and later
  load/validation failures
- point users to `latu-runtime-manager status`
- keep static ELF execution and successful dynamic execution unchanged

Example:

```console
$ latx-x86_64 --runtime-info -L /opt/x86-runtime
{"runtime_source": "command_line", "schema_version": 1, "runtime_root": "/opt/x86-runtime", "guest_abi": "x86_64"}
```

A loader failure now reports the guest ABI, actual `PT_INTERP`, selected
runtime root, selection source, configured loader path, actually attempted
path, stable reason, underlying detail, and next command.

## Commit structure

1. expose selected runtime information and its source
2. refactor ELF image loading so interpreter errors can be returned without
   changing existing diagnostics
3. add actionable LATU runtime-loader guidance and regression coverage

## Scope

This PR does not download, create, install, or select a distribution-specific
runtime. It only exposes translator state and improves failures at the point
where the ELF interpreter is actually loaded.

## Validation

On a LoongArch host, using the exact final commit chain:

- deterministic RED on the parent of the guidance commit; GREEN on the final
  commit
- normal tests-disabled product builds: x86_64 PASS, i386 PASS
- CI-equivalent debug `-Werror` builds: x86_64 KZT PASS, i386 PASS
- `lat-pr-fast`: x86_64 12/12 PASS, i386 6/6 PASS
- focused runtime tests cover both ABIs, all selection sources, JSON escaping,
  missing loader, invalid header, truncated/load error, real EACCES, valid
  dynamic loader, and static ELF without false guidance
- the nested CI run exercises metadata and every pre-execution diagnostic but
  skips translated guest execution; the native LoongArch run covers the full
  dynamic and static success paths
- the nested-emulation test has an explicit 300-second per-test timeout; the
  workflow has a 30-minute job timeout so a cold nested build can finish first
- real x86_64 runtime executes successfully with the selected root
- private `binfmt_misc` gates pass for x86_64 and i386; the host binfmt
  registrations are unchanged before and after the tests
- normal product builds do not build the test-only fixtures
- `git diff --check` passes; checkpatch reports no errors
