### PR TITLE
Fix CREATE_SYSV_VALIST issue

### DIFF
--- a/target/i386/cpu.h
+++ b/target/i386/cpu.h
@@ -1236,6 +1236,7 @@ typedef struct {
  * that APIC ID hasn't been set yet
  */
 #define UNASSIGNED_APIC_ID 0xFFFFFFFF
+#define N_SCRATCH 200
 
 typedef union X86LegacyXSaveArea {
     struct {
@@ -1662,6 +1663,7 @@ typedef struct CPUX86State {
     ucontext_t *puc;
     uintptr_t insn_save[2];
 #endif
+    uint64_t scratch[N_SCRATCH];
 } CPUX86State;
 
 struct kvm_msrs;

--- a/target/i386/latx/context/wrappedlibc.c
+++ b/target/i386/latx/context/wrappedlibc.c
@@ -633,45 +633,40 @@ EXPORT void my___longjmp_chk(/*struct __jmp_buf_tag __env[1]*/void *p, int32_t _
 //EXPORT int32_t my___sigsetjmp(/*struct __jmp_buf_tag __env[1]*/void *p) __attribute__((alias("my_setjmp")));
 
 EXPORT int my_printf(void* fmt, void* b) {
-    char scratch_buff [26*8] = {0};
     __MY_CPU;
-    myStackAlign((const char*)fmt, b, (uint64_t *)scratch_buff, cpu->regs[R_EAX], 1);
+    myStackAlign((const char*)fmt, b, cpu->scratch, cpu->regs[R_EAX], 1);
     PREPARE_VALIST;
     return vprintf((const char*)fmt, VARARGS);
 }
 EXPORT int my___printf_chk(int chk, void* fmt, void* b)
 {
     (void)chk;
-    char scratch_buff [26*8] = {0};
     __MY_CPU;
-    myStackAlign((const char*)fmt, b, (uint64_t *)scratch_buff, cpu->regs[R_EAX], 2);
+    myStackAlign((const char*)fmt, b, cpu->scratch, cpu->regs[R_EAX], 2);
     PREPARE_VALIST;
     return vprintf((const char*)fmt, VARARGS);
 }
 EXPORT int my_wprintf(void* fmt, void* b) {
-    char scratch_buff [26*8] = {0};
     __MY_CPU;
-    myStackAlignW((const char*)fmt, b, (uint64_t *)scratch_buff, cpu->regs[R_EAX], 1);
+    myStackAlignW((const char*)fmt, b, cpu->scratch, cpu->regs[R_EAX], 1);
     PREPARE_VALIST;
     return vwprintf((const wchar_t*)fmt, VARARGS);
 }
 EXPORT int my___wprintf_chk(int chk, void* fmt, void* b)
 {
     (void)chk;
-    char scratch_buff [26*8] = {0};
     __MY_CPU;
-    myStackAlignW((const char*)fmt, b, (uint64_t *)scratch_buff, cpu->regs[R_EAX], 2);
+    myStackAlignW((const char*)fmt, b, cpu->scratch, cpu->regs[R_EAX], 2);
     PREPARE_VALIST;
     return vwprintf((const wchar_t*)fmt, VARARGS);
 }
 
 EXPORT int my_vprintf(void* fmt, x64_va_list_t b) {
+    __MY_CPU;
     #ifdef CONVERT_VALIST
     CONVERT_VALIST(b);
     #else
-    char scratch_buff [26*8] = {0};
-    myStackAlignValist((const char*)fmt, (uint64_t *)scratch_buff, b);
-    __MY_CPU;
+    myStackAlignValist((const char*)fmt, cpu->scratch, b);
     PREPARE_VALIST;
     #endif
     return vprintf(fmt, VARARGS);
@@ -679,12 +674,11 @@ EXPORT int my_vprintf(void* fmt, x64_va_list_t b) {
 EXPORT int my___vprintf_chk(void* fmt, x64_va_list_t b) __attribute__((alias("my_vprintf")));
 
 EXPORT int my_vfprintf(void* F, void* fmt, x64_va_list_t b) {
+    __MY_CPU;
     #ifdef CONVERT_VALIST
     CONVERT_VALIST(b);
     #else
-    char scratch_buff [26*8] = {0};
-    myStackAlignValist((const char*)fmt, (uint64_t *)scratch_buff, b);
-    __MY_CPU;
+    myStackAlignValist((const char*)fmt, cpu->scratch, b);
     PREPARE_VALIST;
     #endif
     return vfprintf(F, fmt, VARARGS);
@@ -693,28 +687,25 @@ EXPORT int my___vfprintf_chk(void* F, void* fmt, x64_va_list_t b) __attribute__(
 EXPORT int my__IO_vfprintf(void* F, void* fmt, x64_va_list_t b) __attribute__((alias("my_vfprintf")));
 
 EXPORT int my_fprintf(void* F, void* fmt, void* b)  {
-    char scratch_buff [26*8] = {0};
     __MY_CPU;
-    myStackAlign((const char*)fmt, b, (uint64_t *)scratch_buff, cpu->regs[R_EAX], 2);
+    myStackAlign((const char*)fmt, b, cpu->scratch, cpu->regs[R_EAX], 2);
     PREPARE_VALIST;
     return vfprintf(F, fmt, VARARGS);
 }
 EXPORT int my___fprintf_chk(void* F, int flag, void* fmt, void* b)  {
     (void)flag;
-    char scratch_buff [26*8] = {0};
     __MY_CPU;
-    myStackAlign((const char*)fmt, b, (uint64_t *)scratch_buff, cpu->regs[R_EAX], 3);
+    myStackAlign((const char*)fmt, b, cpu->scratch, cpu->regs[R_EAX], 3);
     PREPARE_VALIST;
     return vfprintf(F, fmt, VARARGS);
 }
 
 EXPORT int my_vwprintf(void* fmt, x64_va_list_t b) {
+    __MY_CPU;
     #ifdef CONVERT_VALIST
     CONVERT_VALIST(b);
     #else
-    char scratch_buff [26*8] = {0};
-    myStackAlignWValist((const char*)fmt, (uint64_t *)scratch_buff, b);
-    __MY_CPU;
+    myStackAlignWValist((const char*)fmt, cpu->scratch, b);
     PREPARE_VALIST;
     #endif
     int r = vwprintf(fmt, VARARGS);
@@ -722,82 +713,74 @@ EXPORT int my_vwprintf(void* fmt, x64_va_list_t b) {
 }
 
 EXPORT int my_fwprintf(void* F, void* fmt, void* b)  {
-    char scratch_buff [26*8] = {0};
     __MY_CPU;
-    myStackAlignW((const char*)fmt, b, (uint64_t *)scratch_buff, cpu->regs[R_EAX], 2);
+    myStackAlignW((const char*)fmt, b, cpu->scratch, cpu->regs[R_EAX], 2);
     PREPARE_VALIST;
     return vfwprintf(F, fmt, VARARGS);
 }
 
 EXPORT int my___fwprintf_chk(void* F, int flag, void* fmt, void* b) {
-    char scratch_buff [26*8] = {0};
     __MY_CPU;
-    myStackAlignW((const char*)fmt, b, (uint64_t *)scratch_buff, cpu->regs[R_EAX], 3);
+    myStackAlignW((const char*)fmt, b, cpu->scratch, cpu->regs[R_EAX], 3);
     PREPARE_VALIST;
     return vfwprintf(F, fmt, VARARGS);
 }
 
 EXPORT int my_vfwprintf(void* F, void* fmt, x64_va_list_t  b) {
+    __MY_CPU;
     #ifdef CONVERT_VALIST
     CONVERT_VALIST(b);
     #else
-    char scratch_buff [26*8] = {0};
-    myStackAlignWValist((const char*)fmt, (uint64_t *)scratch_buff, b);
-    __MY_CPU;
+    myStackAlignWValist((const char*)fmt, cpu->scratch, b);
     PREPARE_VALIST;
     #endif
     return vfwprintf(F, fmt, VARARGS);
 }
 EXPORT int my___vfwprintf_chk(void* F, int flag, void* fmt, x64_va_list_t b)  {
+    __MY_CPU;
     #ifdef CONVERT_VALIST
     CONVERT_VALIST(b);
     #else
-    char scratch_buff [26*8] = {0};
-    myStackAlignWValist((const char*)fmt, (uint64_t *)scratch_buff, b);
-    __MY_CPU;
+    myStackAlignWValist((const char*)fmt, cpu->scratch, b);
     PREPARE_VALIST;
     #endif
     return vfwprintf(F, fmt, VARARGS);
 }
 
 EXPORT int my_dprintf(int d, void* fmt, void* b) {
-    char scratch_buff [26*8] = {0};
     __MY_CPU;
-    myStackAlign((const char*)fmt, b, (uint64_t *)scratch_buff, cpu->regs[R_EAX], 2);
+    myStackAlign((const char*)fmt, b, cpu->scratch, cpu->regs[R_EAX], 2);
     PREPARE_VALIST;
     return vdprintf(d, fmt, VARARGS);
 }
 
 EXPORT int my___dprintf_chk(int d, int flag, void* fmt, void* b)  {
     (void)flag;
-    char scratch_buff [26*8] = {0};
     __MY_CPU;
-    myStackAlign((const char*)fmt, b, (uint64_t *)scratch_buff, cpu->regs[R_EAX], 3);
+    myStackAlign((const char*)fmt, b, cpu->scratch, cpu->regs[R_EAX], 3);
     PREPARE_VALIST;
     return vdprintf(d, fmt, VARARGS);
 }
 
 
 EXPORT int my_vdprintf(int d, void* fmt, x64_va_list_t b) {
+    __MY_CPU;
     #ifdef CONVERT_VALIST
     CONVERT_VALIST(b);
     #else
-    char scratch_buff [26*8] = {0};
-    myStackAlignValist((const char*)fmt, (uint64_t *)scratch_buff, b);
-    __MY_CPU;
+    myStackAlignValist((const char*)fmt, cpu->scratch, b);
     PREPARE_VALIST;
     #endif
     return vdprintf(d, fmt, VARARGS);
 }
 
 EXPORT int my___vdprintf_chk(int d, int flag, void* fmt, x64_va_list_t b)  {
+    __MY_CPU;
     (void)flag;
     #ifdef CONVERT_VALIST
     CONVERT_VALIST(b);
     #else
-    char scratch_buff [26*8] = {0};
-    myStackAlignValist((const char*)fmt, (uint64_t *)scratch_buff, b);
-    __MY_CPU;
+    myStackAlignValist((const char*)fmt, cpu->scratch, b);
     PREPARE_VALIST;
     #endif
     return vdprintf(d, fmt, VARARGS);
@@ -812,12 +795,10 @@ EXPORT void *my_div(void *result, int numerator, int denominator) {
 
 EXPORT int my_snprintf(void* buff, size_t s, void * fmt, uint64_t * b) {
     #ifdef PREFER_CONVERT_VAARG
-    char scratch_buff [26*8] = {0};
-    CREATE_VALIST_FROM_VAARG(b, (uint64_t *)scratch_buff, 3);
+    CREATE_VALIST_FROM_VAARG(b, cpu->scratch, 3);
     #else
-    char scratch_buff [26*8] = {0};
     __MY_CPU;
-    myStackAlign((const char*)fmt, b, (uint64_t *)scratch_buff, cpu->regs[R_EAX], 3);
+    myStackAlign((const char*)fmt, b, cpu->scratch, cpu->regs[R_EAX], 3);
     PREPARE_VALIST;
     #endif
     int r = vsnprintf(buff, s, fmt, VARARGS);
@@ -828,12 +809,10 @@ EXPORT int my___snprintf_chk(void* buff, size_t s, int flags, size_t maxlen, voi
 {
     (void)flags; (void)maxlen;
     #ifdef PREFER_CONVERT_VAARG
-    char scratch_buff [26*8] = {0};
-    CREATE_VALIST_FROM_VAARG(b, (uint64_t *)scratch_buff, 5);
+    CREATE_VALIST_FROM_VAARG(b, cpu->scratch, 5);
     #else
-    char scratch_buff [26*8] = {0};
     __MY_CPU;
-    myStackAlign((const char*)fmt, b, (uint64_t *)scratch_buff, cpu->regs[R_EAX], 5);
+    myStackAlign((const char*)fmt, b, cpu->scratch, cpu->regs[R_EAX], 5);
     PREPARE_VALIST;
     #endif
     int r = vsnprintf(buff, s, fmt, VARARGS);
@@ -842,12 +821,10 @@ EXPORT int my___snprintf_chk(void* buff, size_t s, int flags, size_t maxlen, voi
 
 EXPORT int my_sprintf(void* buff, void * fmt, void * b) {
     #ifdef PREFER_CONVERT_VAARG
-    char scratch_buff [26*8] = {0};
-    CREATE_VALIST_FROM_VAARG(b, (uint64_t *)scratch_buff, 2);
+    CREATE_VALIST_FROM_VAARG(b, cpu->scratch, 2);
     #else
-    char scratch_buff [26*8] = {0};
     __MY_CPU;
-    myStackAlign((const char*)fmt, b, (uint64_t *)scratch_buff, cpu->regs[R_EAX], 2);
+    myStackAlign((const char*)fmt, b, cpu->scratch, cpu->regs[R_EAX], 2);
     PREPARE_VALIST;
     #endif
     return vsprintf(buff, (const char*)fmt, VARARGS);
@@ -855,45 +832,40 @@ EXPORT int my_sprintf(void* buff, void * fmt, void * b) {
 EXPORT int my___sprintf_chk(void* buff, int flag, size_t l, void * fmt, void * b) {
     (void)flag; (void)l;
     #ifdef PREFER_CONVERT_VAARG
-    char scratch_buff [26*8] = {0};
-    CREATE_VALIST_FROM_VAARG(b, (uint64_t *)scratch_buff, 4);
+    CREATE_VALIST_FROM_VAARG(b, cpu->scratch, 4);
     #else
-    char scratch_buff [26*8] = {0};
     __MY_CPU;
-    myStackAlign((const char*)fmt, b, (uint64_t *)scratch_buff, cpu->regs[R_EAX], 4);
+    myStackAlign((const char*)fmt, b, cpu->scratch, cpu->regs[R_EAX], 4);
     PREPARE_VALIST;
     #endif
     return vsprintf(buff, (const char*)fmt, VARARGS);
 }
 
 EXPORT int my_asprintf(void** buff, void * fmt, uint64_t * b) {
-    char scratch_buff [26*8] = {0};
     __MY_CPU;
-    myStackAlign((const char*)fmt, b, (uint64_t *)scratch_buff, cpu->regs[R_EAX], 2);
+    myStackAlign((const char*)fmt, b, cpu->scratch, cpu->regs[R_EAX], 2);
     PREPARE_VALIST;
     return vasprintf((char**)buff, (char*)fmt, VARARGS);
 }
 EXPORT int my___asprintf(void** buff, void * fmt, uint64_t * b) __attribute__((alias("my_asprintf")));
 
 EXPORT int my_vasprintf(char** buff, void* fmt, x64_va_list_t b) {
+    __MY_CPU;
     #ifdef CONVERT_VALIST
     CONVERT_VALIST(b);
     #else
-    char scratch_buff [26*8] = {0};
-    myStackAlignValist((const char*)fmt, (uint64_t *)scratch_buff, b);
-    __MY_CPU;
+    myStackAlignValist((const char*)fmt, cpu->scratch, b);
     PREPARE_VALIST;
     #endif
     return vasprintf(buff, fmt, VARARGS);
 }
 
 EXPORT int my_vsprintf(void* buff,  void * fmt, x64_va_list_t b) {
+    __MY_CPU;
     #ifdef CONVERT_VALIST
     CONVERT_VALIST(b);
     #else
-    char scratch_buff [26*8] = {0};
-    myStackAlignValist((const char*)fmt, (uint64_t *)scratch_buff, b);
-    __MY_CPU;
+    myStackAlignValist((const char*)fmt, cpu->scratch, b);
     PREPARE_VALIST;
     #endif
     return vsprintf(buff, fmt, VARARGS);
@@ -902,12 +874,11 @@ EXPORT int my___vsprintf_chk(void* buff, void * fmt, x64_va_list_t b) __attribut
 
 EXPORT int my_vfscanf(void* stream, void* fmt, x64_va_list_t b)
 {
+    __MY_CPU;
     #ifdef CONVERT_VALIST
     CONVERT_VALIST(b);
     #else
-    char scratch_buff [26*8] = {0};
-    myStackAlignScanfValist((const char*)fmt, (uint64_t *)scratch_buff, b);
-    __MY_CPU;
+    myStackAlignScanfValist((const char*)fmt, cpu->scratch, b);
     PREPARE_VALIST;
     #endif
     return vfscanf(stream, fmt, VARARGS);
@@ -915,12 +886,11 @@ EXPORT int my_vfscanf(void* stream, void* fmt, x64_va_list_t b)
 
 EXPORT int my_vsscanf(void* stream, void* fmt, x64_va_list_t b)
 {
+    __MY_CPU;
     #ifdef CONVERT_VALIST
     CONVERT_VALIST(b);
     #else
-    char scratch_buff [26*8] = {0};
-    myStackAlignScanfValist((const char*)fmt, (uint64_t *)scratch_buff, b);
-    __MY_CPU;
+    myStackAlignScanfValist((const char*)fmt, cpu->scratch, b);
     PREPARE_VALIST;
     #endif
     return vsscanf(stream, fmt, VARARGS);
@@ -930,12 +900,11 @@ EXPORT int my__vsscanf(void* stream, void* fmt, void* b) __attribute__((alias("m
 
 EXPORT int my_vswscanf(void* stream, void* fmt, x64_va_list_t b)
 {
+    __MY_CPU;
     #ifdef CONVERT_VALIST
     CONVERT_VALIST(b);
     #else
-    char scratch_buff [26*8] = {0};
-    myStackAlignScanfWValist((const char*)fmt, (uint64_t *)scratch_buff, b);
-    __MY_CPU;
+    myStackAlignScanfWValist((const char*)fmt, cpu->scratch, b);
     PREPARE_VALIST;
     #endif
     return vswscanf(stream, fmt, VARARGS);
@@ -943,9 +912,8 @@ EXPORT int my_vswscanf(void* stream, void* fmt, x64_va_list_t b)
 
 EXPORT int my_sscanf(void* stream, void* fmt, uint64_t* b)
 {
-    char scratch_buff [26*8] = {0};
-    myStackAlignScanf((const char*)fmt, b, (uint64_t *)scratch_buff, 2);
     __MY_CPU;
+    myStackAlignScanf((const char*)fmt, b, cpu->scratch, 2);
     PREPARE_VALIST;
 
     return vsscanf(stream, fmt, VARARGS);
@@ -957,9 +925,8 @@ EXPORT int my___isoc99_vfscanf(void* stream, void* fmt, void* b) __attribute__((
 
 EXPORT int my___isoc99_fscanf(void* stream, void* fmt, uint64_t* b)
 {
-  char scratch_buff [26*8] = {0};
-  myStackAlignScanf((const char*)fmt, b, (uint64_t *)scratch_buff, 2);
   __MY_CPU;
+  myStackAlignScanf((const char*)fmt, b, cpu->scratch, 2);
   PREPARE_VALIST;
 
   return vfscanf(stream, fmt, VARARGS);
@@ -968,9 +935,8 @@ EXPORT int my_fscanf(void* stream, void* fmt, uint64_t* b) __attribute__((alias(
 
 EXPORT int my___isoc99_scanf(void* fmt, uint64_t* b)
 {
-  char scratch_buff [26*8] = {0};
-  myStackAlignScanf((const char*)fmt, b, (uint64_t *)scratch_buff, 1);
   __MY_CPU;
+  myStackAlignScanf((const char*)fmt, b, cpu->scratch, 1);
   PREPARE_VALIST;
 
   return vscanf(fmt, VARARGS);
@@ -978,9 +944,8 @@ EXPORT int my___isoc99_scanf(void* fmt, uint64_t* b)
 
 EXPORT int my___isoc99_sscanf(void* stream, void* fmt, uint64_t* b)
 {
-  char scratch_buff [26*8] = {0};
-  myStackAlignScanf((const char*)fmt, b, (uint64_t *)scratch_buff, 2);
   __MY_CPU;
+  myStackAlignScanf((const char*)fmt, b, cpu->scratch, 2);
   PREPARE_VALIST;
 
   return vsscanf(stream, fmt, VARARGS);
@@ -988,21 +953,19 @@ EXPORT int my___isoc99_sscanf(void* stream, void* fmt, uint64_t* b)
 
 EXPORT int my___isoc99_swscanf(void* stream, void* fmt, uint64_t* b)
 {
-  char scratch_buff [26*8] = {0};
-  myStackAlignScanf((const char*)fmt, b, (uint64_t *)scratch_buff, 2);
   __MY_CPU;
+  myStackAlignScanf((const char*)fmt, b, cpu->scratch, 2);
   PREPARE_VALIST;
 
   return vswscanf(stream, fmt, VARARGS);
 }
 
 EXPORT int my_vsnprintf(void* buff, size_t s, void * fmt, x64_va_list_t b) {
+    __MY_CPU;
     #ifdef CONVERT_VALIST
     CONVERT_VALIST(b);
     #else
-    char scratch_buff [26*8] = {0};
-    myStackAlignValist((const char*)fmt, (uint64_t *)scratch_buff, b);
-    __MY_CPU;
+    myStackAlignValist((const char*)fmt, cpu->scratch, b);
     PREPARE_VALIST;
     #endif
     int r = vsnprintf(buff, s, fmt, VARARGS);
@@ -1010,12 +973,11 @@ EXPORT int my_vsnprintf(void* buff, size_t s, void * fmt, x64_va_list_t b) {
 }
 EXPORT int my___vsnprintf(void* buff, size_t s, void * fmt, x64_va_list_t b) __attribute__((alias("my_vsnprintf")));
 EXPORT int my___vsnprintf_chk(void* buff, size_t s, int flags, size_t slen, void * fmt, x64_va_list_t b) {
+    __MY_CPU;
     #ifdef CONVERT_VALIST
     CONVERT_VALIST(b);
     #else
-    char scratch_buff [26*8] = {0};
-    myStackAlignValist((const char*)fmt, (uint64_t *)scratch_buff, b);
-    __MY_CPU;
+    myStackAlignValist((const char*)fmt, cpu->scratch, b);
     PREPARE_VALIST;
     #endif
     int r = vsnprintf(buff, s, fmt, VARARGS);
@@ -1026,7 +988,6 @@ EXPORT int my_vasprintf(void* strp, void* fmt, void* b, va_list V)
 {
     #ifndef NOALIGN
     // need to align on arm
-    char scratch_buff [26*8] = {0};
     myStackAlign((const char*)fmt, (uint32_t*)b, scratch_buff);
     __MY_CPU;
     PREPARE_VALIST;
@@ -1042,13 +1003,12 @@ EXPORT int my_vasprintf(void* strp, void* fmt, void* b, va_list V)
 #endif
 EXPORT int my___vasprintf_chk(void* buff, int flags, void* fmt, x64_va_list_t b)
 {
+    __MY_CPU;
     (void)flags;
     #ifdef CONVERT_VALIST
     CONVERT_VALIST(b);
     #else
-    char scratch_buff [26*8] = {0};
-    myStackAlignValist((const char*)fmt, (uint64_t *)scratch_buff, b);
-    __MY_CPU;
+    myStackAlignValist((const char*)fmt, cpu->scratch, b);
     PREPARE_VALIST;
     #endif
     int r = vasprintf(buff, fmt, VARARGS);
@@ -1056,19 +1016,17 @@ EXPORT int my___vasprintf_chk(void* buff, int flags, void* fmt, x64_va_list_t b)
 }
 EXPORT int my___asprintf_chk(void* result_ptr, int flags, void* fmt, void* b)
 {
-    char scratch_buff [26*8] = {0};
     __MY_CPU;
-    myStackAlign((const char*)fmt, b, (uint64_t *)scratch_buff, cpu->regs[R_EAX], 3);
+    myStackAlign((const char*)fmt, b, cpu->scratch, cpu->regs[R_EAX], 3);
     PREPARE_VALIST;
     return vasprintf((char**)result_ptr, (char*)fmt, VARARGS);
 }
 EXPORT int my_vswprintf(void* buff, size_t s, void * fmt, x64_va_list_t b) {
+    __MY_CPU;
     #ifdef CONVERT_VALIST
     CONVERT_VALIST(b);
     #else
-    char scratch_buff [26*8] = {0};
-    myStackAlignWValist((const char*)fmt, (uint64_t *)scratch_buff, b);
-    __MY_CPU;
+    myStackAlignWValist((const char*)fmt, cpu->scratch, b);
     PREPARE_VALIST;
     #endif
     int r = vswprintf(buff, s, fmt, VARARGS);
@@ -1079,9 +1037,8 @@ EXPORT int my___vswprintf_chk(void* buff, size_t s, void * fmt, x64_va_list_t b)
 
 EXPORT int my_swscanf(void* stream, void* fmt, uint64_t* b)
 {
-    char scratch_buff [26*8] = {0};
-    myStackAlignScanfW((const char*)fmt, b, (uint64_t *)scratch_buff, 2);
     __MY_CPU;
+    myStackAlignScanfW((const char*)fmt, b, cpu->scratch, 2);
     PREPARE_VALIST;
 
     return vswscanf(stream, fmt, VARARGS);
@@ -1090,7 +1047,6 @@ EXPORT int my_swscanf(void* stream, void* fmt, uint64_t* b)
 #if 0
 EXPORT void my_verr(int eval, void* fmt, void* b) {
     #ifndef NOALIGN
-    char scratch_buff [26*8] = {0};
     myStackAlignW((const char*)fmt, (uint32_t*)b, scratch_buff);
     __MY_CPU;
     PREPARE_VALIST;
@@ -1104,7 +1060,6 @@ EXPORT void my_verr(int eval, void* fmt, void* b) {
 
 EXPORT void my_vwarn(void* fmt, void* b) {
     #ifndef NOALIGN
-    char scratch_buff [26*8] = {0};
     myStackAlignW((const char*)fmt, (uint32_t*)b, scratch_buff);
     __MY_CPU;
     PREPARE_VALIST;
@@ -1117,71 +1072,63 @@ EXPORT void my_vwarn(void* fmt, void* b) {
 }
 #endif
 EXPORT void my_err(int eval, void* fmt, void* b) {
-    char scratch_buff [26*8] = {0};
     __MY_CPU;
-    myStackAlign((const char*)fmt, b, (uint64_t *)scratch_buff, cpu->regs[R_EAX], 2);
+    myStackAlign((const char*)fmt, b, cpu->scratch, cpu->regs[R_EAX], 2);
     PREPARE_VALIST;
     verr(eval, (const char*)fmt, VARARGS);
 }
 EXPORT void my_errx(int eval, void* fmt, void* b) {
-    char scratch_buff [26*8] = {0};
     __MY_CPU;
-    myStackAlign((const char*)fmt, b, (uint64_t *)scratch_buff, cpu->regs[R_EAX], 2);
+    myStackAlign((const char*)fmt, b, cpu->scratch, cpu->regs[R_EAX], 2);
     PREPARE_VALIST;
     verrx(eval, (const char*)fmt, VARARGS);
 }
 EXPORT void my_warn(void* fmt, void* b) {
-    char scratch_buff [26*8] = {0};
     __MY_CPU;
-    myStackAlign((const char*)fmt, b, (uint64_t *)scratch_buff, cpu->regs[R_EAX], 1);
+    myStackAlign((const char*)fmt, b, cpu->scratch, cpu->regs[R_EAX], 1);
     PREPARE_VALIST;
     vwarn((const char*)fmt, VARARGS);
 }
 EXPORT void my_warnx(void* fmt, void* b) {
-    char scratch_buff [26*8] = {0};
     __MY_CPU;
-    myStackAlign((const char*)fmt, b, (uint64_t *)scratch_buff, cpu->regs[R_EAX], 1);
+    myStackAlign((const char*)fmt, b, cpu->scratch, cpu->regs[R_EAX], 1);
     PREPARE_VALIST;
     vwarnx((const char*)fmt, VARARGS);
 }
 
 EXPORT void my_syslog(int priority, const char* fmt, uint64_t* b)
 {
-    char scratch_buff [26*8] = {0};
     __MY_CPU;
-    myStackAlign(fmt, b, (uint64_t *)scratch_buff, cpu->regs[R_EAX], 2);
+    myStackAlign(fmt, b, cpu->scratch, cpu->regs[R_EAX], 2);
     PREPARE_VALIST;
     return vsyslog(priority, fmt, VARARGS);
 }
 EXPORT void my___syslog_chk(int priority, int flags, const char* fmt, uint64_t* b)
 {
     (void)flags;
-    char scratch_buff [26*8] = {0};
     __MY_CPU;
-    myStackAlign(fmt, b, (uint64_t *)scratch_buff, cpu->regs[R_EAX], 3);
+    myStackAlign(fmt, b, cpu->scratch, cpu->regs[R_EAX], 3);
     PREPARE_VALIST;
     return vsyslog(priority, fmt, VARARGS);
 }
 EXPORT void my_vsyslog(int priority, const char* fmt, x64_va_list_t b)
 {
+    __MY_CPU;
     #ifdef CONVERT_VALIST
     CONVERT_VALIST(b);
     #else
-    char scratch_buff [26*8] = {0};
-    myStackAlignValist((const char*)fmt, (uint64_t *)scratch_buff, b);
-    __MY_CPU;
+    myStackAlignValist((const char*)fmt, cpu->scratch, b);
     PREPARE_VALIST;
     #endif
     return vsyslog(priority, fmt, VARARGS);
 }
 EXPORT void my___vsyslog_chk(int priority, int flag, const char* fmt, x64_va_list_t b)
 {
+    __MY_CPU;
     #ifdef CONVERT_VALIST
     CONVERT_VALIST(b);
     #else
-    char scratch_buff [26*8] = {0};
-    myStackAlignValist((const char*)fmt, (uint64_t *)scratch_buff, b);
-    __MY_CPU;
+    myStackAlignValist((const char*)fmt, cpu->scratch, b);
     PREPARE_VALIST;
     #endif
     return vsyslog(priority, fmt, VARARGS);
@@ -1191,17 +1138,15 @@ EXPORT int my___swprintf_chk(void* s, size_t n, int32_t flag, size_t slen, void*
 {
     (void)flag;
     (void)slen;
-    char scratch_buff [26*8] = {0};
     __MY_CPU;
-    myStackAlignW((const char*)fmt, b, (uint64_t *)scratch_buff, cpu->regs[R_EAX], 5);
+    myStackAlignW((const char*)fmt, b, cpu->scratch, cpu->regs[R_EAX], 5);
     PREPARE_VALIST;
     return vswprintf(s, n, (const wchar_t*)fmt, VARARGS);
 }
 EXPORT int my_swprintf(void* s, size_t n, void* fmt, uint64_t* b)
 {
-    char scratch_buff [26*8] = {0};
     __MY_CPU;
-    myStackAlignW((const char*)fmt, b, (uint64_t *)scratch_buff, cpu->regs[R_EAX], 3);
+    myStackAlignW((const char*)fmt, b, cpu->scratch, cpu->regs[R_EAX], 3);
     PREPARE_VALIST;
     return vswprintf(s, n, (const wchar_t*)fmt, VARARGS);
 }

--- a/target/i386/latx/include/myalign.h
+++ b/target/i386/latx/include/myalign.h
@@ -43,7 +43,6 @@ typedef struct x64_va_list_s {
 
 #if defined(__loongarch64) || defined(__powerpc64__) || defined(__riscv)
 #define __MY_CPU CPUX86State *cpu = (CPUX86State *)lsenv->cpu_state
-#define __MY_R_RSP cpu->regs[R_ESP]
 
 #define CREATE_SYSV_VALIST(A) \
   va_list sysv_varargs = (va_list)A
@@ -76,7 +75,7 @@ typedef struct x64_va_list_s {
 #endif
 
 #define VARARGS sysv_varargs
-#define PREPARE_VALIST CREATE_SYSV_VALIST(__MY_R_RSP)
+#define PREPARE_VALIST CREATE_SYSV_VALIST(cpu->scratch)
 #define VARARGS_(A) sysv_varargs
 #define PREPARE_VALIST_(A) CREATE_SYSV_VALIST(A)
 uintptr_t getVArgs(int pos, uintptr_t* b, int N);


### PR DESCRIPTION
## Summary / 变更说明

直通libc中公共 printf 家族函数遇到变长参数转换错误，导致matlab测试失败。本patch做了修正。

## Validation / 验证

<pre><code class="c">
//mini x64程序(main.c)即可复现
#include <stdarg.h>
void test_vsprintf(const char *fmt, ...) {
    char buf[64];
    va_list ap;
    va_start(ap, fmt);
    vsprintf(buf, fmt, ap);   
    va_end(ap);
    puts(buf); // 预期输出hello.world 。 但开启wrappedlibc_private.h中GOWM(vsprintf, iFppA)后，输出乱码
}

int main() {
   test_vsprintf("%s.%s", "hello", "world"); 
</code></pre>