### PR TITLE
LATX: fix LTO assembly and build warnings

### DIFF
--- a/configure
+++ b/configure
@@ -6592,6 +6592,7 @@ test -n "$objcc" && echo "objc = [$(meson_quote $objcc)]" >> $cross
 echo "ar = [$(meson_quote $ar)]" >> $cross
 echo "nm = [$(meson_quote $nm)]" >> $cross
 echo "pkgconfig = [$(meson_quote $pkg_config_exe)]" >> $cross
+echo "pkg-config = [$(meson_quote $pkg_config_exe)]" >> $cross
 echo "ranlib = [$(meson_quote $ranlib)]" >> $cross
 if has $sdl2_config; then
   echo "sdl2-config = [$(meson_quote $sdl2_config)]" >> $cross

--- a/docs/meson.build
+++ b/docs/meson.build
@@ -38,12 +38,12 @@ endif
 if build_docs
   SPHINX_ARGS += ['-Dversion=' + meson.project_version(), '-Drelease=' + config_host['PKGVERSION']]
 
-  sphinx_extn_depends = [ meson.source_root() / 'docs/sphinx/depfile.py',
-                          meson.source_root() / 'docs/sphinx/hxtool.py',
-                          meson.source_root() / 'docs/sphinx/kerneldoc.py',
-                          meson.source_root() / 'docs/sphinx/kernellog.py',
-                          meson.source_root() / 'docs/sphinx/qapidoc.py',
-                          meson.source_root() / 'docs/sphinx/qmp_lexer.py',
+  sphinx_extn_depends = [ project_source_root / 'docs/sphinx/depfile.py',
+                          project_source_root / 'docs/sphinx/hxtool.py',
+                          project_source_root / 'docs/sphinx/kerneldoc.py',
+                          project_source_root / 'docs/sphinx/kernellog.py',
+                          project_source_root / 'docs/sphinx/qapidoc.py',
+                          project_source_root / 'docs/sphinx/qmp_lexer.py',
                           qapi_gen_depends ]
 
   have_ga = have_tools and config_host.has_key('CONFIG_GUEST_AGENT')

--- a/meson.build
+++ b/meson.build
@@ -1,8 +1,11 @@
 project('latx', ['c'], meson_version: '>=0.55.0',
         default_options: ['warning_level=1', 'c_std=gnu99', 'cpp_std=gnu++11', 'b_colorout=auto'] +
                          (meson.version().version_compare('>=0.56.0') ? [ 'b_staticpic=false' ] : []),
-        version: run_command('head', meson.source_root() / 'VERSION',
+        version: run_command('head', meson.current_source_dir() / 'VERSION',
                              check: true).stdout().strip())
+
+project_source_root = meson.current_source_dir()
+project_build_root = meson.current_build_dir()
 
 not_found = dependency('', required: false)
 if meson.version().version_compare('>=0.56.0')
@@ -328,21 +331,21 @@ genh += configure_file(output: 'config-host.h', configuration: config_host_data)
 
 hxtool = find_program('scripts/hxtool')
 qapi_gen = find_program('scripts/qapi-gen.py')
-qapi_gen_depends = [ meson.source_root() / 'scripts/qapi/__init__.py',
-                     meson.source_root() / 'scripts/qapi/commands.py',
-                     meson.source_root() / 'scripts/qapi/common.py',
-                     meson.source_root() / 'scripts/qapi/error.py',
-                     meson.source_root() / 'scripts/qapi/events.py',
-                     meson.source_root() / 'scripts/qapi/expr.py',
-                     meson.source_root() / 'scripts/qapi/gen.py',
-                     meson.source_root() / 'scripts/qapi/introspect.py',
-                     meson.source_root() / 'scripts/qapi/parser.py',
-                     meson.source_root() / 'scripts/qapi/schema.py',
-                     meson.source_root() / 'scripts/qapi/source.py',
-                     meson.source_root() / 'scripts/qapi/types.py',
-                     meson.source_root() / 'scripts/qapi/visit.py',
-                     meson.source_root() / 'scripts/qapi/common.py',
-                     meson.source_root() / 'scripts/qapi-gen.py'
+qapi_gen_depends = [ project_source_root / 'scripts/qapi/__init__.py',
+                     project_source_root / 'scripts/qapi/commands.py',
+                     project_source_root / 'scripts/qapi/common.py',
+                     project_source_root / 'scripts/qapi/error.py',
+                     project_source_root / 'scripts/qapi/events.py',
+                     project_source_root / 'scripts/qapi/expr.py',
+                     project_source_root / 'scripts/qapi/gen.py',
+                     project_source_root / 'scripts/qapi/introspect.py',
+                     project_source_root / 'scripts/qapi/parser.py',
+                     project_source_root / 'scripts/qapi/schema.py',
+                     project_source_root / 'scripts/qapi/source.py',
+                     project_source_root / 'scripts/qapi/types.py',
+                     project_source_root / 'scripts/qapi/visit.py',
+                     project_source_root / 'scripts/qapi/common.py',
+                     project_source_root / 'scripts/qapi-gen.py'
 ]
 
 tracetool = [
@@ -730,7 +733,6 @@ foreach target : target_dirs
 
     execs = [{
       'name': 'latx-' + target_name,
-      'gui': false,
       'sources': [],
       'dependencies': []
     }]
@@ -744,8 +746,7 @@ foreach target : target_dirs
                objects: lib.extract_all_objects(recursive: true),
                link_language: link_language,
                link_depends: exe.get('link_depends', []),
-               link_args: link_args,
-               gui_app: exe['gui'])
+               link_args: link_args)
 
     emulators += {exe['name']: emulator}
 

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,8 @@
 project('latx', ['c'], meson_version: '>=0.55.0',
         default_options: ['warning_level=1', 'c_std=gnu99', 'cpp_std=gnu++11', 'b_colorout=auto'] +
                          (meson.version().version_compare('>=0.56.0') ? [ 'b_staticpic=false' ] : []),
-        version: run_command('head', meson.source_root() / 'VERSION').stdout().strip())
+        version: run_command('head', meson.source_root() / 'VERSION',
+                             check: true).stdout().strip())
 
 not_found = dependency('', required: false)
 if meson.version().version_compare('>=0.56.0')
@@ -622,7 +623,7 @@ foreach target : target_dirs
         'target/i386/latx/sbt/smc_reload.c',
         'target/i386/latx/sbt/aot_smc_reload.c',
         'accel/tcg/tb-jump.c'
-      ) + genh + tcg_trace_genh + syscall_nr_generated,
+      ) + genh + tcg_trace_genh + [syscall_nr_generated],
       c_args: smc_reload_test_c_args,
       dependencies: [glib],
       include_directories: target_inc,
