### PR TITLE
release-build-notices

### DIFF
--- a/latxbuild/build-release.sh
+++ b/latxbuild/build-release.sh
@@ -7,6 +7,7 @@ pkgdate=$(date +%Y%m%d)
 srcdir=$(realpath "$(dirname "$0")/../")
 pkgdir=$srcdir/pkg
 tarballs=$pkgname-$pkgver-$pkgdate.tar.xz
+package_root=$pkgdir/$pkgname-$pkgver
 
 prepare() {
     [ -d $srcdir/build32 ] || mkdir -p $srcdir/build32
@@ -101,6 +102,16 @@ EOF
     )
 }
 
+report_artifacts() {
+    printf '\n构建和打包完成。\n'
+    printf '编译目录：\n'
+    printf '  32 位：%s（产物：%s）\n' "$srcdir/build32" "latx-i386"
+    printf '  64 位：%s（产物：%s）\n' "$srcdir/build64" "latx-x86_64"
+    printf '打包暂存目录：%s\n' "$package_root"
+    printf '最终压缩包：%s\n' "$srcdir/$tarballs"
+}
+
 prepare
 build
 package
+report_artifacts

--- a/linux-user/main.c
+++ b/linux-user/main.c
@@ -1288,7 +1288,6 @@ int main(int argc, char **argv, char **envp)
         fprintf(stderr, ". Please check KERNEL and HARDWARE.\n");
     }
     if (!(hwcap & HWCAP_LOONGARCH_LASX)) {
-            fprintf(stderr, "not found LASX, use 128-bit vectors\n");
             option_enable_lasx = 0;
     }
 #endif


### PR DESCRIPTION
## Summary / 变更说明

- `build-release.sh` 成功结束后，打印 32/64 位构建产物、打包暂存目录和最终 `.tar.xz` 压缩包的位置。
- 当主机不支持 LASX 时，保留现有的 LASX 禁用与 128 位向量回退行为，但不再打印提示信息。

## Validation / 验证

- 执行了 `bash -n latxbuild/build-release.sh`，脚本语法检查通过。
- 执行了 `git diff --check`，未发现空白字符错误。
- 未执行完整构建或运行时测试；本次分别是构建完成提示和日志删除改动。

## Checklist / 检查项

- [x] I have read `CONTRIBUTING.md`. / 我已阅读 `CONTRIBUTING.md`。
- [x] Every commit contains a DCO sign-off (`git commit -s`). /
  每个提交都包含 DCO 签署（`git commit -s`）。
- [x] I have included relevant build or test results, or explained why they
  are not applicable. /
  我已提供相关构建或测试结果，或说明了不适用的原因。