### PR TITLE
LATX, fix: unlink translated caller on helper signals

### DIFF
--- a/target/i386/latx/latx-signal.c
+++ b/target/i386/latx/latx-signal.c
@@ -223,6 +223,35 @@ bool signal_in_glue(CPUArchState *env, ucontext_t *uc)
     return true;
 }
 
+static void unlink_tb_jmp(CPUArchState *env, TranslationBlock *current_tb,
+                          ucontext_t *uc)
+{
+#ifdef CONFIG_LATX_TU
+    if (current_tb->bool_flags & IS_TU_SPLIT) {
+        TranslationBlock *next_tb = current_tb;
+        /* The split TB cannot be unlinked, so we need to found an unsplit TB. */
+        while (next_tb && (next_tb->bool_flags & IS_TU_SPLIT)) {
+            uintptr_t next_pc = (uintptr_t) current_tb->tc.ptr + current_tb->tc.size + 1;
+            next_tb = tcg_tb_lookup(next_pc);
+            if (next_tb) {
+                current_tb = next_tb;
+            }
+        }
+    }
+    if (use_tu_jmp(current_tb)) {
+        assert(current_tb->tu_jmp[TU_TB_INDEX_TARGET] != TB_JMP_RESET_OFFSET_INVALID);
+        unlink_tu_jmp(current_tb);
+        return;
+    }
+#endif
+    if (use_indirect_jmp(current_tb) &&
+            current_tb->jmp_indirect != TB_JMP_RESET_OFFSET_INVALID) {
+        unlink_indirect_jmp(env, current_tb, uc);
+    } else {
+        unlink_direct_jmp(current_tb);
+    }
+}
+
 void tb_exit_to_qemu(CPUArchState *env, ucontext_t *uc)
 {
     TranslationBlock *current_tb = NULL;
@@ -230,30 +259,7 @@ void tb_exit_to_qemu(CPUArchState *env, ucontext_t *uc)
 
     current_tb = tcg_tb_lookup(pc);
     if (current_tb) {
-#ifdef CONFIG_LATX_TU
-        if (current_tb->bool_flags & IS_TU_SPLIT) {
-            TranslationBlock *next_tb = current_tb;
-            /* The split TB cannot be unlinked, so we need to found an unsplit TB. */
-            while (next_tb && (next_tb->bool_flags & IS_TU_SPLIT)) {
-                uintptr_t next_pc = (uintptr_t) current_tb->tc.ptr + current_tb->tc.size + 1;
-                next_tb = tcg_tb_lookup(next_pc);
-                if (next_tb) {
-                    current_tb = next_tb;
-                }
-            }
-        }
-        if (use_tu_jmp(current_tb)) {
-            assert(current_tb->tu_jmp[TU_TB_INDEX_TARGET] != TB_JMP_RESET_OFFSET_INVALID);
-            unlink_tu_jmp(current_tb);
-            return;
-        }
-#endif
-        if (use_indirect_jmp(current_tb) &&
-                current_tb->jmp_indirect != TB_JMP_RESET_OFFSET_INVALID) {
-            unlink_indirect_jmp(env, current_tb, uc);
-        } else {
-            unlink_direct_jmp(current_tb);
-        }
+        unlink_tb_jmp(env, current_tb, uc);
     } else {
         if (!signal_in_glue(env, uc)) {
 #ifdef SIGNAL_UNLINK_DBG

--- a/target/i386/latx/latx-signal.c
+++ b/target/i386/latx/latx-signal.c
@@ -260,8 +260,17 @@ void tb_exit_to_qemu(CPUArchState *env, ucontext_t *uc)
     current_tb = tcg_tb_lookup(pc);
     if (current_tb) {
         unlink_tb_jmp(env, current_tb, uc);
-    } else {
-        if (!signal_in_glue(env, uc)) {
+    } else if (!signal_in_glue(env, uc)) {
+        /*
+         * A leaf C helper is called directly from translated code, so the
+         * saved return address points into its translated caller. A lookup
+         * miss means the signal did not interrupt such a helper, so it is
+         * safe to leave every TB linked as before.
+         */
+        current_tb = tcg_tb_lookup(UC_GR(uc)[1] - sizeof(uint32_t));
+        if (current_tb) {
+            unlink_tb_jmp(env, current_tb, uc);
+        } else {
 #ifdef SIGNAL_UNLINK_DBG
             fprintf(stderr, "lhl-debug %s current_tb NULL pid %d\n", __func__, getpid());
 #endif


### PR DESCRIPTION
## Summary

- recover the translated caller from the saved LoongArch return address when a host signal interrupts a native leaf helper outside the code cache
- preserve the existing signal-in-glue handling
- apply the existing split-TU walk before unlinking an AOT/TU caller

## Root cause

`tb_exit_to_qemu()` originally looked up only the interrupted host PC. OpenSSL AES helpers execute as native C helpers outside the translated code cache, so a `SIGALRM` delivered inside one of these helpers produced no `TranslationBlock`. The caller stayed linked and execution could continue without returning to the dispatcher to process the pending guest signal.

The failure is not AOT-specific. Runtime inspection showed the same lookup miss with default AOT and with `LATX_AOT=0`; the saved return address resolves to a TU TB in the former case and a normal dynamic TB in the latter.

## Validation

- reproduced the original OpenSSL hang on LoongArch AOSC OS
- confirmed with GDB that the interrupted helper PC misses the TB lookup while `RA - 4` resolves the translated caller in both AOT modes
- release build completed on LoongArch
- 10/10 consecutive OpenSSL AES-128-GCM speed runs completed with default AOT
- 10/10 consecutive OpenSSL AES-128-GCM speed runs completed with `LATX_AOT=0`

Fixes #150