@@ -642,7 +643,7 @@ foreach target : target_dirs
         'target/i386/latx/sbt/aot_smc_reload.c',
         'accel/tcg/tb-jump.c',
         'util/pagesize.c'
-      ) + genh + tcg_trace_genh + syscall_nr_generated,
+      ) + genh + tcg_trace_genh + [syscall_nr_generated],
       c_args: smc_reload_test_c_args,
       dependencies: [glib],
       include_directories: target_inc,
@@ -660,7 +661,7 @@ foreach target : target_dirs
         'target/i386/latx/sbt/tests/tb-flush-smc-reload-async-test.c',
         'target/i386/latx/sbt/smc_reload.c',
         'accel/tcg/tb-flush.c'
-      ) + genh + tcg_trace_genh + syscall_nr_generated,
+      ) + genh + tcg_trace_genh + [syscall_nr_generated],
       c_args: smc_reload_test_c_args,
       dependencies: [glib],
       include_directories: target_inc,
@@ -677,7 +678,7 @@ foreach target : target_dirs
       files(
         'target/i386/latx/sbt/tests/aot-file-publish-test.c',
         'target/i386/latx/sbt/file_ctx.c'
-      ) + genh + tcg_trace_genh + syscall_nr_generated,
+      ) + genh + tcg_trace_genh + [syscall_nr_generated],
       c_args: smc_reload_test_c_args,
       dependencies: [glib],
       include_directories: target_inc,
@@ -696,7 +697,7 @@ foreach target : target_dirs
       'test-latx-aot-exit-worker',
       files(
         'target/i386/latx/sbt/tests/aot-exit-worker-test.c'
-      ) + genh + tcg_trace_genh + syscall_nr_generated,
+      ) + genh + tcg_trace_genh + [syscall_nr_generated],
       c_args: smc_reload_test_c_args,
       dependencies: [glib],
       include_directories: target_inc,
@@ -714,7 +715,7 @@ foreach target : target_dirs
         'target/i386/latx/sbt/tests/aot-pe-load-address-test.c',
         'target/i386/latx/sbt/segment.c',
         'target/i386/latx/sbt/aot_lib.c'
-      ) + genh + tcg_trace_genh + syscall_nr_generated,
+      ) + genh + tcg_trace_genh + [syscall_nr_generated],
       c_args: smc_reload_test_c_args,
       dependencies: [glib],
       include_directories: target_inc,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -41,9 +41,9 @@ option('tcg', type: 'feature', value: 'auto',
        description: 'TCG support')
 option('tcg_interpreter', type: 'boolean', value: false,
        description: 'TCG with bytecode interpreter (experimental and slow)')
-option('cfi', type: 'boolean', value: 'false',
+option('cfi', type: 'boolean', value: false,
        description: 'Control-Flow Integrity (CFI)')
-option('cfi_debug', type: 'boolean', value: 'false',
+option('cfi_debug', type: 'boolean', value: false,
        description: 'Verbose errors in case of CFI violation')
 option('multiprocess', type: 'feature', value: 'auto',
        description: 'Out of process device emulation support')

--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -1,7 +1,7 @@
 if 'CONFIG_HAS_LD_DYNAMIC_LIST' in config_host
-  plugin_ldflags = ['-Wl,--dynamic-list=' + (meson.build_root() / 'qemu-plugins-ld.symbols')]
+  plugin_ldflags = ['-Wl,--dynamic-list=' + (project_build_root / 'qemu-plugins-ld.symbols')]
 elif 'CONFIG_HAS_LD_EXPORTED_SYMBOLS_LIST' in config_host
-  plugin_ldflags = ['-Wl,-exported_symbols_list,' + (meson.build_root() / 'qemu-plugins-ld64.symbols')]
+  plugin_ldflags = ['-Wl,-exported_symbols_list,' + (project_build_root / 'qemu-plugins-ld64.symbols')]
 else
   plugin_ldflags = []
 endif

--- a/target/i386/latx/include/reg-alloc.h
+++ b/target/i386/latx/include/reg-alloc.h
@@ -188,24 +188,4 @@ void imm_cache_free_temp_helper(IR2_OPND dest_op);
 IR2_OPND ra_alloc_st(int);
 IR2_OPND ra_alloc_mda(void);
 
-#define _IFC_REG(n)				\
-	".ifc	\\r, $r" #n "\n\t"		\
-	"\\var	= " #n "\n\t"			\
-	".endif\n\t"
-
-    __asm__(".macro	parse_r var r, imm\n\t"
-	"\\var	= -1\n\t"
-	_IFC_REG(0)  _IFC_REG(1)  _IFC_REG(2)  _IFC_REG(3)
-	_IFC_REG(4)  _IFC_REG(5)  _IFC_REG(6)  _IFC_REG(7)
-	_IFC_REG(8)  _IFC_REG(9)  _IFC_REG(10) _IFC_REG(11)
-	_IFC_REG(12) _IFC_REG(13) _IFC_REG(14) _IFC_REG(15)
-	_IFC_REG(16) _IFC_REG(17) _IFC_REG(18) _IFC_REG(19)
-	_IFC_REG(20) _IFC_REG(21) _IFC_REG(22) _IFC_REG(23)
-	_IFC_REG(24) _IFC_REG(25) _IFC_REG(26) _IFC_REG(27)
-	_IFC_REG(28) _IFC_REG(29) _IFC_REG(30) _IFC_REG(31)
-	".iflt	\\var\n\t"
-	".error	\"Unable to parse register name \\r\"\n\t"
-	".endif\n\t"
-	".endm");
-
 #endif

--- a/target/i386/latx/translator/tr-pattern.c
+++ b/target/i386/latx/translator/tr-pattern.c
@@ -16,6 +16,37 @@
 #ifdef CONFIG_LATX_INSTS_PATTERN
 
 #define WRAP(ins) (dt_X86_INS_##ins)
+#define PARSE_R_IFC_REG(n)                     \
+    ".ifc \\r, $r" #n "\n\t"                 \
+    "\\var = " #n "\n\t"                     \
+    ".endif\n\t"
+/*
+ * LTO may duplicate or reorder file-scope assembly.  Keep the assembler
+ * macro with its users and give each extended asm statement a unique name.
+ */
+#define DEFINE_PARSE_R                         \
+    ".macro parse_r_%= var r\n\t"              \
+    "\\var = -1\n\t"                          \
+    PARSE_R_IFC_REG(0)  PARSE_R_IFC_REG(1)  \
+    PARSE_R_IFC_REG(2)  PARSE_R_IFC_REG(3)  \
+    PARSE_R_IFC_REG(4)  PARSE_R_IFC_REG(5)  \
+    PARSE_R_IFC_REG(6)  PARSE_R_IFC_REG(7)  \
+    PARSE_R_IFC_REG(8)  PARSE_R_IFC_REG(9)  \
+    PARSE_R_IFC_REG(10) PARSE_R_IFC_REG(11) \
+    PARSE_R_IFC_REG(12) PARSE_R_IFC_REG(13) \
+    PARSE_R_IFC_REG(14) PARSE_R_IFC_REG(15) \
+    PARSE_R_IFC_REG(16) PARSE_R_IFC_REG(17) \
+    PARSE_R_IFC_REG(18) PARSE_R_IFC_REG(19) \
+    PARSE_R_IFC_REG(20) PARSE_R_IFC_REG(21) \
+    PARSE_R_IFC_REG(22) PARSE_R_IFC_REG(23) \
+    PARSE_R_IFC_REG(24) PARSE_R_IFC_REG(25) \
+    PARSE_R_IFC_REG(26) PARSE_R_IFC_REG(27) \
+    PARSE_R_IFC_REG(28) PARSE_R_IFC_REG(29) \
+    PARSE_R_IFC_REG(30) PARSE_R_IFC_REG(31) \
+    ".iflt \\var\n\t"                         \
+    ".error \"Unable to parse register name \\r\"\n\t" \
+    ".endif\n\t"                                \
+    ".endm\n\t"
 #define EFLAGS_CACULATE(opnd0, opnd1, inst, i, flags)            \
     do {                                                             \
         bool need_calc_flag = ir1_need_calculate_any_flag(inst);     \
@@ -2445,10 +2476,11 @@ void opt_instptn_fix(CPUState *cpu, TranslationBlock *tb, int index)
                 {
                 case 8:
                     asm volatile (
-                        "parse_r __src, %[src]  \n\t"
-                        "parse_r __dst, %[dst]  \n\t"
+                        DEFINE_PARSE_R
+                        "parse_r_%= __src, %[src]  \n\t"
+                        "parse_r_%= __dst, %[dst]  \n\t"
                         ".word (0x003f0008 | (__src << 10) | (__dst << 5))\n\t" /*x86sub.b*/
-                        "parse_r __flags, %[flags]  \n\t"
+                        "parse_r_%= __flags, %[flags]  \n\t"
                         ".word (0x005c0000 | (0x3f << 10) | __flags)\n\t"  /*x86mfflag*/
                         : [dst]"+r"(a0),
                         [flags]"=r"(eflags)
@@ -2458,10 +2490,11 @@ void opt_instptn_fix(CPUState *cpu, TranslationBlock *tb, int index)
                 break;
                 case 16:
                     asm volatile (
-                        "parse_r __src, %[src]  \n\t"
-                        "parse_r __dst, %[dst]  \n\t"
+                        DEFINE_PARSE_R
+                        "parse_r_%= __src, %[src]  \n\t"
+                        "parse_r_%= __dst, %[dst]  \n\t"
                         ".word (0x003f0009 | (__src << 10) | (__dst << 5))\n\t" /*x86sub.h*/
-                        "parse_r __flags, %[flags]  \n\t"
+                        "parse_r_%= __flags, %[flags]  \n\t"
                         ".word (0x005c0000 | (0x3f << 10) | __flags)\n\t"  /*x86mfflag*/
                         : [dst]"+r"(a0),
                         [flags]"=r"(eflags)
@@ -2471,10 +2504,11 @@ void opt_instptn_fix(CPUState *cpu, TranslationBlock *tb, int index)
                 break;
                 case 32:
                     asm volatile (
-                        "parse_r __src, %[src]  \n\t"
-                        "parse_r __dst, %[dst]  \n\t"
+                        DEFINE_PARSE_R
+                        "parse_r_%= __src, %[src]  \n\t"
+                        "parse_r_%= __dst, %[dst]  \n\t"
                         ".word (0x003f000a | (__src << 10) | (__dst << 5))\n\t" /*x86sub.w*/
-                        "parse_r __flags, %[flags]  \n\t"
+                        "parse_r_%= __flags, %[flags]  \n\t"
                         ".word (0x005c0000 | (0x3f << 10) | __flags)\n\t"  /*x86mfflag*/
                         : [dst]"+r"(a0),
                         [flags]"=r"(eflags)
@@ -2484,10 +2518,11 @@ void opt_instptn_fix(CPUState *cpu, TranslationBlock *tb, int index)
                 break;
                 case 64:
                     asm volatile (
-                        "parse_r __src, %[src]  \n\t"
-                        "parse_r __dst, %[dst]  \n\t"
+                        DEFINE_PARSE_R
+                        "parse_r_%= __src, %[src]  \n\t"
+                        "parse_r_%= __dst, %[dst]  \n\t"
                         ".word (0x003f000b | (__src << 10) | (__dst << 5))\n\t" /*x86sub.d*/
-                        "parse_r __flags, %[flags]  \n\t"
+                        "parse_r_%= __flags, %[flags]  \n\t"
                         ".word (0x005c0000 | (0x3f << 10) | __flags)\n\t"  /*x86mfflag*/
                         : [dst]"+r"(a0),
                         [flags]"=r"(eflags)
@@ -2516,10 +2551,11 @@ void opt_instptn_fix(CPUState *cpu, TranslationBlock *tb, int index)
                 {
                 case 8:
                     asm volatile (
-                        "parse_r __src, %[src]  \n\t"
-                        "parse_r __dst, %[dst]  \n\t"
+                        DEFINE_PARSE_R
+                        "parse_r_%= __src, %[src]  \n\t"
+                        "parse_r_%= __dst, %[dst]  \n\t"
                         ".word (0x003f8010 | (__src << 10) | (__dst << 5))\n\t" /*x86and.b*/
-                        "parse_r __flags, %[flags]  \n\t"
+                        "parse_r_%= __flags, %[flags]  \n\t"
                         ".word (0x005c0000 | (0x3f << 10) | __flags)\n\t"  /*x86mfflag*/
                         : [dst]"+r"(a0),
                         [flags]"=r"(eflags)
@@ -2529,10 +2565,11 @@ void opt_instptn_fix(CPUState *cpu, TranslationBlock *tb, int index)
                 break;
                 case 16:
                     asm volatile (
-                        "parse_r __src, %[src]  \n\t"
-                        "parse_r __dst, %[dst]  \n\t"
+                        DEFINE_PARSE_R
+                        "parse_r_%= __src, %[src]  \n\t"
+                        "parse_r_%= __dst, %[dst]  \n\t"
                         ".word (0x003f8011 | (__src << 10) | (__dst << 5))\n\t" /*x86and.h*/
-                        "parse_r __flags, %[flags]  \n\t"
+                        "parse_r_%= __flags, %[flags]  \n\t"
                         ".word (0x005c0000 | (0x3f << 10) | __flags)\n\t"  /*x86mfflag*/
                         : [dst]"+r"(a0),
                         [flags]"=r"(eflags)
@@ -2542,10 +2579,11 @@ void opt_instptn_fix(CPUState *cpu, TranslationBlock *tb, int index)
                 break;
                 case 32:
                     asm volatile (
-                        "parse_r __src, %[src]  \n\t"
-                        "parse_r __dst, %[dst]  \n\t"
+                        DEFINE_PARSE_R
+                        "parse_r_%= __src, %[src]  \n\t"
+                        "parse_r_%= __dst, %[dst]  \n\t"
                         ".word (0x003f8012 | (__src << 10) | (__dst << 5))\n\t" /*x86and.w*/
-                        "parse_r __flags, %[flags]  \n\t"
+                        "parse_r_%= __flags, %[flags]  \n\t"
                         ".word (0x005c0000 | (0x3f << 10) | __flags)\n\t"  /*x86mfflag*/
                         : [dst]"+r"(a0),
                         [flags]"=r"(eflags)
@@ -2555,10 +2593,11 @@ void opt_instptn_fix(CPUState *cpu, TranslationBlock *tb, int index)
                 break;
                 case 64:
                     asm volatile (
-                        "parse_r __src, %[src]  \n\t"
-                        "parse_r __dst, %[dst]  \n\t"
+                        DEFINE_PARSE_R
+                        "parse_r_%= __src, %[src]  \n\t"
+                        "parse_r_%= __dst, %[dst]  \n\t"
                         ".word (0x003f8013 | (__src << 10) | (__dst << 5))\n\t" /*x86and.d*/
-                        "parse_r __flags, %[flags]  \n\t"
+                        "parse_r_%= __flags, %[flags]  \n\t"
                         ".word (0x005c0000 | (0x3f << 10) | __flags)\n\t"  /*x86mfflag*/
                         : [dst]"+r"(a0),
                         [flags]"=r"(eflags)

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -19,8 +19,8 @@ endforeach
 test(
   'test-latu-install',
   find_program('runtime/test-latu-install.sh'),
-  args: [python.full_path(), meson.source_root() / 'meson' / 'meson.py',
-         meson.build_root(), get_option('prefix')],
+  args: [python.full_path(), project_source_root / 'meson' / 'meson.py',
+         project_build_root, get_option('prefix')],
   depends: latu_install_depends,
   protocol: 'exitcode',
   suite: 'lat-pr-fast',

--- a/trace/meson.build
+++ b/trace/meson.build
@@ -3,7 +3,7 @@ specific_ss.add(files('control-target.c'))
 
 trace_events_files = []
 foreach dir : [ '.' ] + trace_events_subdirs
-  trace_events_file = meson.source_root() / dir / 'trace-events'
+  trace_events_file = project_source_root / dir / 'trace-events'
   trace_events_files += [ trace_events_file ]
   group_name = dir == '.' ? 'root' : dir.underscorify()
   group = '--group=' + group_name
@@ -70,7 +70,7 @@ foreach d : [
 ]
   gen = custom_target(d[0],
                 output: d[0],
-                input: meson.source_root() / 'trace-events',
+                input: project_source_root / 'trace-events',
                 command: [ tracetool, '--group=root', '--format=@0@'.format(d[1]), '@INPUT@', '@OUTPUT@' ],
                 depend_files: tracetool_depends)
   specific_ss.add(when: 'CONFIG_TCG', if_true: gen)


### PR DESCRIPTION
## Summary / 变更说明

- Make the raw LBT inline assembly in `tr-pattern.c` safe under GCC LTO by defining a uniquely named `parse_r_%=` assembler macro inside each extended-asm statement.
- Remove the file-scope assembler macro from the widely included `reg-alloc.h` header.
- Eliminate Meson configuration warnings by:
  - adding an explicit `check: true` to `run_command()`;
  - keeping generated sources as lists;
  - emitting compatible `pkgconfig` and `pkg-config` machine-file entries;
  - replacing deprecated source/build-root APIs;
  - using boolean values for boolean options;
  - removing the no-op deprecated `gui_app: false` argument.

The LTO failure was caused by relying on a file-scope assembler macro emitted from a common header. LTO repartitions and reorders translation units, so the macro could be duplicated or used outside the expected definition order, producing assembler failures. Keeping the definition with each use and using GCC's `%=` unique suffix removes that ordering and duplication dependency without changing the raw LBT opcodes.

The exact strict-aliasing note visible in the original report did not reproduce on the current L3 toolchain because its compile flags already include `-fno-strict-aliasing`. The reproducible fatal LTO assembler issue is covered by this fix.

## Validation / 验证

Validated on the L3 LoongArch host using the PR source tree.

Standard build scripts, after the warning cleanup:

- `./latxbuild/build64.sh -c`: passed, 472/472; warning/error/deprecation scan: 0 matches.
- `./latxbuild/build32.sh -c`: passed, 399/399; warning/error/deprecation scan: 0 matches.
- `./latxbuild/build-release.sh`: passed; i386 372/372 and x86_64 445/445, package generated; warning/error/deprecation scan: 0 matches.

LTO-specific and runtime validation:

- Deterministic RED in the same checkout with the production hunk temporarily reverted: LTO link failed with repeated `parse_r` assembler macro-definition errors.
- Full LTO build with automatic LTO partitioning: passed with no compiler, assembler, linker, or strict-aliasing warning matches.
- Full normal build: passed with no compiler, assembler, or linker warning matches.
- `lat-pr-fast`: 14/14 passed in both LTO and normal configurations.
- Runtime smoke test with `LATX_AOT=0` and the x86_64 guest root: exit 0.

## Checklist / 检查项

- [x] I have read `CONTRIBUTING.md`. / 我已阅读 `CONTRIBUTING.md`。
- [x] Every commit contains a DCO sign-off (`git commit -s`). /
      每个提交都包含 DCO 签署（`git commit -s`）。
- [x] I have included relevant build or test results, or explained why they
      are not applicable. /
      我已提供相关构建或测试结果，或说明了不适用的原因。