### PR TITLE
linux-user: emulate x86 prctl state for Wine WoW64

### DIFF
--- a/linux-user/main.c
+++ b/linux-user/main.c
@@ -304,6 +304,7 @@ void init_task_state(TaskState *ts)
         .ss_flags = TARGET_SS_DISABLE,
     };
     ts->sys_dispatch_len = -1;
+    ts->sys_dispatch_inclusive = false;
 }
 
 CPUArchState *cpu_copy(CPUArchState *env)

--- a/linux-user/main.c
+++ b/linux-user/main.c
@@ -303,8 +303,10 @@ void init_task_state(TaskState *ts)
         .ss_size = 0,
         .ss_flags = TARGET_SS_DISABLE,
     };
+#ifdef TARGET_I386
     ts->sys_dispatch_len = -1;
     ts->sys_dispatch_inclusive = false;
+#endif
 }
 
 CPUArchState *cpu_copy(CPUArchState *env)
@@ -1273,7 +1275,8 @@ int main(int argc, char **argv, char **envp)
     int log_mask;
     unsigned long max_reserved_va;
     bool preserve_argv0;
-#ifdef TARGET_X86_64
+#ifdef TARGET_I386
+    int initial_guest_exe_fd = -1;
     unsigned int inherited_guest_mdwe = 0;
     bool inherited_guest_tsc_disabled = false;
 #endif
@@ -1305,9 +1308,20 @@ int main(int argc, char **argv, char **envp)
         (void) envlist_setenv(envlist, *wrk);
     }
 
-#ifdef TARGET_X86_64
-    if (g_strcmp0(getenv(LATX_GUEST_MDWE_ENV), "1") == 0) {
-        inherited_guest_mdwe = TARGET_PR_MDWE_REFUSE_EXEC_GAIN;
+#ifdef TARGET_I386
+    {
+        const char *value = getenv(LATX_GUEST_MDWE_ENV);
+        char *end = NULL;
+        unsigned long parsed = value ? g_ascii_strtoull(value, &end, 10) : 0;
+        unsigned int valid = TARGET_PR_MDWE_REFUSE_EXEC_GAIN |
+                             TARGET_PR_MDWE_NO_INHERIT;
+
+        if (value && end != value && *end == '\0' &&
+            (parsed & ~valid) == 0 &&
+            (!(parsed & TARGET_PR_MDWE_NO_INHERIT) ||
+             (parsed & TARGET_PR_MDWE_REFUSE_EXEC_GAIN))) {
+            inherited_guest_mdwe = parsed;
+        }
     }
     inherited_guest_tsc_disabled =
         g_strcmp0(getenv(LATX_GUEST_TSC_ENV), "1") == 0;
@@ -1457,7 +1471,7 @@ int main(int argc, char **argv, char **envp)
     env = cpu->env_ptr;
     cpu_reset(cpu);
 
-#ifdef TARGET_X86_64
+#ifdef TARGET_I386
     if (inherited_guest_tsc_disabled) {
         env->cr[4] |= CR4_TSD_MASK;
     }
@@ -1645,7 +1659,7 @@ int main(int argc, char **argv, char **envp)
     /* build Task State */
     ts->info = info;
     ts->bprm = &bprm;
-#ifdef TARGET_X86_64
+#ifdef TARGET_I386
     info->prctl_mdwe = inherited_guest_mdwe;
 #endif
     cpu->opaque = ts;
@@ -1654,13 +1668,21 @@ int main(int argc, char **argv, char **envp)
     aot_set_process_profile(target_argc, target_argv);
     aot_init();
 #endif
+#ifdef TARGET_I386
+    initial_guest_exe_fd = fcntl(execfd, F_DUPFD_CLOEXEC, 0);
+    if (initial_guest_exe_fd < 0) {
+        error_report("Unable to preserve guest executable: %s",
+                     strerror(errno));
+        _exit(EXIT_FAILURE);
+    }
+#endif
     ret = loader_exec(execfd, exec_path, target_argv, target_environ, regs,
         info, &bprm);
     if (ret != 0) {
         printf("Error while loading %s: %s\n", exec_path, strerror(-ret));
         _exit(EXIT_FAILURE);
     }
-#ifdef TARGET_X86_64
+#ifdef TARGET_I386
     {
         size_t auxv_size = MIN((size_t)info->auxv_len,
                                sizeof(info->prctl_auxv));
@@ -1683,7 +1705,7 @@ int main(int argc, char **argv, char **envp)
         info->prctl_mm_arg_end = info->env_strings;
         info->prctl_mm_env_start = info->env_strings;
         info->prctl_mm_env_end = info->file_string;
-        info->prctl_mm_exe_fd = -1;
+        info->prctl_mm_exe_fd = initial_guest_exe_fd;
     }
 #endif
 #ifdef CONFIG_LATX_FAST_JMPCACHE

--- a/linux-user/main.c
+++ b/linux-user/main.c
@@ -303,6 +303,7 @@ void init_task_state(TaskState *ts)
         .ss_size = 0,
         .ss_flags = TARGET_SS_DISABLE,
     };
+    ts->sys_dispatch_len = -1;
 }
 
 CPUArchState *cpu_copy(CPUArchState *env)
@@ -1271,6 +1272,10 @@ int main(int argc, char **argv, char **envp)
     int log_mask;
     unsigned long max_reserved_va;
     bool preserve_argv0;
+#ifdef TARGET_X86_64
+    unsigned int inherited_guest_mdwe = 0;
+    bool inherited_guest_tsc_disabled = false;
+#endif
 
 #if defined(CONFIG_LATX) && defined(__loongarch__)
     /* Lets check hwcap */
@@ -1298,6 +1303,16 @@ int main(int argc, char **argv, char **envp)
     for (wrk = environ; *wrk != NULL; wrk++) {
         (void) envlist_setenv(envlist, *wrk);
     }
+
+#ifdef TARGET_X86_64
+    if (g_strcmp0(getenv(LATX_GUEST_MDWE_ENV), "1") == 0) {
+        inherited_guest_mdwe = TARGET_PR_MDWE_REFUSE_EXEC_GAIN;
+    }
+    inherited_guest_tsc_disabled =
+        g_strcmp0(getenv(LATX_GUEST_TSC_ENV), "1") == 0;
+    (void)envlist_unsetenv(envlist, LATX_GUEST_MDWE_ENV);
+    (void)envlist_unsetenv(envlist, LATX_GUEST_TSC_ENV);
+#endif
 
     /* extracting environment variables */
     optind = parse_args(argc, argv);
@@ -1440,6 +1455,12 @@ int main(int argc, char **argv, char **envp)
     cpu = cpu_create(cpu_type);
     env = cpu->env_ptr;
     cpu_reset(cpu);
+
+#ifdef TARGET_X86_64
+    if (inherited_guest_tsc_disabled) {
+        env->cr[4] |= CR4_TSD_MASK;
+    }
+#endif
 
 
 #ifdef CONFIG_LATX
@@ -1623,6 +1644,9 @@ int main(int argc, char **argv, char **envp)
     /* build Task State */
     ts->info = info;
     ts->bprm = &bprm;
+#ifdef TARGET_X86_64
+    info->prctl_mdwe = inherited_guest_mdwe;
+#endif
     cpu->opaque = ts;
     task_settid(ts);
 #ifdef CONFIG_LATX_AOT
@@ -1635,6 +1659,32 @@ int main(int argc, char **argv, char **envp)
         printf("Error while loading %s: %s\n", exec_path, strerror(-ret));
         _exit(EXIT_FAILURE);
     }
+#ifdef TARGET_X86_64
+    {
+        size_t auxv_size = MIN((size_t)info->auxv_len,
+                               sizeof(info->prctl_auxv));
+
+        memset(info->prctl_auxv, 0, sizeof(info->prctl_auxv));
+        if (auxv_size && copy_from_user(info->prctl_auxv,
+                                        info->saved_auxv, auxv_size)) {
+            fprintf(stderr, "Unable to save guest auxiliary vector\n");
+            _exit(EXIT_FAILURE);
+        }
+        info->prctl_auxv_initialized = true;
+        info->prctl_mm_start_code = info->start_code;
+        info->prctl_mm_end_code = info->end_code;
+        info->prctl_mm_start_data = info->start_data;
+        info->prctl_mm_end_data = info->end_data;
+        info->prctl_mm_start_brk = info->start_brk;
+        info->prctl_mm_brk = info->brk;
+        info->prctl_mm_start_stack = info->start_stack;
+        info->prctl_mm_arg_start = info->arg_strings;
+        info->prctl_mm_arg_end = info->env_strings;
+        info->prctl_mm_env_start = info->env_strings;
+        info->prctl_mm_env_end = info->file_string;
+        info->prctl_mm_exe_fd = -1;
+    }
+#endif
 #ifdef CONFIG_LATX_FAST_JMPCACHE
         if(!latx_fast_jmp_cache_init(env)) {
             fprintf(stderr, "[LATX-ERR] latx_fast_jmp_cache_init error!\n");

--- a/linux-user/main.c
+++ b/linux-user/main.c
@@ -1667,7 +1667,7 @@ int main(int argc, char **argv, char **envp)
         memset(info->prctl_auxv, 0, sizeof(info->prctl_auxv));
         if (auxv_size && copy_from_user(info->prctl_auxv,
                                         info->saved_auxv, auxv_size)) {
-            fprintf(stderr, "Unable to save guest auxiliary vector\n");
+            error_report("Unable to save guest auxiliary vector");
             _exit(EXIT_FAILURE);
         }
         info->prctl_auxv_initialized = true;

--- a/linux-user/mmap.c
+++ b/linux-user/mmap.c
@@ -165,8 +165,11 @@ int target_mprotect(abi_ulong start, abi_ulong len, int target_prot)
     if (!guest_range_valid_untagged(start, len)) {
         return -TARGET_ENOMEM;
     }
-
     mmap_lock();
+    if (!page_check_range(start, len, PAGE_VALID)) {
+        mmap_unlock();
+        return -TARGET_ENOMEM;
+    }
 
     host_start = start & qemu_host_page_mask;
     host_end = HOST_PAGE_ALIGN(end);
@@ -755,8 +758,9 @@ abi_long target_mmap(abi_ulong start, abi_ulong len, int target_prot,
     }
 #endif
 
-    if (option_prlimit && rlimit_as_account && (vir_rlimit_as != RLIM_INFINITY)
-        && (len + vir_rlimit_as_acc >= vir_rlimit_as)) {
+    if (option_prlimit && rlimit_as_account &&
+        vir_rlimit_as != RLIM_INFINITY &&
+        len > vir_rlimit_as - MIN(vir_rlimit_as_acc, vir_rlimit_as)) {
         errno = ENOMEM;
         goto fail;
     }
@@ -1252,7 +1256,8 @@ int target_munmap(abi_ulong start, abi_ulong len, int rlimit_as_account)
     }
     mmap_unlock();
 
-    if (option_prlimit && rlimit_as_account && vir_rlimit_as != RLIM_INFINITY) {
+    if (ret == 0 && option_prlimit && rlimit_as_account &&
+        vir_rlimit_as != RLIM_INFINITY) {
         if (vir_rlimit_as_acc > len) {
             vir_rlimit_as_acc -= len;
         } else {
@@ -1270,6 +1275,9 @@ abi_long target_mremap(abi_ulong old_addr, abi_ulong old_size,
     abi_ulong account_add = 0;
     abi_ulong account_sub = 0;
     bool keep_old;
+    bool manual_move = false;
+    bool can_manual_move = true;
+    bool unreserved_extension = false;
     int prot;
     void *host_addr;
 
@@ -1344,41 +1352,95 @@ abi_long target_mremap(abi_ulong old_addr, abi_ulong old_size,
     mmap_lock();
 
     prot = page_get_flags(old_addr);
-    if (!keep_old && (flags & MREMAP_MAYMOVE) &&
+    if ((prot & (PAGE_VALID | PAGE_ANON)) != (PAGE_VALID | PAGE_ANON) ||
+        (prot & PAGE_MEMSHARE)) {
+        can_manual_move = false;
+    } else {
+        abi_ulong addr;
+
+        for (addr = old_addr; addr < old_addr + old_size;
+             addr += TARGET_PAGE_SIZE) {
+            int page_prot = page_get_flags(addr);
+
+            if ((page_prot & (PAGE_VALID | PAGE_ANON)) !=
+                    (PAGE_VALID | PAGE_ANON) ||
+                (page_prot & PAGE_MEMSHARE) ||
+                (page_prot & PAGE_BITS) != (prot & PAGE_BITS)) {
+                can_manual_move = false;
+                break;
+            }
+        }
+    }
+    if (!keep_old && !can_manual_move && (flags & MREMAP_MAYMOVE) &&
         (prot & PAGE_ANON) && !(prot & PAGE_MEMSHARE) &&
         !(old_addr & ~qemu_host_page_mask) &&
         (HOST_PAGE_ALIGN(old_size) != old_size ||
          HOST_PAGE_ALIGN(new_size) != new_size)) {
+        errno = EFAULT;
+        host_addr = MAP_FAILED;
+    } else if (!keep_old && can_manual_move && (flags & MREMAP_MAYMOVE) &&
+        !(old_addr & ~qemu_host_page_mask) &&
+        (HOST_PAGE_ALIGN(old_size) != old_size ||
+         HOST_PAGE_ALIGN(new_size) != new_size)) {
         abi_ulong mmap_start = new_addr;
+        abi_ulong source_host_size = HOST_PAGE_ALIGN(old_size);
+        abi_ulong target_host_size = HOST_PAGE_ALIGN(new_size);
+        abi_ulong addr;
         size_t copy_size = MIN(old_size, new_size);
-        int host_prot = (prot & PAGE_WRITE ? PROT_WRITE : 0) |
-                        (prot & (PAGE_READ | PAGE_EXEC) ? PROT_READ : 0);
+        int source_host_prot = 0;
+        void *temp = MAP_FAILED;
 
         if (!(flags & MREMAP_FIXED)) {
             mmap_start = mmap_find_vma(0, new_size, TARGET_PAGE_SIZE);
         }
         if (mmap_start == (abi_ulong)-1 ||
-            (mmap_start & ~qemu_host_page_mask) ||
             (mmap_start < old_addr + old_size &&
              old_addr < mmap_start + new_size)) {
             errno = mmap_start == (abi_ulong)-1 ? ENOMEM : EINVAL;
             host_addr = MAP_FAILED;
         } else {
-            host_addr = mmap(g2h_untagged(mmap_start), new_size,
-                             PROT_READ | PROT_WRITE,
-                             MAP_FIXED | MAP_PRIVATE | MAP_ANONYMOUS,
-                             -1, 0);
-            if (host_addr != MAP_FAILED) {
-                memcpy(host_addr, g2h_untagged(old_addr), copy_size);
-                if (mprotect(host_addr, HOST_PAGE_ALIGN(new_size),
-                             host_prot) < 0) {
-                    int saved_errno = errno;
+            temp = mmap(NULL, target_host_size, PROT_READ | PROT_WRITE,
+                        MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+            host_addr = temp;
+            if (temp != MAP_FAILED) {
+                for (addr = old_addr; addr < old_addr + source_host_size;
+                     addr += TARGET_PAGE_SIZE) {
+                    int page_prot = page_get_flags(addr);
 
-                    munmap(host_addr, HOST_PAGE_ALIGN(new_size));
-                    errno = saved_errno;
+                    source_host_prot |= page_prot & (PAGE_READ | PAGE_WRITE);
+                    if (page_prot & PAGE_EXEC) {
+                        source_host_prot |= PROT_READ;
+                    }
+                }
+                if (!(source_host_prot & PROT_READ) &&
+                    mprotect(g2h_untagged(old_addr), source_host_size,
+                             source_host_prot | PROT_READ) < 0) {
                     host_addr = MAP_FAILED;
                 } else {
-                    new_addr = mmap_start;
+                    memcpy(temp, g2h_untagged(old_addr), copy_size);
+                    if (!(source_host_prot & PROT_READ) &&
+                        mprotect(g2h_untagged(old_addr), source_host_size,
+                                 source_host_prot) < 0) {
+                        abort();
+                    }
+                    new_addr = target_mmap(
+                        mmap_start, new_size, PROT_READ | PROT_WRITE,
+                        MAP_FIXED | MAP_PRIVATE | MAP_ANONYMOUS,
+                        -1, 0, 0);
+                    if (new_addr == (abi_ulong)-1) {
+                        host_addr = MAP_FAILED;
+                    } else {
+                        memcpy(g2h_untagged(new_addr), temp, copy_size);
+                        if (target_mprotect(new_addr, new_size,
+                                            prot & PAGE_BITS) != 0) {
+                            abort();
+                        }
+                        host_addr = g2h_untagged(new_addr);
+                    }
+                }
+                munmap(temp, target_host_size);
+                if (host_addr != MAP_FAILED) {
+                    manual_move = true;
                 }
             }
         }
@@ -1430,6 +1492,7 @@ abi_long target_mremap(abi_ulong old_addr, abi_ulong old_size,
                 }
                 munmap(g2h_untagged(TARGET_PAGE_ALIGN(old_addr + old_size)),
                        num_pages * TARGET_PAGE_SIZE);
+                unreserved_extension = true;
             }
             host_addr = mremap(g2h_untagged(old_addr),
                                old_size, new_size, flags);
@@ -1453,15 +1516,24 @@ abi_long target_mremap(abi_ulong old_addr, abi_ulong old_size,
     }
 
     if (host_addr == MAP_FAILED) {
+        if (unreserved_extension) {
+            mmap_reserve(old_addr + old_size, new_size - old_size);
+        }
         new_addr = -1;
     } else {
         new_addr = h2g(host_addr);
+        if (manual_move && mmap_unmap_host_range(old_addr, old_size) != 0) {
+            abort();
+        }
 #ifdef TARGET_X86_64
         guest_vma_name_remap(old_addr, source_size, new_addr, new_size,
                              keep_old);
 #endif
         if (!keep_old) {
             page_set_flags(old_addr, old_addr + old_size, 0);
+        } else if (flags & MREMAP_DONTUNMAP) {
+            page_set_flags(old_addr, old_addr + old_size,
+                           prot | PAGE_VALID | PAGE_RESET);
         }
         page_set_flags(new_addr, new_addr + new_size,
                        prot | PAGE_VALID | PAGE_RESET);
@@ -1470,7 +1542,7 @@ abi_long target_mremap(abi_ulong old_addr, abi_ulong old_size,
         if (option_aot) {
             seg_info *seg;
 
-            if (!keep_old) {
+            if (!keep_old || (flags & MREMAP_DONTUNMAP)) {
                 seg = segment_tree_lookup2(old_addr, old_addr + old_size);
                 if (seg) {
                     segment_tree_remove(seg);

--- a/linux-user/mmap.c
+++ b/linux-user/mmap.c
@@ -777,9 +777,8 @@ abi_long target_mmap(abi_ulong start, abi_ulong len, int target_prot,
      * be atomic with respect to an external process.
      */
     if (flags & MAP_SHARED) {
-        if (option_monitor_shared_mem) {
-            page_flags |= PAGE_MEMSHARE;
-        }
+        /* Preserve sharing semantics even when monitoring is disabled. */
+        page_flags |= PAGE_MEMSHARE;
         CPUState *cpu = thread_cpu;
         if (!(cpu->tcg_cflags & CF_PARALLEL)) {
             cpu->tcg_cflags |= CF_PARALLEL;
@@ -1349,6 +1348,12 @@ abi_long target_mremap(abi_ulong old_addr, abi_ulong old_size,
         }
     }
 
+    /*
+     * The partial-host-page fallback temporarily changes host protection
+     * and copies mappings.  Keep other guest threads out until both the host
+     * mapping and guest page metadata describe the completed operation.
+     */
+    start_exclusive();
     mmap_lock();
 
     prot = page_get_flags(old_addr);
@@ -1557,6 +1562,7 @@ abi_long target_mremap(abi_ulong old_addr, abi_ulong old_size,
     }
 
     mmap_unlock();
+    end_exclusive();
 
     if (host_addr != MAP_FAILED && option_prlimit && rlimit_as_account &&
         vir_rlimit_as != RLIM_INFINITY) {

--- a/linux-user/mmap.c
+++ b/linux-user/mmap.c
@@ -1172,62 +1172,69 @@ static void mmap_reserve(abi_ulong start, abi_ulong size)
     }
 }
 
+/* Called with the mmap lock held. */
+static int mmap_unmap_host_range(abi_ulong start, abi_ulong len)
+{
+    abi_ulong end = start + len;
+    abi_ulong real_start = start & qemu_host_page_mask;
+    abi_ulong real_end = HOST_PAGE_ALIGN(end);
+    abi_ulong addr;
+    int prot;
+
+    if (start > real_start) {
+        prot = 0;
+        for (addr = real_start; addr < start; addr += TARGET_PAGE_SIZE) {
+            prot |= page_get_flags(addr);
+        }
+        if (real_end == real_start + qemu_host_page_size) {
+            for (addr = end; addr < real_end; addr += TARGET_PAGE_SIZE) {
+                prot |= page_get_flags(addr);
+            }
+            end = real_end;
+        }
+        if (prot != 0) {
+            real_start += qemu_host_page_size;
+        }
+    }
+    if (end < real_end) {
+        prot = 0;
+        for (addr = end; addr < real_end; addr += TARGET_PAGE_SIZE) {
+            prot |= page_get_flags(addr);
+        }
+        if (prot != 0) {
+            real_end -= qemu_host_page_size;
+        }
+    }
+
+    if (real_start >= real_end) {
+        return 0;
+    }
+    if (reserved_va) {
+        mmap_reserve(real_start, real_end - real_start);
+        return 0;
+    }
+    if (is_shadow_page_shmm(real_start)) {
+        fprintf(stderr, "%s:%d, should not happen\n", __func__, __LINE__);
+    }
+    return munmap(g2h_untagged(real_start), real_end - real_start);
+}
+
 int target_munmap(abi_ulong start, abi_ulong len, int rlimit_as_account)
 {
-    abi_ulong end, real_start, real_end, addr;
-    int prot, ret;
+    int ret;
 
     trace_target_munmap(start, len);
 
-    if (start & ~TARGET_PAGE_MASK)
+    if (start & ~TARGET_PAGE_MASK) {
         return -TARGET_EINVAL;
+    }
     len = TARGET_PAGE_ALIGN(len);
     if (len == 0 || !guest_range_valid_untagged(start, len)) {
         return -TARGET_EINVAL;
     }
 
     mmap_lock();
-    end = start + len;
-    real_start = start & qemu_host_page_mask;
-    real_end = HOST_PAGE_ALIGN(end);
-
-
-    if (start > real_start) {
-        /* handle host page containing start */
-        prot = 0;
-        for(addr = real_start; addr < start; addr += TARGET_PAGE_SIZE) {
-            prot |= page_get_flags(addr);
-        }
-        if (real_end == real_start + qemu_host_page_size) {
-            for(addr = end; addr < real_end; addr += TARGET_PAGE_SIZE) {
-                prot |= page_get_flags(addr);
-            }
-            end = real_end;
-        }
-        if (prot != 0)
-            real_start += qemu_host_page_size;
-    }
-    if (end < real_end) {
-        prot = 0;
-        for(addr = end; addr < real_end; addr += TARGET_PAGE_SIZE) {
-            prot |= page_get_flags(addr);
-        }
-        if (prot != 0)
-            real_end -= qemu_host_page_size;
-    }
-
-    ret = 0;
-    /* unmap what we can */
-    if (real_start < real_end) {
-        if (reserved_va) {
-            mmap_reserve(real_start, real_end - real_start);
-        } else {
-            if (is_shadow_page_shmm(real_start)) {
-                fprintf(stderr, "%s:%d, should not happen\n", __func__, __LINE__);
-            }
-            ret = munmap(g2h_untagged(real_start), real_end - real_start);
-        }
-    }
+    ret = mmap_unmap_host_range(start, len);
 
     if (ret == 0) {
 #ifdef CONFIG_LATX_AOT

--- a/linux-user/mmap.c
+++ b/linux-user/mmap.c
@@ -1079,6 +1079,9 @@ abi_long target_mmap(abi_ulong start, abi_ulong len, int target_prot,
     }
 
  the_end:
+#ifdef TARGET_X86_64
+    guest_vma_name_reset(start, len);
+#endif
     trace_target_mmap_complete(start);
     if (qemu_loglevel_mask(CPU_LOG_PAGE)) {
         log_page_dump(__func__);
@@ -1232,6 +1235,9 @@ int target_munmap(abi_ulong start, abi_ulong len, int rlimit_as_account)
         }
 #endif
         page_set_flags(start, start + len, 0);
+#ifdef TARGET_X86_64
+        guest_vma_name_reset(start, len);
+#endif
     }
     mmap_unlock();
 
@@ -1361,6 +1367,9 @@ abi_long target_mremap(abi_ulong old_addr, abi_ulong old_size,
     } else {
         new_addr = h2g(host_addr);
         prot = page_get_flags(old_addr);
+#ifdef TARGET_X86_64
+        guest_vma_name_remap(old_addr, old_size, new_addr, new_size);
+#endif
         page_set_flags(old_addr, old_addr + old_size, 0);
         if (option_monitor_shared_mem && (flags & MAP_TYPE) == MAP_SHARED) {
             prot |= PAGE_MEMSHARE;

--- a/linux-user/mmap.c
+++ b/linux-user/mmap.c
@@ -1393,6 +1393,7 @@ abi_long target_mremap(abi_ulong old_addr, abi_ulong old_size,
         abi_ulong addr;
         size_t copy_size = MIN(old_size, new_size);
         int source_host_prot = 0;
+        int move_errno = 0;
         void *temp = MAP_FAILED;
 
         if (!(flags & MREMAP_FIXED)) {
@@ -1420,30 +1421,43 @@ abi_long target_mremap(abi_ulong old_addr, abi_ulong old_size,
                 if (!(source_host_prot & PROT_READ) &&
                     mprotect(g2h_untagged(old_addr), source_host_size,
                              source_host_prot | PROT_READ) < 0) {
+                    move_errno = errno;
                     host_addr = MAP_FAILED;
                 } else {
                     memcpy(temp, g2h_untagged(old_addr), copy_size);
                     if (!(source_host_prot & PROT_READ) &&
                         mprotect(g2h_untagged(old_addr), source_host_size,
                                  source_host_prot) < 0) {
-                        abort();
-                    }
-                    new_addr = target_mmap(
-                        mmap_start, new_size, PROT_READ | PROT_WRITE,
-                        MAP_FIXED | MAP_PRIVATE | MAP_ANONYMOUS,
-                        -1, 0, 0);
-                    if (new_addr == (abi_ulong)-1) {
+                        move_errno = errno;
                         host_addr = MAP_FAILED;
                     } else {
-                        memcpy(g2h_untagged(new_addr), temp, copy_size);
-                        if (target_mprotect(new_addr, new_size,
-                                            prot & PAGE_BITS) != 0) {
-                            abort();
+                        new_addr = target_mmap(
+                            mmap_start, new_size, PROT_READ | PROT_WRITE,
+                            MAP_FIXED | MAP_PRIVATE | MAP_ANONYMOUS,
+                            -1, 0, 0);
+                        if (new_addr == (abi_ulong)-1) {
+                            move_errno = errno;
+                            host_addr = MAP_FAILED;
+                        } else {
+                            memcpy(g2h_untagged(new_addr), temp, copy_size);
+                            if (target_mprotect(new_addr, new_size,
+                                                prot & PAGE_BITS) != 0) {
+                                move_errno = errno;
+                                if (target_munmap(new_addr, new_size, 0)) {
+                                    qemu_log_mask(LOG_UNIMP,
+                                                  "mremap rollback failed\n");
+                                }
+                                host_addr = MAP_FAILED;
+                            } else {
+                                host_addr = g2h_untagged(new_addr);
+                            }
                         }
-                        host_addr = g2h_untagged(new_addr);
                     }
                 }
                 munmap(temp, target_host_size);
+                if (move_errno) {
+                    errno = move_errno;
+                }
                 if (host_addr != MAP_FAILED) {
                     manual_move = true;
                 }
@@ -1520,6 +1534,17 @@ abi_long target_mremap(abi_ulong old_addr, abi_ulong old_size,
         }
     }
 
+    if (host_addr != MAP_FAILED && manual_move &&
+        mmap_unmap_host_range(old_addr, old_size) != 0) {
+        int move_errno = errno;
+
+        if (target_munmap(new_addr, new_size, 0)) {
+            qemu_log_mask(LOG_UNIMP, "mremap rollback failed\n");
+        }
+        errno = move_errno;
+        host_addr = MAP_FAILED;
+    }
+
     if (host_addr == MAP_FAILED) {
         if (unreserved_extension) {
             mmap_reserve(old_addr + old_size, new_size - old_size);
@@ -1527,9 +1552,6 @@ abi_long target_mremap(abi_ulong old_addr, abi_ulong old_size,
         new_addr = -1;
     } else {
         new_addr = h2g(host_addr);
-        if (manual_move && mmap_unmap_host_range(old_addr, old_size) != 0) {
-            abort();
-        }
 #ifdef TARGET_X86_64
         guest_vma_name_remap(old_addr, source_size, new_addr, new_size,
                              keep_old);

--- a/linux-user/mmap.c
+++ b/linux-user/mmap.c
@@ -21,6 +21,10 @@
 #include "trace.h"
 #include "exec/log.h"
 #include "qemu.h"
+
+#ifndef MREMAP_DONTUNMAP
+#define MREMAP_DONTUNMAP 4
+#endif
 #ifdef CONFIG_LATX
 #include "latx-config.h"
 #endif
@@ -1255,10 +1259,14 @@ abi_long target_mremap(abi_ulong old_addr, abi_ulong old_size,
                        abi_ulong new_size, unsigned long flags,
                        abi_ulong new_addr, int rlimit_as_account)
 {
+    abi_ulong source_size;
+    abi_ulong account_add = 0;
+    abi_ulong account_sub = 0;
+    bool keep_old;
     int prot;
     void *host_addr;
 
-    if (flags & ~(MREMAP_FIXED | MREMAP_MAYMOVE)) {
+    if (flags & ~(MREMAP_FIXED | MREMAP_MAYMOVE | MREMAP_DONTUNMAP)) {
         errno = EINVAL;
         return -1;
     }
@@ -1268,12 +1276,40 @@ abi_long target_mremap(abi_ulong old_addr, abi_ulong old_size,
         return -1;
     }
 
+    if (!new_size) {
+        errno = EINVAL;
+        return -1;
+    }
+    new_size = TARGET_PAGE_ALIGN(new_size);
+    if (!new_size) {
+        errno = ENOMEM;
+        return -1;
+    }
+    if (old_size) {
+        old_size = TARGET_PAGE_ALIGN(old_size);
+        if (!old_size) {
+            errno = ENOMEM;
+            return -1;
+        }
+    } else if (!(flags & MREMAP_MAYMOVE)) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if ((flags & MREMAP_DONTUNMAP) &&
+        (!(flags & MREMAP_MAYMOVE) || !old_size || old_size != new_size)) {
+        errno = EINVAL;
+        return -1;
+    }
+
     if (old_addr & ~TARGET_PAGE_MASK) {
         errno = EINVAL;
         return -1;
     }
 
-    if (!guest_range_valid_untagged(old_addr, old_size) ||
+    keep_old = !old_size || (flags & MREMAP_DONTUNMAP);
+    source_size = old_size ? old_size : new_size;
+    if (!guest_range_valid_untagged(old_addr, source_size) ||
         ((flags & MREMAP_FIXED) &&
          !guest_range_valid_untagged(new_addr, new_size)) ||
         ((flags & MREMAP_MAYMOVE) == 0 &&
@@ -1282,10 +1318,17 @@ abi_long target_mremap(abi_ulong old_addr, abi_ulong old_size,
         return -1;
     }
 
-    if (option_prlimit && rlimit_as_account && (new_size > old_size)
-        && (vir_rlimit_as != RLIM_INFINITY)) {
-        abi_ulong diff = new_size - old_size;
-        if (diff + vir_rlimit_as_acc > vir_rlimit_as ) {
+    if (keep_old) {
+        account_add = new_size;
+    } else if (new_size > old_size) {
+        account_add = new_size - old_size;
+    } else {
+        account_sub = old_size - new_size;
+    }
+    if (option_prlimit && rlimit_as_account && account_add &&
+        vir_rlimit_as != RLIM_INFINITY) {
+        if (account_add > vir_rlimit_as -
+                          MIN(vir_rlimit_as_acc, vir_rlimit_as)) {
             errno = ENOMEM;
             return -1;
         }
@@ -1293,11 +1336,50 @@ abi_long target_mremap(abi_ulong old_addr, abi_ulong old_size,
 
     mmap_lock();
 
-    if (flags & MREMAP_FIXED) {
+    prot = page_get_flags(old_addr);
+    if (!keep_old && (flags & MREMAP_MAYMOVE) &&
+        (prot & PAGE_ANON) && !(prot & PAGE_MEMSHARE) &&
+        !(old_addr & ~qemu_host_page_mask) &&
+        (HOST_PAGE_ALIGN(old_size) != old_size ||
+         HOST_PAGE_ALIGN(new_size) != new_size)) {
+        abi_ulong mmap_start = new_addr;
+        size_t copy_size = MIN(old_size, new_size);
+        int host_prot = (prot & PAGE_WRITE ? PROT_WRITE : 0) |
+                        (prot & (PAGE_READ | PAGE_EXEC) ? PROT_READ : 0);
+
+        if (!(flags & MREMAP_FIXED)) {
+            mmap_start = mmap_find_vma(0, new_size, TARGET_PAGE_SIZE);
+        }
+        if (mmap_start == (abi_ulong)-1 ||
+            (mmap_start & ~qemu_host_page_mask) ||
+            (mmap_start < old_addr + old_size &&
+             old_addr < mmap_start + new_size)) {
+            errno = mmap_start == (abi_ulong)-1 ? ENOMEM : EINVAL;
+            host_addr = MAP_FAILED;
+        } else {
+            host_addr = mmap(g2h_untagged(mmap_start), new_size,
+                             PROT_READ | PROT_WRITE,
+                             MAP_FIXED | MAP_PRIVATE | MAP_ANONYMOUS,
+                             -1, 0);
+            if (host_addr != MAP_FAILED) {
+                memcpy(host_addr, g2h_untagged(old_addr), copy_size);
+                if (mprotect(host_addr, HOST_PAGE_ALIGN(new_size),
+                             host_prot) < 0) {
+                    int saved_errno = errno;
+
+                    munmap(host_addr, HOST_PAGE_ALIGN(new_size));
+                    errno = saved_errno;
+                    host_addr = MAP_FAILED;
+                } else {
+                    new_addr = mmap_start;
+                }
+            }
+        }
+    } else if (flags & MREMAP_FIXED) {
         host_addr = mremap(g2h_untagged(old_addr), old_size, new_size,
                            flags, g2h_untagged(new_addr));
 
-        if (reserved_va && host_addr != MAP_FAILED) {
+        if (reserved_va && host_addr != MAP_FAILED && !keep_old) {
             /* If new and old addresses overlap then the above mremap will
                already have failed with EINVAL.  */
             mmap_reserve(old_addr, old_size);
@@ -1317,7 +1399,7 @@ abi_long target_mremap(abi_ulong old_addr, abi_ulong old_size,
             if (host_addr == MAP_FAILED)
                 errno = EFAULT;
             else {
-                if (reserved_va) {
+                if (reserved_va && !keep_old) {
                     mmap_reserve(old_addr, old_size);
                 }
             }
@@ -1335,12 +1417,13 @@ abi_long target_mremap(abi_ulong old_addr, abi_ulong old_size,
             }
         }
         if (prot == 0) {
-            if (reserved_va && new_size > old_size && num_pages)
+            if (reserved_va && new_size > old_size && num_pages) {
                 if (is_shadow_page_shmm(TARGET_PAGE_ALIGN(old_addr + old_size))) {
                     fprintf(stderr, "%s:%d, should not happen\n", __func__, __LINE__);
                 }
                 munmap(g2h_untagged(TARGET_PAGE_ALIGN(old_addr + old_size)),
-                                        num_pages*TARGET_PAGE_SIZE);
+                       num_pages * TARGET_PAGE_SIZE);
+            }
             host_addr = mremap(g2h_untagged(old_addr),
                                old_size, new_size, flags);
 
@@ -1366,38 +1449,42 @@ abi_long target_mremap(abi_ulong old_addr, abi_ulong old_size,
         new_addr = -1;
     } else {
         new_addr = h2g(host_addr);
-        prot = page_get_flags(old_addr);
 #ifdef TARGET_X86_64
-        guest_vma_name_remap(old_addr, old_size, new_addr, new_size);
+        guest_vma_name_remap(old_addr, source_size, new_addr, new_size,
+                             keep_old);
 #endif
-        page_set_flags(old_addr, old_addr + old_size, 0);
-        if (option_monitor_shared_mem && (flags & MAP_TYPE) == MAP_SHARED) {
-            prot |= PAGE_MEMSHARE;
+        if (!keep_old) {
+            page_set_flags(old_addr, old_addr + old_size, 0);
         }
         page_set_flags(new_addr, new_addr + new_size,
                        prot | PAGE_VALID | PAGE_RESET);
-    }
 
 #ifdef CONFIG_LATX_AOT
-    if (option_aot) {
-        seg_info *seg = segment_tree_lookup2(old_addr, old_addr + old_size);
-        if (seg) {
-            segment_tree_remove(seg);
+        if (option_aot) {
+            seg_info *seg;
+
+            if (!keep_old) {
+                seg = segment_tree_lookup2(old_addr, old_addr + old_size);
+                if (seg) {
+                    segment_tree_remove(seg);
+                }
+            }
+            seg = segment_tree_lookup2(new_addr, new_addr + new_size);
+            if (seg) {
+                segment_tree_remove(seg);
+            }
         }
-        seg = segment_tree_lookup2(new_addr, new_addr + new_size);
-        if (seg) {
-            segment_tree_remove(seg);
-        }
-    }
 #endif
+    }
 
     mmap_unlock();
 
-    if (option_prlimit && rlimit_as_account && (new_size != old_size)
-        && (vir_rlimit_as != RLIM_INFINITY)) {
-        abi_long diff = new_size - old_size;
-        if ((diff > 0) || (vir_rlimit_as_acc > -diff)) {
-            vir_rlimit_as_acc += diff;
+    if (host_addr != MAP_FAILED && option_prlimit && rlimit_as_account &&
+        vir_rlimit_as != RLIM_INFINITY) {
+        if (account_add) {
+            vir_rlimit_as_acc += account_add;
+        } else if (vir_rlimit_as_acc > account_sub) {
+            vir_rlimit_as_acc -= account_sub;
         } else {
             vir_rlimit_as_acc = 0;
         }

--- a/linux-user/mmap.c
+++ b/linux-user/mmap.c
@@ -112,7 +112,7 @@ static int validate_prot_to_pageflags(int *host_prot, int prot)
      *
      * Pages that are executable by the guest will never be executed
      * by the host, but the host will need to be able to read them.
-     */
+    */
     *host_prot = (prot & (PROT_READ | PROT_WRITE))
                | (prot & PROT_EXEC ? PROT_READ : 0);
 
@@ -438,7 +438,7 @@ static abi_ulong mmap_find_vma_reserved(abi_ulong start, abi_ulong size,
             }
         }
     }
-    */
+     */
     target_ulong ret;
     target_ulong max = reserved_va - 1;
 
@@ -777,9 +777,10 @@ abi_long target_mmap(abi_ulong start, abi_ulong len, int target_prot,
      * be atomic with respect to an external process.
      */
     if (flags & MAP_SHARED) {
+        CPUState *cpu = thread_cpu;
+
         /* Preserve sharing semantics even when monitoring is disabled. */
         page_flags |= PAGE_MEMSHARE;
-        CPUState *cpu = thread_cpu;
         if (!(cpu->tcg_cflags & CF_PARALLEL)) {
             cpu->tcg_cflags |= CF_PARALLEL;
             tb_flush(cpu);
@@ -1086,7 +1087,7 @@ abi_long target_mmap(abi_ulong start, abi_ulong len, int target_prot,
     }
 
  the_end:
-#ifdef TARGET_X86_64
+#ifdef TARGET_I386
     guest_vma_name_reset(start, len);
 #endif
     trace_target_mmap_complete(start);
@@ -1249,7 +1250,7 @@ int target_munmap(abi_ulong start, abi_ulong len, int rlimit_as_account)
         }
 #endif
         page_set_flags(start, start + len, 0);
-#ifdef TARGET_X86_64
+#ifdef TARGET_I386
         guest_vma_name_reset(start, len);
 #endif
     }
@@ -1276,6 +1277,10 @@ abi_long target_mremap(abi_ulong old_addr, abi_ulong old_size,
     bool keep_old;
     bool manual_move = false;
     bool can_manual_move = true;
+#if defined(CONFIG_LATX) && defined(TARGET_I386)
+    abi_ulong addr;
+    bool shared_mapping = false;
+#endif
     bool unreserved_extension = false;
     int prot;
     void *host_addr;
@@ -1320,6 +1325,10 @@ abi_long target_mremap(abi_ulong old_addr, abi_ulong old_size,
         errno = EINVAL;
         return -1;
     }
+    if ((flags & MREMAP_FIXED) && (new_addr & ~TARGET_PAGE_MASK)) {
+        errno = EINVAL;
+        return -1;
+    }
 
     keep_old = !old_size || (flags & MREMAP_DONTUNMAP);
     source_size = old_size ? old_size : new_size;
@@ -1357,6 +1366,45 @@ abi_long target_mremap(abi_ulong old_addr, abi_ulong old_size,
     mmap_lock();
 
     prot = page_get_flags(old_addr);
+#if defined(CONFIG_LATX) && defined(TARGET_I386)
+    for (addr = old_addr; addr < old_addr + source_size;
+         addr += TARGET_PAGE_SIZE) {
+        int page_prot = page_get_flags(addr);
+
+        if (page_get_target_data(addr)) {
+            errno = EFAULT;
+            host_addr = MAP_FAILED;
+            goto mremap_done;
+        }
+        if (page_prot & PAGE_MEMSHARE) {
+            shared_mapping = true;
+        }
+    }
+    if (shared_mapping) {
+        for (addr = old_addr; addr < old_addr + source_size;
+             addr += TARGET_PAGE_SIZE) {
+            int page_prot = page_get_flags(addr);
+
+            if ((page_prot & (PAGE_VALID | PAGE_MEMSHARE)) !=
+                    (PAGE_VALID | PAGE_MEMSHARE) ||
+                ((page_prot ^ prot) &
+                 (PAGE_BITS | PAGE_WRITE_ORG | PAGE_ANON))) {
+                errno = EFAULT;
+                host_addr = MAP_FAILED;
+                goto mremap_done;
+            }
+        }
+        if ((old_addr & ~qemu_host_page_mask) ||
+            (source_size & ~qemu_host_page_mask) ||
+            (new_size & ~qemu_host_page_mask) ||
+            ((flags & MREMAP_FIXED) &&
+             (new_addr & ~qemu_host_page_mask))) {
+            errno = EFAULT;
+            host_addr = MAP_FAILED;
+            goto mremap_done;
+        }
+    }
+#endif
     if ((prot & (PAGE_VALID | PAGE_ANON)) != (PAGE_VALID | PAGE_ANON) ||
         (prot & PAGE_MEMSHARE)) {
         can_manual_move = false;
@@ -1534,6 +1582,9 @@ abi_long target_mremap(abi_ulong old_addr, abi_ulong old_size,
         }
     }
 
+#if defined(CONFIG_LATX) && defined(TARGET_I386)
+mremap_done:
+#endif
     if (host_addr != MAP_FAILED && manual_move &&
         mmap_unmap_host_range(old_addr, old_size) != 0) {
         int move_errno = errno;
@@ -1552,7 +1603,7 @@ abi_long target_mremap(abi_ulong old_addr, abi_ulong old_size,
         new_addr = -1;
     } else {
         new_addr = h2g(host_addr);
-#ifdef TARGET_X86_64
+#ifdef TARGET_I386
         guest_vma_name_remap(old_addr, source_size, new_addr, new_size,
                              keep_old);
 #endif

--- a/linux-user/qemu.h
+++ b/linux-user/qemu.h
@@ -70,8 +70,8 @@ struct image_info {
         uint32_t        note_flags;
 
 #ifdef TARGET_X86_64
-        /* Linux 6.14 x86_64 has 50 native words in mm->saved_auxv. */
-#define TARGET_X86_64_PRCTL_AUXV_WORDS 50
+        /* Current Linux x86_64 has 54 native words in mm->saved_auxv. */
+#define TARGET_X86_64_PRCTL_AUXV_WORDS 54
         abi_ulong       prctl_auxv[TARGET_X86_64_PRCTL_AUXV_WORDS];
         bool            prctl_auxv_initialized;
         unsigned int    prctl_mdwe;
@@ -87,7 +87,6 @@ struct image_info {
         abi_ulong       prctl_mm_env_start;
         abi_ulong       prctl_mm_env_end;
         int             prctl_mm_exe_fd;
-        char            *prctl_mm_exe_path;
 #endif
 
 #ifdef TARGET_MIPS
@@ -105,7 +104,8 @@ struct image_info {
 /* Called with the linux-user mmap lock held. */
 void guest_vma_name_reset(abi_ulong start, abi_ulong len);
 void guest_vma_name_remap(abi_ulong old_start, abi_ulong old_len,
-                          abi_ulong new_start, abi_ulong new_len);
+                          abi_ulong new_start, abi_ulong new_len,
+                          bool keep_old);
 #endif
 extern struct image_info info1, *info;
 
@@ -228,6 +228,7 @@ typedef struct TaskState {
     abi_ulong sys_dispatch;
     abi_ulong sys_dispatch_selector;
     abi_ulong sys_dispatch_len;
+    bool sys_dispatch_inclusive;
     void* ptrace_poke_page;
 } __attribute__((aligned(16))) TaskState;
 

--- a/linux-user/qemu.h
+++ b/linux-user/qemu.h
@@ -101,6 +101,11 @@ struct image_info {
 #define LATX_GUEST_TSC_ENV  "_LATX_GUEST_TSC"
 #define TARGET_PR_MDWE_REFUSE_EXEC_GAIN 1U
 #define TARGET_PR_MDWE_NO_INHERIT      2U
+
+/* Called with the linux-user mmap lock held. */
+void guest_vma_name_reset(abi_ulong start, abi_ulong len);
+void guest_vma_name_remap(abi_ulong old_start, abi_ulong old_len,
+                          abi_ulong new_start, abi_ulong new_len);
 #endif
 extern struct image_info info1, *info;
 

--- a/linux-user/qemu.h
+++ b/linux-user/qemu.h
@@ -69,11 +69,39 @@ struct image_info {
         /* For target-specific processing of NT_GNU_PROPERTY_TYPE_0. */
         uint32_t        note_flags;
 
+#ifdef TARGET_X86_64
+        /* Linux 6.14 x86_64 has 50 native words in mm->saved_auxv. */
+#define TARGET_X86_64_PRCTL_AUXV_WORDS 50
+        abi_ulong       prctl_auxv[TARGET_X86_64_PRCTL_AUXV_WORDS];
+        bool            prctl_auxv_initialized;
+        unsigned int    prctl_mdwe;
+        abi_ulong       prctl_mm_start_code;
+        abi_ulong       prctl_mm_end_code;
+        abi_ulong       prctl_mm_start_data;
+        abi_ulong       prctl_mm_end_data;
+        abi_ulong       prctl_mm_start_brk;
+        abi_ulong       prctl_mm_brk;
+        abi_ulong       prctl_mm_start_stack;
+        abi_ulong       prctl_mm_arg_start;
+        abi_ulong       prctl_mm_arg_end;
+        abi_ulong       prctl_mm_env_start;
+        abi_ulong       prctl_mm_env_end;
+        int             prctl_mm_exe_fd;
+        char            *prctl_mm_exe_path;
+#endif
+
 #ifdef TARGET_MIPS
         int             fp_abi;
         int             interp_fp_abi;
 #endif
 };
+
+#ifdef TARGET_X86_64
+#define LATX_GUEST_MDWE_ENV "_LATX_GUEST_MDWE"
+#define LATX_GUEST_TSC_ENV  "_LATX_GUEST_TSC"
+#define TARGET_PR_MDWE_REFUSE_EXEC_GAIN 1U
+#define TARGET_PR_MDWE_NO_INHERIT      2U
+#endif
 extern struct image_info info1, *info;
 
 #if defined(CONFIG_LATX) && defined(TARGET_I386)
@@ -191,6 +219,10 @@ typedef struct TaskState {
 
     /* This thread's sigaltstack, if it has one */
     struct target_sigaltstack sigaltstack_used;
+    /* This thread's syscall user dispatch state; ~0 means disabled. */
+    abi_ulong sys_dispatch;
+    abi_ulong sys_dispatch_selector;
+    abi_ulong sys_dispatch_len;
     void* ptrace_poke_page;
 } __attribute__((aligned(16))) TaskState;
 

--- a/linux-user/qemu.h
+++ b/linux-user/qemu.h
@@ -75,6 +75,9 @@ struct image_info {
         abi_ulong       prctl_auxv[TARGET_X86_64_PRCTL_AUXV_WORDS];
         bool            prctl_auxv_initialized;
         unsigned int    prctl_mdwe;
+        unsigned int    prctl_futex_hash_slots;
+        bool            prctl_futex_hash_custom;
+        bool            prctl_timer_restore_ids;
         abi_ulong       prctl_mm_start_code;
         abi_ulong       prctl_mm_end_code;
         abi_ulong       prctl_mm_start_data;

--- a/linux-user/qemu.h
+++ b/linux-user/qemu.h
@@ -69,10 +69,12 @@ struct image_info {
         /* For target-specific processing of NT_GNU_PROPERTY_TYPE_0. */
         uint32_t        note_flags;
 
-#ifdef TARGET_X86_64
-        /* Current Linux x86_64 has 54 native words in mm->saved_auxv. */
-#define TARGET_X86_64_PRCTL_AUXV_WORDS 54
-        abi_ulong       prctl_auxv[TARGET_X86_64_PRCTL_AUXV_WORDS];
+#ifdef TARGET_I386
+        /* Native x86_64 kernels reserve 54 words in mm->saved_auxv. */
+#define TARGET_X86_PRCTL_AUXV_WORDS 54
+#define TARGET_X86_PRCTL_AUXV_SIZE \
+        (TARGET_X86_PRCTL_AUXV_WORDS * sizeof(uint64_t))
+        uint8_t         prctl_auxv[TARGET_X86_PRCTL_AUXV_SIZE];
         bool            prctl_auxv_initialized;
         unsigned int    prctl_mdwe;
         unsigned int    prctl_futex_hash_slots;
@@ -98,7 +100,7 @@ struct image_info {
 #endif
 };
 
-#ifdef TARGET_X86_64
+#ifdef TARGET_I386
 #define LATX_GUEST_MDWE_ENV "_LATX_GUEST_MDWE"
 #define LATX_GUEST_TSC_ENV  "_LATX_GUEST_TSC"
 #define TARGET_PR_MDWE_REFUSE_EXEC_GAIN 1U
@@ -227,11 +229,13 @@ typedef struct TaskState {
 
     /* This thread's sigaltstack, if it has one */
     struct target_sigaltstack sigaltstack_used;
+#ifdef TARGET_I386
     /* This thread's syscall user dispatch state; ~0 means disabled. */
     abi_ulong sys_dispatch;
     abi_ulong sys_dispatch_selector;
     abi_ulong sys_dispatch_len;
     bool sys_dispatch_inclusive;
+#endif
     void* ptrace_poke_page;
 } __attribute__((aligned(16))) TaskState;
 

--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -24,6 +24,7 @@
 #include "qemu/memfd.h"
 #include "qemu/queue.h"
 #include "qemu/rcu.h"
+#include "qemu-common.h"
 #include <elf.h>
 #include <endian.h>
 #include <grp.h>
@@ -9823,13 +9824,6 @@ static int do_fork(CPUArchState *env, unsigned int flags, abi_ulong newsp,
             if (flags & CLONE_CHILD_SETTID)
                 put_user_u32(sys_gettid(), child_tidptr);
             ts = (TaskState *)cpu->opaque;
-#ifdef TARGET_X86_64
-            mmap_lock();
-            if (ts->info->prctl_mdwe & TARGET_PR_MDWE_NO_INHERIT) {
-                ts->info->prctl_mdwe = 0;
-            }
-            mmap_unlock();
-#endif
             /* Linux clears syscall user dispatch in every fork child. */
             ts->sys_dispatch = 0;
             ts->sys_dispatch_selector = 0;
@@ -11281,7 +11275,7 @@ static int write_guest_proc_range(int fd, abi_ulong start, abi_ulong end)
         if (!ptr) {
             return -1;
         }
-        written = write(fd, ptr, len);
+        written = qemu_write_full(fd, ptr, len);
         unlock_user(ptr, start, 0);
         if (written != len) {
             return -1;
@@ -12233,6 +12227,7 @@ static int open_self_stat(void *cpu_env, int fd, const char *oldpath)
     g_autoptr(GString) buf = g_string_new(NULL);
     int i = 0;
     FILE *fp;
+    char *line = NULL;
     char *orig = NULL;
     char *word = NULL;
     size_t orig_len = 0;
@@ -12266,10 +12261,19 @@ static int open_self_stat(void *cpu_env, int fd, const char *oldpath)
 #endif
 
     fp = fopen("/proc/self/stat", "r");
-    if (fp == NULL || getline(&orig, &orig_len, fp) == -1)
+    if (fp == NULL) {
         return -1;
+    }
+    if (getline(&line, &orig_len, fp) == -1) {
+        int saved_errno = errno;
 
-    word = orig;
+        fclose(fp);
+        g_free(line);
+        errno = saved_errno;
+        return -1;
+    }
+
+    word = line;
 
     do {
         orig = word;
@@ -12279,8 +12283,9 @@ static int open_self_stat(void *cpu_env, int fd, const char *oldpath)
         if (NULL == word) {
             /* Find a pointer to '\0' */
             word = strchr(orig, '\0');
-            if (NULL == word)
-                return -1;
+            if (NULL == word) {
+                goto fail;
+            }
             /* \0 not needed */
             word --;
             /* Don't enter the loop next time */
@@ -12337,19 +12342,28 @@ static int open_self_stat(void *cpu_env, int fd, const char *oldpath)
                             ts->info->start_stack);
 #endif
         } else {
-            if (write(fd, orig, word_len) != word_len)
-                return -1;
+            if (qemu_write_full(fd, orig, word_len) != word_len) {
+                goto fail;
+            }
             continue;
         }
 
-        if (write(fd, buf->str, buf->len) != buf->len) {
-            return -1;
+        if (qemu_write_full(fd, buf->str, buf->len) != buf->len) {
+            goto fail;
         }
 
     } while(++i);
 
     fclose(fp);
+    g_free(line);
     return 0;
+
+fail:
+    i = errno;
+    fclose(fp);
+    g_free(line);
+    errno = i;
+    return -1;
 }
 
 static int open_self_auxv(void *cpu_env, int fd, const char *oldpath)
@@ -12358,7 +12372,6 @@ static int open_self_auxv(void *cpu_env, int fd, const char *oldpath)
     TaskState *ts = cpu->opaque;
 #ifdef TARGET_X86_64
     abi_ulong auxv[TARGET_X86_64_PRCTL_AUXV_WORDS];
-    const char *ptr = (const char *)auxv;
     size_t words;
     size_t len;
 
@@ -12371,15 +12384,8 @@ static int open_self_auxv(void *cpu_env, int fd, const char *oldpath)
         }
     }
     len = MIN(words + 2, ARRAY_SIZE(auxv)) * sizeof(auxv[0]);
-
-    while (len > 0) {
-        ssize_t written = write(fd, ptr, len);
-
-        if (written <= 0) {
-            break;
-        }
-        len -= written;
-        ptr += written;
+    if (qemu_write_full(fd, auxv, len) != len) {
+        return -1;
     }
     lseek(fd, 0, SEEK_SET);
 #else
@@ -12393,17 +12399,12 @@ static int open_self_auxv(void *cpu_env, int fd, const char *oldpath)
      */
     ptr = lock_user(VERIFY_READ, auxv, len, 0);
     if (ptr != NULL) {
-        while (len > 0) {
-            ssize_t r;
-            r = write(fd, ptr, len);
-            if (r <= 0) {
-                break;
-            }
-            len -= r;
-            ptr += r;
+        if (qemu_write_full(fd, ptr, len) != len) {
+            unlock_user(ptr, auxv, 0);
+            return -1;
         }
         lseek(fd, 0, SEEK_SET);
-        unlock_user(ptr, auxv, len);
+        unlock_user(ptr, auxv, 0);
     }
 #endif
 
@@ -12795,6 +12796,7 @@ static int do_openat(void *cpu_env, int dirfd, const char *pathname, int flags, 
         if ((r = fake_open->fill(cpu_env, fd, pathname))) {
             int e = errno;
             close(fd);
+            unlink(filename);
             errno = e;
             return r;
         }
@@ -12829,9 +12831,11 @@ static int real_proc_self_fd(int ofd)
 
     /* get filename */
     snprintf(buf_in, sizeof(buf_in), "/proc/self/fd/%d", ofd);
-    if (readlink(buf_in, buf_out, MAX_PATH_SIZE) < 0) {
+    len = readlink(buf_in, buf_out, sizeof(buf_out) - 1);
+    if (len < 0) {
         return fd;
     }
+    buf_out[len] = 0;
 
     /*is /proc/myself */
     tmpdir = getenv("TMPDIR");
@@ -12975,15 +12979,24 @@ static bool is_x86_elf_fd(int fd)
     return (ehdr.e_machine == EM_386) || (ehdr.e_machine == EM_X86_64);
 }
 
+static int open_exec_inspection_file(int dirfd, const char *file_name,
+                                     int flags)
+{
+    char fd_path[64];
+
+    if (!file_name[0] && (flags & AT_EMPTY_PATH)) {
+        snprintf(fd_path, sizeof(fd_path), "/proc/self/fd/%d", dirfd);
+        return open(fd_path, O_RDONLY | O_CLOEXEC);
+    }
+    return openat(dirfd, file_name, O_RDONLY | O_CLOEXEC);
+}
+
 static bool is_x86_file_at(int dirfd, const char *file_name, int flags)
 {
     int fd;
     bool ret;
 
-    if (!file_name[0] && (flags & AT_EMPTY_PATH)) {
-        return is_x86_elf_fd(dirfd);
-    }
-    fd = openat(dirfd, path(file_name), O_RDONLY | O_CLOEXEC);
+    fd = open_exec_inspection_file(dirfd, file_name, flags);
     if (fd < 0) {
         return false;
     }
@@ -12996,23 +13009,108 @@ static bool is_x86_file_at(int dirfd, const char *file_name, int flags)
 static bool is_self_file_at(int dirfd, const char *file_name, int flags)
 {
     struct stat target_st, self_st;
-    int fd = -1;
+    int fd;
+    bool owned = false;
     bool ret;
 
     if (!file_name[0] && (flags & AT_EMPTY_PATH)) {
         fd = dirfd;
     } else {
-        fd = openat(dirfd, path(file_name), O_PATH | O_CLOEXEC);
+        fd = openat(dirfd, file_name, O_PATH | O_CLOEXEC);
         if (fd < 0) {
             return false;
         }
+        owned = true;
     }
     ret = fstat(fd, &target_st) == 0 &&
           stat("/proc/self/exe", &self_st) == 0 &&
           target_st.st_dev == self_st.st_dev &&
           target_st.st_ino == self_st.st_ino;
-    if (fd != dirfd) {
+    if (owned) {
         close(fd);
+    }
+    return ret;
+}
+
+static bool exec_file_restores_guest_state_at(int dirfd,
+                                               const char *file_name,
+                                               int flags, unsigned int depth)
+{
+    char header[256];
+    char interpreter[PATH_MAX];
+    ssize_t len;
+    size_t start, end;
+    int fd;
+
+    if (depth > 4 || is_self_file_at(dirfd, file_name, flags)) {
+        return depth <= 4;
+    }
+    fd = open_exec_inspection_file(dirfd, file_name, flags);
+    if (fd < 0) {
+        return false;
+    }
+    if (is_x86_elf_fd(fd)) {
+        close(fd);
+        return true;
+    }
+    len = pread(fd, header, sizeof(header), 0);
+    close(fd);
+    if (len < 2 || header[0] != '#' || header[1] != '!') {
+        return false;
+    }
+
+    start = 2;
+    while (start < len && (header[start] == ' ' || header[start] == '\t')) {
+        start++;
+    }
+    end = start;
+    while (end < len && header[end] != ' ' && header[end] != '\t' &&
+           header[end] != '\n' && header[end] != '\r') {
+        end++;
+    }
+    if (end == start || end - start >= sizeof(interpreter)) {
+        return false;
+    }
+    memcpy(interpreter, header + start, end - start);
+    interpreter[end - start] = 0;
+    return exec_file_restores_guest_state_at(AT_FDCWD, interpreter, 0,
+                                              depth + 1);
+}
+
+static bool guest_self_exe_restores_guest_state(CPUArchState *env)
+{
+    char path_buffer[64];
+    const char *exe_pathname;
+    bool ret;
+    int owned_fd;
+
+    exe_pathname = guest_self_exe_open_path(env, path_buffer,
+                                            sizeof(path_buffer), &owned_fd);
+    if (!exe_pathname) {
+        return false;
+    }
+    ret = exec_file_restores_guest_state_at(AT_FDCWD, exe_pathname, 0, 0);
+    if (owned_fd >= 0) {
+        close(owned_fd);
+    }
+    return ret;
+}
+
+static bool guest_self_exe_is_x86(CPUArchState *env)
+{
+    char path_buffer[64];
+    const char *exe_pathname;
+    bool ret;
+    int owned_fd;
+
+    exe_pathname = guest_self_exe_open_path(env, path_buffer,
+                                            sizeof(path_buffer), &owned_fd);
+    if (!exe_pathname) {
+        return false;
+    }
+    ret = is_x86_file_at(AT_FDCWD, exe_pathname, 0);
+    if (owned_fd >= 0) {
+        close(owned_fd);
     }
     return ret;
 }
@@ -13267,8 +13365,13 @@ static abi_long guest_prctl_prepare_exe_file(unsigned int fd,
     if (fstat(fd, &st) < 0) {
         return get_errno(-1);
     }
-    if (!S_ISREG(st.st_mode) ||
-        (fstatvfs(fd, &fs) == 0 && (fs.f_flag & ST_NOEXEC))) {
+    if (!S_ISREG(st.st_mode)) {
+        return -TARGET_EACCES;
+    }
+    if (fstatvfs(fd, &fs) < 0) {
+        return get_errno(-1);
+    }
+    if (fs.f_flag & ST_NOEXEC) {
         return -TARGET_EACCES;
     }
     if (faccessat(fd, "", X_OK, AT_EMPTY_PATH | AT_EACCESS) < 0) {
@@ -14009,6 +14112,9 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
     case TARGET_NR_execveat:
         {
             char **argp, **envp, **exec_envp = NULL;
+            char **exec_argp = NULL;
+            char *hash_str = NULL;
+            char *pidof_arg = NULL;
 #ifdef TARGET_X86_64
             char *prctl_mdwe_env = NULL;
             char *prctl_tsc_env = NULL;
@@ -14019,6 +14125,8 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
             abi_ulong guest_envp;
             abi_ulong addr;
             char **q;
+
+            p = NULL;
             argc = 0;
             guest_argp = arg3;
             for (gp = guest_argp; gp; gp += sizeof(abi_ulong)) {
@@ -14081,26 +14189,35 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
             }
 
             char *pname = strrchr(p, '/');
+            const char *exec_pathname = path(p);
             bool self_exe = is_proc_myself((const char *)p, "exe");
-            bool x86_file = self_exe || is_x86_file_at(arg1, p, arg5);
 #ifdef TARGET_X86_64
-            bool restore_prctl = x86_file ||
-                                 is_self_file_at(arg1, p, arg5);
+            bool x86_file = self_exe ? guest_self_exe_is_x86(env) :
+                            is_x86_file_at(arg1, exec_pathname, arg5);
+            bool restore_prctl = self_exe ?
+                guest_self_exe_restores_guest_state(env) :
+                exec_file_restores_guest_state_at(arg1, exec_pathname,
+                                                  arg5, 0);
 
             exec_envp = prepare_guest_prctl_exec_env(env, envp, envc,
                                                      restore_prctl,
                                                      &prctl_mdwe_env,
                                                      &prctl_tsc_env);
 #else
+            bool x86_file = self_exe ||
+                            is_x86_file_at(arg1, exec_pathname, arg5);
+
             exec_envp = envp;
 #endif
+            exec_argp = argp;
             if (argp[0] && p && pname && strcmp(p, argp[0]) &&
                     strcmp(pname + 1, argp[0]) && x86_file) {
-                argc = argc + 3;
-                char **new_argp = g_new0(char *, argc + 1);
+                int exec_argc = argc + 3;
+                char **new_argp = g_new0(char *, exec_argc + 1);
                 long long hash = 0;
-                char *hash_str = g_new0(char, 8 * sizeof(long long));
-                for (int i = 3; i < argc; ++i) {
+
+                hash_str = g_new0(char, 8 * sizeof(long long));
+                for (int i = 3; i < exec_argc; ++i) {
                     new_argp[i] = argp[i - 3];
                     for (int j = 0; argp[i - 3][j] != '\0'; ++j) {
                         hash += argp[i - 3][j];
@@ -14109,28 +14226,34 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
                 sprintf(hash_str, "%lld", hash);
                 new_argp[0] = new_argp[1] = p;
                 new_argp[2] = hash_str;
-                new_argp[argc] = NULL;
-                g_free(argp);
-                argp = new_argp;
+                new_argp[exec_argc] = NULL;
+                exec_argp = new_argp;
             }
 
             if (!x86_file) {
                 for (int i = 0; i < argc; ++i) {
-                    char *found = strstr(argp[i], "pidof");
+                    char *found = strstr(exec_argp[i], "pidof");
                     if (found != NULL) {
                         size_t old_sub_len = strlen("pidof");
                         size_t new_sub_len = strlen("pidof -x");
-                        size_t prefix_len = found - argp[i];
+                        size_t prefix_len = found - exec_argp[i];
                         size_t suffix_len = strlen(found + old_sub_len);
 
                         /* Allocate new string: prefix + "pidof -x" + suffix */
-                        char *new_arg = g_malloc(prefix_len + new_sub_len + suffix_len + 1);
+                        if (exec_argp == argp) {
+                            exec_argp = g_new(char *, argc + 1);
+                            memcpy(exec_argp, argp,
+                                   sizeof(*argp) * (argc + 1));
+                        }
+                        pidof_arg = g_malloc(prefix_len + new_sub_len +
+                                             suffix_len + 1);
 
                         /* Build the new string */
-                        strncpy(new_arg, argp[i], prefix_len);
-                        strcpy(new_arg + prefix_len, "pidof -x");
-                        strcpy(new_arg + prefix_len + new_sub_len, found + strlen("pidof"));
-                        argp[i] = new_arg;
+                        memcpy(pidof_arg, exec_argp[i], prefix_len);
+                        strcpy(pidof_arg + prefix_len, "pidof -x");
+                        strcpy(pidof_arg + prefix_len + new_sub_len,
+                               found + old_sub_len);
+                        exec_argp[i] = pidof_arg;
                         break;
                     }
                 }
@@ -14159,16 +14282,15 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
                     ret = get_errno(-1);
                 } else {
                     ret = get_errno(safe_execveat(AT_FDCWD, exe_pathname,
-                                                  argp, exec_envp, arg5));
+                                                  exec_argp, exec_envp, arg5));
                     if (exe_fd >= 0) {
                         close(exe_fd);
                     }
                 }
             } else {
-                ret = get_errno(safe_execveat(arg1, p, argp, exec_envp,
-                                              arg5));
+                ret = get_errno(safe_execveat(arg1, exec_pathname, exec_argp,
+                                              exec_envp, arg5));
             }
-            unlock_user(p, arg2, 0);
 
             goto execveat_end;
 
@@ -14176,6 +14298,7 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
             ret = -TARGET_EFAULT;
 
         execveat_end:
+            unlock_user(p, arg2, 0);
             for (gp = guest_argp, q = argp; *q;
                   gp += sizeof(abi_ulong), q++) {
                 if (get_user_ual(addr, gp)
@@ -14193,6 +14316,11 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
                 unlock_user(*q, addr, 0);
             }
 
+            if (exec_argp != argp) {
+                g_free(exec_argp);
+            }
+            g_free(pidof_arg);
+            g_free(hash_str);
             g_free(argp);
 #ifdef TARGET_X86_64
             g_free(prctl_mdwe_env);
@@ -14208,6 +14336,9 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
     case TARGET_NR_execve:
         {
             char **argp, **envp, **exec_envp = NULL;
+            char **exec_argp = NULL;
+            char *hash_str = NULL;
+            char *pidof_arg = NULL;
 #ifdef TARGET_X86_64
             char *prctl_mdwe_env = NULL;
             char *prctl_tsc_env = NULL;
@@ -14218,6 +14349,8 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
             abi_ulong guest_envp;
             abi_ulong addr;
             char **q;
+
+            p = NULL;
             argc = 0;
             guest_argp = arg2;
             for (gp = guest_argp; gp; gp += sizeof(abi_ulong)) {
@@ -14269,26 +14402,32 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
 
             char *pname = strrchr(p, '/');
             bool self_exe = is_proc_myself((const char *)p, "exe");
-            bool x86_file = self_exe ||
-                            is_x86_file_at(AT_FDCWD, p, 0);
 #ifdef TARGET_X86_64
-            bool restore_prctl = x86_file ||
-                                 is_self_file_at(AT_FDCWD, p, 0);
+            bool x86_file = self_exe ? guest_self_exe_is_x86(env) :
+                            is_x86_file_at(AT_FDCWD, path(p), 0);
+            bool restore_prctl = self_exe ?
+                guest_self_exe_restores_guest_state(env) :
+                exec_file_restores_guest_state_at(AT_FDCWD, path(p), 0, 0);
 
             exec_envp = prepare_guest_prctl_exec_env(env, envp, envc,
                                                      restore_prctl,
                                                      &prctl_mdwe_env,
                                                      &prctl_tsc_env);
 #else
+            bool x86_file = self_exe ||
+                            is_x86_file_at(AT_FDCWD, path(p), 0);
+
             exec_envp = envp;
 #endif
+            exec_argp = argp;
             if (argp[0] && p && pname && strcmp(p, argp[0]) &&
                     strcmp(pname + 1, argp[0]) && x86_file) {
-                argc = argc + 3;
-                char **new_argp = g_new0(char *, argc + 1);
+                int exec_argc = argc + 3;
+                char **new_argp = g_new0(char *, exec_argc + 1);
                 long long hash = 0;
-                char *hash_str = g_new0(char, 8 * sizeof(long long));
-                for (int i = 3; i < argc; ++i) {
+
+                hash_str = g_new0(char, 8 * sizeof(long long));
+                for (int i = 3; i < exec_argc; ++i) {
                     new_argp[i] = argp[i - 3];
                     for (int j = 0; argp[i - 3][j] != '\0'; ++j) {
                         hash += argp[i - 3][j];
@@ -14297,28 +14436,34 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
                 sprintf(hash_str, "%lld", hash);
                 new_argp[0] = new_argp[1] = p;
                 new_argp[2] = hash_str;
-                new_argp[argc] = NULL;
-                g_free(argp);
-                argp = new_argp;
+                new_argp[exec_argc] = NULL;
+                exec_argp = new_argp;
             }
 
             if (!x86_file) {
                 for (int i = 0; i < argc; ++i) {
-                    char *found = strstr(argp[i], "pidof");
+                    char *found = strstr(exec_argp[i], "pidof");
                     if (found != NULL) {
                         size_t old_sub_len = strlen("pidof");
                         size_t new_sub_len = strlen("pidof -x");
-                        size_t prefix_len = found - argp[i];
+                        size_t prefix_len = found - exec_argp[i];
                         size_t suffix_len = strlen(found + old_sub_len);
 
                         /* Allocate new string: prefix + "pidof -x" + suffix */
-                        char *new_arg = g_malloc(prefix_len + new_sub_len + suffix_len + 1);
+                        if (exec_argp == argp) {
+                            exec_argp = g_new(char *, argc + 1);
+                            memcpy(exec_argp, argp,
+                                   sizeof(*argp) * (argc + 1));
+                        }
+                        pidof_arg = g_malloc(prefix_len + new_sub_len +
+                                             suffix_len + 1);
 
                         /* Build the new string */
-                        strncpy(new_arg, argp[i], prefix_len);
-                        strcpy(new_arg + prefix_len, "pidof -x");
-                        strcpy(new_arg + prefix_len + new_sub_len, found + strlen("pidof"));
-                        argp[i] = new_arg;
+                        memcpy(pidof_arg, exec_argp[i], prefix_len);
+                        strcpy(pidof_arg + prefix_len, "pidof -x");
+                        strcpy(pidof_arg + prefix_len + new_sub_len,
+                               found + old_sub_len);
+                        exec_argp[i] = pidof_arg;
                         break;
                     }
                 }
@@ -14341,10 +14486,17 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
                     }
                     goto execve_end;
                 }
-                if (!strcmp((const char *)*argp, "/proc/self/exe")) {
-                    *argp = (char *)temp;
+                if (exec_argp[0] &&
+                    !strcmp(exec_argp[0], "/proc/self/exe")) {
+                    if (exec_argp == argp) {
+                        exec_argp = g_new(char *, argc + 1);
+                        memcpy(exec_argp, argp,
+                               sizeof(*argp) * (argc + 1));
+                    }
+                    *exec_argp = (char *)temp;
                 }
-                ret = get_errno(safe_execve(exe_pathname, argp, exec_envp));
+                ret = get_errno(safe_execve(exe_pathname, exec_argp,
+                                            exec_envp));
                 if (exe_fd >= 0) {
                     close(exe_fd);
                 }
@@ -14360,9 +14512,8 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
                  * before the execve completes and makes it the other
                  * program's problem.
                  */
-                ret = get_errno(safe_execve(path(p), argp, exec_envp));
+                ret = get_errno(safe_execve(path(p), exec_argp, exec_envp));
             }
-            unlock_user(p, arg1, 0);
 
             goto execve_end;
 
@@ -14370,6 +14521,7 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
             ret = -TARGET_EFAULT;
 
         execve_end:
+            unlock_user(p, arg1, 0);
             for (gp = guest_argp, q = argp; *q;
                   gp += sizeof(abi_ulong), q++) {
                 if (get_user_ual(addr, gp)
@@ -14385,6 +14537,11 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
                 unlock_user(*q, addr, 0);
             }
 
+            if (exec_argp != argp) {
+                g_free(exec_argp);
+            }
+            g_free(pidof_arg);
+            g_free(hash_str);
             g_free(argp);
 #ifdef TARGET_X86_64
             g_free(prctl_mdwe_env);
@@ -15677,35 +15834,35 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
 #ifdef TARGET_NR_readlink
     case TARGET_NR_readlink:
         {
-            void *p2;
+            void *p2 = NULL;
+
             p = lock_user_string(arg1);
-            p2 = lock_user(VERIFY_WRITE, arg2, arg3, 0);
-            if (arg3 < 0) {
-                ret = -TARGET_EINVAL;
-            } else if (!p || !p2) {
+            if (!p) {
                 ret = -TARGET_EFAULT;
-            } else if (!arg3) {
-                /* Short circuit this for the magic exe check. */
+            } else if (arg3 <= 0) {
                 ret = -TARGET_EINVAL;
-            } else if (is_proc_myself((const char *)p, "exe")) {
-                char real[PATH_MAX];
-                const char *temp = guest_self_exe_link_path(cpu_env, real,
-                                                            sizeof(real));
-                /* Return value is # of bytes that we wrote to the buffer. */
-                if (temp == NULL) {
-                    ret = MIN(strlen(real_path), arg3);
-                    memcpy(p2, real_path, ret);
-                } else {
-                    /* Don't worry about sign mismatch as earlier mapping
-                     * logic would have thrown a bad address error. */
-                    ret = MIN(strlen(real), arg3);
-                    /* We cannot NUL terminate the string. */
-                    memcpy(p2, real, ret);
-                }
             } else {
-                ret = get_errno(readlink(path(p), p2, arg3));
+                p2 = lock_user(VERIFY_WRITE, arg2, arg3, 0);
+                if (!p2) {
+                    ret = -TARGET_EFAULT;
+                } else if (is_proc_myself((const char *)p, "exe")) {
+                    char real[PATH_MAX];
+                    const char *temp = guest_self_exe_link_path(
+                        cpu_env, real, sizeof(real));
+
+                    /* Return value is # of bytes written to the buffer. */
+                    if (temp == NULL) {
+                        ret = get_errno(-1);
+                    } else {
+                        ret = MIN(strlen(real), arg3);
+                        /* readlink does not NUL terminate the string. */
+                        memcpy(p2, real, ret);
+                    }
+                } else {
+                    ret = get_errno(readlink(path(p), p2, arg3));
+                }
             }
-            unlock_user(p2, arg2, ret);
+            unlock_user(p2, arg2, ret > 0 ? ret : 0);
             unlock_user(p, arg1, 0);
         }
         return ret;
@@ -15713,26 +15870,33 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
 #if defined(TARGET_NR_readlinkat)
     case TARGET_NR_readlinkat:
         {
-            void *p2;
-            p  = lock_user_string(arg2);
-            p2 = lock_user(VERIFY_WRITE, arg3, arg4, 0);
-            if (!p || !p2) {
-                ret = -TARGET_EFAULT;
-            } else if (is_proc_myself((const char *)p, "exe")) {
-                char real[PATH_MAX];
-                const char *temp = guest_self_exe_link_path(cpu_env, real,
-                                                            sizeof(real));
+            void *p2 = NULL;
 
-                if (temp == NULL) {
-                    ret = get_errno(-1);
-                } else {
-                    ret = MIN(strlen(temp), arg4);
-                    memcpy(p2, temp, ret);
-                }
+            p  = lock_user_string(arg2);
+            if (!p) {
+                ret = -TARGET_EFAULT;
+            } else if (arg4 <= 0) {
+                ret = -TARGET_EINVAL;
             } else {
-                ret = get_errno(readlinkat(arg1, path(p), p2, arg4));
+                p2 = lock_user(VERIFY_WRITE, arg3, arg4, 0);
+                if (!p2) {
+                    ret = -TARGET_EFAULT;
+                } else if (is_proc_myself((const char *)p, "exe")) {
+                    char real[PATH_MAX];
+                    const char *temp = guest_self_exe_link_path(
+                        cpu_env, real, sizeof(real));
+
+                    if (temp == NULL) {
+                        ret = get_errno(-1);
+                    } else {
+                        ret = MIN(strlen(temp), arg4);
+                        memcpy(p2, temp, ret);
+                    }
+                } else {
+                    ret = get_errno(readlinkat(arg1, path(p), p2, arg4));
+                }
             }
-            unlock_user(p2, arg3, ret);
+            unlock_user(p2, arg3, ret > 0 ? ret : 0);
             unlock_user(p, arg2, 0);
         }
         return ret;

--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -11560,17 +11560,23 @@ struct open_self_maps_data {
 # define test_stack(S, E, L)  (S == L)
 #endif
 
-static void open_self_maps_4(const struct open_self_maps_data *d,
-                             const MapInfo *mi, abi_ptr start,
-                             abi_ptr end, unsigned flags)
+static void open_self_maps_4_line(const struct open_self_maps_data *d,
+                                  const MapInfo *mi, abi_ptr start,
+                                  abi_ptr end, unsigned flags,
+                                  const char *vma_name)
 {
     const struct image_info *info = d->ts->info;
     const char *path = mi->path;
+    char named_path[96];
     uint64_t offset;
     int fd = d->fd;
     int count;
 
-    if (test_stack(start, end, info->stack_limit)) {
+    if (vma_name) {
+        snprintf(named_path, sizeof(named_path),
+                 mi->is_priv ? "[anon:%s]" : "[anon_shmem:%s]", vma_name);
+        path = named_path;
+    } else if (test_stack(start, end, info->stack_limit)) {
         path = "[stack]";
 #ifdef TARGET_X86_64
     } else if (start == info->prctl_mm_start_brk) {
@@ -11648,6 +11654,13 @@ static void open_self_maps_4(const struct open_self_maps_data *d,
                 (flags & PAGE_EXEC) ? " me" : "",
                 mi->is_priv ? "" : " ms");
     }
+}
+
+static void open_self_maps_4(const struct open_self_maps_data *d,
+                             const MapInfo *mi, abi_ptr start,
+                             abi_ptr end, unsigned flags)
+{
+    open_self_maps_4_line(d, mi, start, end, flags, NULL);
 }
 
 /*

--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -36,6 +36,7 @@
 #include <sys/personality.h>
 #include <sys/prctl.h>
 #include <sys/resource.h>
+#include <sys/statvfs.h>
 #include <sys/swap.h>
 #include <linux/capability.h>
 #include <sched.h>
@@ -258,6 +259,82 @@ out_marker:
 #include <linux/dma-buf.h>
 
 #include <sys/syscall.h>
+
+/* Generic prctl constants that may be absent from old host headers. */
+#ifndef PR_SET_IO_FLUSHER
+#define PR_SET_IO_FLUSHER 57
+#define PR_GET_IO_FLUSHER 58
+#endif
+#ifndef PR_SET_SYSCALL_USER_DISPATCH
+#define PR_SET_SYSCALL_USER_DISPATCH 59
+#define PR_SYS_DISPATCH_OFF 0
+#define PR_SYS_DISPATCH_ON 1
+#define SYSCALL_DISPATCH_FILTER_ALLOW 0
+#define SYSCALL_DISPATCH_FILTER_BLOCK 1
+#endif
+#ifndef PR_SCHED_CORE
+#define PR_SCHED_CORE 62
+#define PR_SCHED_CORE_GET 0
+#endif
+#ifndef PR_SET_MDWE
+#define PR_SET_MDWE 65
+#define PR_MDWE_REFUSE_EXEC_GAIN (1UL << 0)
+#define PR_MDWE_NO_INHERIT (1UL << 1)
+#define PR_GET_MDWE 66
+#endif
+#ifndef PR_GET_AUXV
+#define PR_GET_AUXV 0x41555856
+#endif
+#ifndef PR_SET_MM_MAP_SIZE
+#define PR_SET_MM_START_CODE 1
+#define PR_SET_MM_END_CODE 2
+#define PR_SET_MM_START_DATA 3
+#define PR_SET_MM_END_DATA 4
+#define PR_SET_MM_START_STACK 5
+#define PR_SET_MM_START_BRK 6
+#define PR_SET_MM_BRK 7
+#define PR_SET_MM_ARG_START 8
+#define PR_SET_MM_ARG_END 9
+#define PR_SET_MM_ENV_START 10
+#define PR_SET_MM_ENV_END 11
+#define PR_SET_MM_AUXV 12
+#define PR_SET_MM_EXE_FILE 13
+#define PR_SET_MM_MAP 14
+#define PR_SET_MM_MAP_SIZE 15
+#endif
+#ifndef PR_SET_VMA
+#define PR_SET_VMA 0x53564d41
+#define PR_SET_VMA_ANON_NAME 0
+#endif
+#ifndef PR_SET_MEMORY_MERGE
+#define PR_SET_MEMORY_MERGE 67
+#define PR_GET_MEMORY_MERGE 68
+#endif
+#ifndef PR_SPEC_DISABLE_NOEXEC
+#define PR_SPEC_STORE_BYPASS 0
+#define PR_SPEC_INDIRECT_BRANCH 1
+#define PR_SPEC_L1D_FLUSH 2
+#define PR_SPEC_NOT_AFFECTED 0
+#define PR_SPEC_PRCTL (1UL << 0)
+#define PR_SPEC_ENABLE (1UL << 1)
+#define PR_SPEC_DISABLE (1UL << 2)
+#define PR_SPEC_FORCE_DISABLE (1UL << 3)
+#define PR_SPEC_DISABLE_NOEXEC (1UL << 4)
+#endif
+#ifndef PR_RISCV_V_SET_CONTROL
+#define PR_RISCV_V_SET_CONTROL 69
+#define PR_RISCV_V_GET_CONTROL 70
+#define PR_RISCV_SET_ICACHE_FLUSH_CTX 71
+#endif
+#ifndef PR_PPC_GET_DEXCR
+#define PR_PPC_GET_DEXCR 72
+#define PR_PPC_SET_DEXCR 73
+#endif
+#ifndef PR_GET_SHADOW_STACK_STATUS
+#define PR_GET_SHADOW_STACK_STATUS 74
+#define PR_SET_SHADOW_STACK_STATUS 75
+#define PR_LOCK_SHADOW_STACK_STATUS 76
+#endif
 
 #ifdef CONFIG_LATX
 #define IMAGE_NT_SIGNATURE 0x00004550
@@ -1354,7 +1431,8 @@ abi_long do_brk(abi_ulong new_brk)
     if (new_brk <= brk_page) {
         /* Heap contents are initialized to zero, as for anonymous
          * mapped pages.  */
-        if (new_brk > target_brk) {
+        if (new_brk > target_brk &&
+            page_check_range(target_brk, new_brk - target_brk, PAGE_WRITE)) {
             memset(g2h_untagged(target_brk), 0, new_brk - target_brk);
         }
 	    target_brk = new_brk;
@@ -1381,7 +1459,10 @@ abi_long do_brk(abi_ulong new_brk)
          * come from the remaining part of the previous page: it may
          * contains garbage data due to a previous heap usage (grown
          * then shrunken).  */
-        memset(g2h_untagged(target_brk), 0, brk_page - target_brk);
+        if (brk_page > target_brk &&
+            page_check_range(target_brk, brk_page - target_brk, PAGE_WRITE)) {
+            memset(g2h_untagged(target_brk), 0, brk_page - target_brk);
+        }
 
         target_brk = new_brk;
         brk_page = HOST_PAGE_ALIGN(target_brk);
@@ -9720,6 +9801,15 @@ static int do_fork(CPUArchState *env, unsigned int flags, abi_ulong newsp,
             if (flags & CLONE_CHILD_SETTID)
                 put_user_u32(sys_gettid(), child_tidptr);
             ts = (TaskState *)cpu->opaque;
+#ifdef TARGET_X86_64
+            if (ts->info->prctl_mdwe & TARGET_PR_MDWE_NO_INHERIT) {
+                ts->info->prctl_mdwe = 0;
+            }
+#endif
+            /* Linux clears syscall user dispatch in every fork child. */
+            ts->sys_dispatch = 0;
+            ts->sys_dispatch_selector = 0;
+            ts->sys_dispatch_len = -1;
             if (flags & CLONE_NEWIPC) {
                 ts->ipc_namespace_isolated = true;
             }
@@ -11161,33 +11251,71 @@ static void regs_to_seccomp_trace(const struct target_pt_regs *regs,
 static int open_self_cmdline(void *cpu_env, int fd, const char *oldpath)
 {
     CPUState *cpu = env_cpu((CPUArchState *)cpu_env);
-    struct linux_binprm *bprm = ((TaskState *)cpu->opaque)->bprm;
+#ifdef TARGET_X86_64
     struct image_info *info = ((TaskState *)cpu->opaque)->info;
-    static bool setproctitle_called;
+    abi_ulong addr = info->prctl_mm_arg_start;
+    abi_ulong remaining = info->prctl_mm_arg_end - addr;
 
-    char argv_last_byte = *(char *)(unsigned long)(info->env_strings - 1);
-    if (argv_last_byte) {
-        setproctitle_called = true;
-    }
+    while (remaining) {
+        size_t len = MIN((abi_ulong)TARGET_PAGE_SIZE, remaining);
+        void *ptr = lock_user(VERIFY_READ, addr, len, 1);
+        ssize_t written;
 
-    if (setproctitle_called) {
-        size_t len = strlen((char *)(unsigned long)info->arg_strings) + 1;
-        if (write(fd, (char *)(unsigned long)info->arg_strings, len) != len) {
+        if (!ptr) {
             return -1;
         }
-    } else {
-        int i;
-        for (i = 0; i < bprm->argc; i++) {
-            size_t len = strlen(bprm->argv[i]) + 1;
+        written = write(fd, ptr, len);
+        unlock_user(ptr, addr, 0);
+        if (written != len) {
+            return -1;
+        }
+        addr += len;
+        remaining -= len;
+    }
+#else
+    struct linux_binprm *bprm = ((TaskState *)cpu->opaque)->bprm;
+    int i;
 
-            if (write(fd, bprm->argv[i], len) != len) {
-                return -1;
-            }
+    for (i = 0; i < bprm->argc; i++) {
+        size_t len = strlen(bprm->argv[i]) + 1;
+
+        if (write(fd, bprm->argv[i], len) != len) {
+            return -1;
         }
     }
-
+#endif
     return 0;
 }
+
+static const char *guest_self_exe_open_path(CPUArchState *env,
+                                            char *buffer, size_t size)
+{
+#ifdef TARGET_X86_64
+    TaskState *ts = env_cpu(env)->opaque;
+
+    if (ts->info->prctl_mm_exe_fd >= 0) {
+        snprintf(buffer, size, "/proc/self/fd/%d",
+                 ts->info->prctl_mm_exe_fd);
+        return buffer;
+    }
+#endif
+    return exec_path;
+}
+
+static const char *guest_self_exe_link_path(CPUArchState *env,
+                                            char *buffer, size_t size)
+{
+#ifdef TARGET_X86_64
+    TaskState *ts = env_cpu(env)->opaque;
+
+    if (ts->info->prctl_mm_exe_path) {
+        pstrcpy(buffer, size, ts->info->prctl_mm_exe_path);
+        return buffer;
+    }
+#endif
+    return realpath(exec_path, buffer);
+}
+
 static char * get_key_value_from_file(const char * key, char * real_path)
 {
     char buf[PATH_MAX];
@@ -11444,8 +11572,13 @@ static void open_self_maps_4(const struct open_self_maps_data *d,
 
     if (test_stack(start, end, info->stack_limit)) {
         path = "[stack]";
+#ifdef TARGET_X86_64
+    } else if (start == info->prctl_mm_start_brk) {
+        path = "[heap]";
+#else
     } else if (start == info->brk) {
         path = "[heap]";
+#endif
     } else if (start == info->vdso) {
         path = "[vdso]";
 #ifdef TARGET_X86_64
@@ -11776,9 +11909,44 @@ static int open_self_stat(void *cpu_env, int fd, const char *oldpath)
             /* Hide translator-only threads from the guest process view. */
             g_string_printf(buf, "%u ", latx_guest_thread_count());
 #endif
+#ifdef TARGET_X86_64
+        } else if (i == 25) {
+            g_string_printf(buf, TARGET_ABI_FMT_ld " ",
+                            ts->info->prctl_mm_start_code);
+        } else if (i == 26) {
+            g_string_printf(buf, TARGET_ABI_FMT_ld " ",
+                            ts->info->prctl_mm_end_code);
         } else if (i == 27) {
             /* stack bottom */
-            g_string_printf(buf, TARGET_ABI_FMT_ld " ", ts->info->start_stack);
+            g_string_printf(buf, TARGET_ABI_FMT_ld " ",
+                            ts->info->prctl_mm_start_stack);
+        } else if (i == 44) {
+            g_string_printf(buf, TARGET_ABI_FMT_ld " ",
+                            ts->info->prctl_mm_start_data);
+        } else if (i == 45) {
+            g_string_printf(buf, TARGET_ABI_FMT_ld " ",
+                            ts->info->prctl_mm_end_data);
+        } else if (i == 46) {
+            g_string_printf(buf, TARGET_ABI_FMT_ld " ",
+                            ts->info->prctl_mm_start_brk);
+        } else if (i == 47) {
+            g_string_printf(buf, TARGET_ABI_FMT_ld " ",
+                            ts->info->prctl_mm_arg_start);
+        } else if (i == 48) {
+            g_string_printf(buf, TARGET_ABI_FMT_ld " ",
+                            ts->info->prctl_mm_arg_end);
+        } else if (i == 49) {
+            g_string_printf(buf, TARGET_ABI_FMT_ld " ",
+                            ts->info->prctl_mm_env_start);
+        } else if (i == 50) {
+            g_string_printf(buf, TARGET_ABI_FMT_ld " ",
+                            ts->info->prctl_mm_env_end);
+#else
+        } else if (i == 27) {
+            /* stack bottom */
+            g_string_printf(buf, TARGET_ABI_FMT_ld " ",
+                            ts->info->start_stack);
+#endif
         } else {
             if (write(fd, orig, word_len) != word_len)
                 return -1;
@@ -11799,6 +11967,21 @@ static int open_self_auxv(void *cpu_env, int fd, const char *oldpath)
 {
     CPUState *cpu = env_cpu((CPUArchState *)cpu_env);
     TaskState *ts = cpu->opaque;
+#ifdef TARGET_X86_64
+    const char *ptr = (const char *)ts->info->prctl_auxv;
+    size_t len = sizeof(ts->info->prctl_auxv);
+
+    while (len > 0) {
+        ssize_t written = write(fd, ptr, len);
+
+        if (written <= 0) {
+            break;
+        }
+        len -= written;
+        ptr += written;
+    }
+    lseek(fd, 0, SEEK_SET);
+#else
     abi_ulong auxv = ts->info->saved_auxv;
     abi_ulong len = ts->info->auxv_len;
     char *ptr;
@@ -11821,6 +12004,7 @@ static int open_self_auxv(void *cpu_env, int fd, const char *oldpath)
         lseek(fd, 0, SEEK_SET);
         unlock_user(ptr, auxv, len);
     }
+#endif
 
     return 0;
 }
@@ -12155,7 +12339,13 @@ static int do_openat(void *cpu_env, int dirfd, const char *pathname, int flags, 
     };
 
     if (is_proc_myself(pathname, "exe")) {
-        return safe_openat(dirfd, exec_path, flags, mode);
+        char exe_path_buffer[64];
+        const char *exe_pathname;
+
+        exe_pathname = guest_self_exe_open_path(cpu_env, exe_path_buffer,
+                                                sizeof(exe_path_buffer));
+
+        return safe_openat(AT_FDCWD, exe_pathname, flags, mode);
     }
 
     for (fake_open = fakes; fake_open->filename; fake_open++) {
@@ -12377,6 +12567,629 @@ static bool is_x86_file(char *file_name)
 
     return (ehdr.e_machine == EM_386) || (ehdr.e_machine == EM_X86_64);
 }
+
+static abi_long do_prctl_syscall_user_dispatch(CPUArchState *env,
+                                               abi_ulong mode,
+                                               abi_ulong offset,
+                                               abi_ulong length,
+                                               abi_ulong selector)
+{
+    CPUState *cpu = env_cpu(env);
+    TaskState *ts = cpu->opaque;
+
+    switch (mode) {
+    case PR_SYS_DISPATCH_OFF:
+        if (offset || length || selector) {
+            return -TARGET_EINVAL;
+        }
+        ts->sys_dispatch_len = -1;
+        return 0;
+    case PR_SYS_DISPATCH_ON:
+        if (offset && offset + length <= offset) {
+            return -TARGET_EINVAL;
+        }
+        if (selector && !access_ok(cpu, VERIFY_READ, selector, 1)) {
+            return -TARGET_EFAULT;
+        }
+        ts->sys_dispatch = offset;
+        ts->sys_dispatch_len = length;
+        ts->sys_dispatch_selector = selector;
+        return 0;
+    default:
+        return -TARGET_EINVAL;
+    }
+}
+
+#ifdef TARGET_X86_64
+struct target_prctl_mm_map {
+    uint64_t start_code;
+    uint64_t end_code;
+    uint64_t start_data;
+    uint64_t end_data;
+    uint64_t start_brk;
+    uint64_t brk;
+    uint64_t start_stack;
+    uint64_t arg_start;
+    uint64_t arg_end;
+    uint64_t env_start;
+    uint64_t env_end;
+    uint64_t auxv;
+    uint32_t auxv_size;
+    uint32_t exe_fd;
+};
+
+struct guest_prctl_mm_map {
+    abi_ulong start_code;
+    abi_ulong end_code;
+    abi_ulong start_data;
+    abi_ulong end_data;
+    abi_ulong start_brk;
+    abi_ulong brk;
+    abi_ulong start_stack;
+    abi_ulong arg_start;
+    abi_ulong arg_end;
+    abi_ulong env_start;
+    abi_ulong env_end;
+};
+
+static abi_long do_prctl_get_auxv(CPUArchState *env, abi_ulong addr,
+                                  abi_ulong len)
+{
+    TaskState *ts = env_cpu(env)->opaque;
+    struct image_info *info = ts->info;
+    size_t size = MIN((size_t)len, sizeof(info->prctl_auxv));
+
+    if (!info->prctl_auxv_initialized) {
+        size_t initial_size = MIN((size_t)info->auxv_len,
+                                  sizeof(info->prctl_auxv));
+
+        memset(info->prctl_auxv, 0, sizeof(info->prctl_auxv));
+        if (initial_size && copy_from_user(info->prctl_auxv,
+                                           info->saved_auxv,
+                                           initial_size)) {
+            return -TARGET_EFAULT;
+        }
+        info->prctl_auxv_initialized = true;
+    }
+
+    if (size && copy_to_user(addr, info->prctl_auxv, size)) {
+        return -TARGET_EFAULT;
+    }
+    return sizeof(info->prctl_auxv);
+}
+
+static bool guest_has_capability(unsigned int capability)
+{
+    struct __user_cap_header_struct header = {
+        .version = _LINUX_CAPABILITY_VERSION_3,
+        .pid = 0,
+    };
+    struct __user_cap_data_struct data[2] = { };
+    unsigned int word = capability / 32;
+
+    return word < ARRAY_SIZE(data) && capget(&header, data) == 0 &&
+           (data[word].effective & (1U << (capability % 32)));
+}
+
+static abi_ulong guest_mmap_min_addr(void)
+{
+    FILE *fp = fopen("/proc/sys/vm/mmap_min_addr", "r");
+    unsigned long long value;
+
+    if (fp) {
+        if (fscanf(fp, "%llu", &value) == 1) {
+            fclose(fp);
+            return value;
+        }
+        fclose(fp);
+    }
+    return TARGET_PAGE_SIZE;
+}
+
+static void guest_prctl_mm_read(const struct image_info *info,
+                                struct guest_prctl_mm_map *map)
+{
+    *map = (struct guest_prctl_mm_map) {
+        .start_code = info->prctl_mm_start_code,
+        .end_code = info->prctl_mm_end_code,
+        .start_data = info->prctl_mm_start_data,
+        .end_data = info->prctl_mm_end_data,
+        .start_brk = info->prctl_mm_start_brk,
+        .brk = info->prctl_mm_brk,
+        .start_stack = info->prctl_mm_start_stack,
+        .arg_start = info->prctl_mm_arg_start,
+        .arg_end = info->prctl_mm_arg_end,
+        .env_start = info->prctl_mm_env_start,
+        .env_end = info->prctl_mm_env_end,
+    };
+}
+
+static void guest_prctl_mm_write(struct image_info *info,
+                                 const struct guest_prctl_mm_map *map)
+{
+    info->prctl_mm_start_code = info->start_code = map->start_code;
+    info->prctl_mm_end_code = info->end_code = map->end_code;
+    info->prctl_mm_start_data = info->start_data = map->start_data;
+    info->prctl_mm_end_data = info->end_data = map->end_data;
+    info->prctl_mm_start_brk = info->start_brk = map->start_brk;
+    info->prctl_mm_brk = info->brk = map->brk;
+    info->prctl_mm_start_stack = info->start_stack = map->start_stack;
+    info->prctl_mm_arg_start = map->arg_start;
+    info->prctl_mm_arg_end = map->arg_end;
+    info->prctl_mm_env_start = map->env_start;
+    info->prctl_mm_env_end = map->env_end;
+
+    target_original_brk = map->start_brk;
+    target_brk = map->brk;
+    brk_page = HOST_PAGE_ALIGN(target_brk);
+}
+
+static abi_long guest_prctl_mm_validate(const struct guest_prctl_mm_map *map)
+{
+    const abi_ulong value[] = {
+        map->start_code, map->end_code,
+        map->start_data, map->end_data,
+        map->start_brk, map->brk,
+        map->start_stack,
+        map->arg_start, map->arg_end,
+        map->env_start, map->env_end,
+    };
+    abi_ulong mmap_min = guest_mmap_min_addr();
+    struct rlimit rlim;
+    size_t i;
+
+    for (i = 0; i < ARRAY_SIZE(value); i++) {
+        if (value[i] < mmap_min || value[i] > GUEST_ADDR_MAX) {
+            return -TARGET_EINVAL;
+        }
+    }
+    if (map->start_code >= map->end_code ||
+        map->start_data > map->end_data ||
+        map->start_brk > map->brk ||
+        map->arg_start > map->arg_end ||
+        map->env_start > map->env_end) {
+        return -TARGET_EINVAL;
+    }
+
+    if (getrlimit(RLIMIT_DATA, &rlim) == 0 && rlim.rlim_cur != RLIM_INFINITY) {
+        uint64_t data_size = map->end_data - map->start_data;
+        uint64_t brk_size = map->brk - map->start_brk;
+
+        if (data_size > rlim.rlim_cur ||
+            brk_size > rlim.rlim_cur - data_size) {
+            return -TARGET_EINVAL;
+        }
+    }
+    return 0;
+}
+
+static abi_long guest_prctl_set_auxv(struct image_info *info,
+                                     abi_ulong addr, abi_ulong len,
+                                     bool replace_all)
+{
+    abi_ulong auxv[TARGET_X86_64_PRCTL_AUXV_WORDS] = { };
+
+    if (len > sizeof(auxv)) {
+        return -TARGET_EINVAL;
+    }
+    if (len && copy_from_user(auxv, addr, len)) {
+        return -TARGET_EFAULT;
+    }
+    auxv[ARRAY_SIZE(auxv) - 2] = 0;
+    auxv[ARRAY_SIZE(auxv) - 1] = 0;
+    if (replace_all) {
+        memcpy(info->prctl_auxv, auxv, sizeof(auxv));
+    } else {
+        memcpy(info->prctl_auxv, auxv, len);
+    }
+    return 0;
+}
+
+static abi_long guest_prctl_set_exe_file(struct image_info *info,
+                                         unsigned int fd)
+{
+    struct stat st;
+    struct statvfs fs;
+    char fd_path[64];
+    char path[PATH_MAX];
+    ssize_t path_len;
+    int saved_fd;
+
+    if (fstat(fd, &st) < 0) {
+        return get_errno(-1);
+    }
+    if (!S_ISREG(st.st_mode) ||
+        (fstatvfs(fd, &fs) == 0 && (fs.f_flag & ST_NOEXEC))) {
+        return -TARGET_EACCES;
+    }
+    if (faccessat(fd, "", X_OK, AT_EMPTY_PATH | AT_EACCESS) < 0) {
+        return get_errno(-1);
+    }
+
+    saved_fd = fcntl(fd, F_DUPFD_CLOEXEC, 0);
+    if (saved_fd < 0) {
+        return get_errno(-1);
+    }
+    snprintf(fd_path, sizeof(fd_path), "/proc/self/fd/%d", fd);
+    path_len = readlink(fd_path, path, sizeof(path) - 1);
+    if (path_len < 0) {
+        close(saved_fd);
+        return get_errno(-1);
+    }
+    path[path_len] = 0;
+
+    if (info->prctl_mm_exe_fd >= 0) {
+        close(info->prctl_mm_exe_fd);
+    }
+    g_free(info->prctl_mm_exe_path);
+    info->prctl_mm_exe_fd = saved_fd;
+    info->prctl_mm_exe_path = g_strdup(path);
+    return 0;
+}
+
+static abi_long do_prctl_set_mm(CPUArchState *env, abi_ulong option,
+                                abi_ulong addr, abi_ulong arg4,
+                                abi_ulong arg5)
+{
+    struct image_info *info = ((TaskState *)env_cpu(env)->opaque)->info;
+    struct guest_prctl_mm_map map;
+    abi_long ret;
+
+    if (arg5 || (arg4 && option != PR_SET_MM_AUXV &&
+                 option != PR_SET_MM_MAP &&
+                 option != PR_SET_MM_MAP_SIZE)) {
+        return -TARGET_EINVAL;
+    }
+
+    if (option == PR_SET_MM_MAP_SIZE) {
+        return put_user_u32(sizeof(struct target_prctl_mm_map), addr) ?
+               -TARGET_EFAULT : 0;
+    }
+
+    if (option == PR_SET_MM_MAP) {
+        struct target_prctl_mm_map *target_map;
+        abi_ulong new_auxv[TARGET_X86_64_PRCTL_AUXV_WORDS] = { };
+        abi_ulong auxv;
+        uint32_t auxv_size, exe_fd;
+
+        if (arg4 != sizeof(*target_map)) {
+            return -TARGET_EINVAL;
+        }
+        if (!lock_user_struct(VERIFY_READ, target_map, addr, 1)) {
+            return -TARGET_EFAULT;
+        }
+        map = (struct guest_prctl_mm_map) {
+            .start_code = tswap64(target_map->start_code),
+            .end_code = tswap64(target_map->end_code),
+            .start_data = tswap64(target_map->start_data),
+            .end_data = tswap64(target_map->end_data),
+            .start_brk = tswap64(target_map->start_brk),
+            .brk = tswap64(target_map->brk),
+            .start_stack = tswap64(target_map->start_stack),
+            .arg_start = tswap64(target_map->arg_start),
+            .arg_end = tswap64(target_map->arg_end),
+            .env_start = tswap64(target_map->env_start),
+            .env_end = tswap64(target_map->env_end),
+        };
+        auxv = tswap64(target_map->auxv);
+        auxv_size = tswap32(target_map->auxv_size);
+        exe_fd = tswap32(target_map->exe_fd);
+        unlock_user_struct(target_map, addr, 0);
+
+        ret = guest_prctl_mm_validate(&map);
+        if (ret) {
+            return ret;
+        }
+        if (auxv_size && (!auxv || auxv_size > sizeof(info->prctl_auxv))) {
+            return -TARGET_EINVAL;
+        }
+        if (auxv_size) {
+            if (copy_from_user(new_auxv, auxv, auxv_size)) {
+                return -TARGET_EFAULT;
+            }
+            new_auxv[ARRAY_SIZE(new_auxv) - 2] = 0;
+            new_auxv[ARRAY_SIZE(new_auxv) - 1] = 0;
+        }
+        if (exe_fd != UINT32_MAX) {
+            unsigned int checkpoint_cap =
+#ifdef CAP_CHECKPOINT_RESTORE
+                CAP_CHECKPOINT_RESTORE;
+#else
+                40;
+#endif
+            if (!guest_has_capability(CAP_SYS_ADMIN) &&
+                !guest_has_capability(checkpoint_cap)) {
+                return -TARGET_EPERM;
+            }
+            ret = guest_prctl_set_exe_file(info, exe_fd);
+            if (ret) {
+                return ret;
+            }
+        }
+        if (auxv_size) {
+            memcpy(info->prctl_auxv, new_auxv, sizeof(new_auxv));
+        }
+        guest_prctl_mm_write(info, &map);
+        return 0;
+    }
+
+    if (!guest_has_capability(CAP_SYS_RESOURCE)) {
+        return -TARGET_EPERM;
+    }
+    if (option == PR_SET_MM_AUXV) {
+        return guest_prctl_set_auxv(info, addr, arg4, false);
+    }
+    if (option == PR_SET_MM_EXE_FILE) {
+        return guest_prctl_set_exe_file(info, addr);
+    }
+    if (addr < guest_mmap_min_addr() || addr > GUEST_ADDR_MAX) {
+        return -TARGET_EINVAL;
+    }
+
+    guest_prctl_mm_read(info, &map);
+    switch (option) {
+    case PR_SET_MM_START_CODE:
+        map.start_code = addr;
+        break;
+    case PR_SET_MM_END_CODE:
+        map.end_code = addr;
+        break;
+    case PR_SET_MM_START_DATA:
+        map.start_data = addr;
+        break;
+    case PR_SET_MM_END_DATA:
+        map.end_data = addr;
+        break;
+    case PR_SET_MM_START_STACK:
+        map.start_stack = addr;
+        break;
+    case PR_SET_MM_START_BRK:
+        map.start_brk = addr;
+        break;
+    case PR_SET_MM_BRK:
+        map.brk = addr;
+        break;
+    case PR_SET_MM_ARG_START:
+        map.arg_start = addr;
+        break;
+    case PR_SET_MM_ARG_END:
+        map.arg_end = addr;
+        break;
+    case PR_SET_MM_ENV_START:
+        map.env_start = addr;
+        break;
+    case PR_SET_MM_ENV_END:
+        map.env_end = addr;
+        break;
+    default:
+        return -TARGET_EINVAL;
+    }
+
+    ret = guest_prctl_mm_validate(&map);
+    if (ret) {
+        return ret;
+    }
+    switch (option) {
+    case PR_SET_MM_START_STACK:
+    case PR_SET_MM_ARG_START:
+    case PR_SET_MM_ARG_END:
+    case PR_SET_MM_ENV_START:
+    case PR_SET_MM_ENV_END:
+        if (!page_get_flags(addr)) {
+            return -TARGET_EFAULT;
+        }
+    }
+    guest_prctl_mm_write(info, &map);
+    return 0;
+}
+
+static abi_long do_prctl_get_tsc(CPUX86State *env, abi_ulong addr)
+{
+    int mode = env->cr[4] & CR4_TSD_MASK ? PR_TSC_SIGSEGV : PR_TSC_ENABLE;
+
+    return put_user_s32(mode, addr) ? -TARGET_EFAULT : 0;
+}
+
+static abi_long do_prctl_set_tsc(CPUX86State *env, abi_ulong mode)
+{
+    switch (mode) {
+    case PR_TSC_ENABLE:
+        env->cr[4] &= ~CR4_TSD_MASK;
+        return 0;
+    case PR_TSC_SIGSEGV:
+        env->cr[4] |= CR4_TSD_MASK;
+        return 0;
+    default:
+        return -TARGET_EINVAL;
+    }
+}
+
+static abi_long do_prctl_speculation_ctrl(bool set, abi_ulong which,
+                                          abi_ulong control,
+                                          abi_ulong arg4, abi_ulong arg5)
+{
+    if ((!set && (control || arg4 || arg5)) ||
+        (set && (arg4 || arg5))) {
+        return -TARGET_EINVAL;
+    }
+    switch (which) {
+    case PR_SPEC_STORE_BYPASS:
+        return set ? -TARGET_ENXIO : PR_SPEC_NOT_AFFECTED;
+    case PR_SPEC_INDIRECT_BRANCH:
+        if (!set) {
+            return PR_SPEC_NOT_AFFECTED;
+        }
+        switch (control) {
+        case PR_SPEC_ENABLE:
+            return 0;
+        case PR_SPEC_DISABLE:
+        case PR_SPEC_FORCE_DISABLE:
+            return -TARGET_EPERM;
+        default:
+            return -TARGET_ERANGE;
+        }
+    case PR_SPEC_L1D_FLUSH:
+        return set ? -TARGET_EPERM : PR_SPEC_FORCE_DISABLE;
+    default:
+        return -TARGET_ENODEV;
+    }
+}
+
+static abi_long do_prctl_mdwe(CPUArchState *env, bool set,
+                              abi_ulong arg2, abi_ulong arg3,
+                              abi_ulong arg4, abi_ulong arg5)
+{
+    struct image_info *info = ((TaskState *)env_cpu(env)->opaque)->info;
+    unsigned long valid = PR_MDWE_REFUSE_EXEC_GAIN | PR_MDWE_NO_INHERIT;
+
+    if (!set) {
+        if (arg2 || arg3 || arg4 || arg5) {
+            return -TARGET_EINVAL;
+        }
+        return info->prctl_mdwe;
+    }
+    if (arg3 || arg4 || arg5 || (arg2 & ~valid) ||
+        ((arg2 & PR_MDWE_NO_INHERIT) &&
+         !(arg2 & PR_MDWE_REFUSE_EXEC_GAIN))) {
+        return -TARGET_EINVAL;
+    }
+    if (info->prctl_mdwe && info->prctl_mdwe != arg2) {
+        return -TARGET_EPERM;
+    }
+    info->prctl_mdwe = arg2;
+    return 0;
+}
+
+static abi_long do_prctl_set_vma(abi_ulong operation, abi_ulong start,
+                                 abi_ulong len,
+                                 abi_ulong name_addr)
+{
+    char *name = NULL;
+    abi_ulong rounded_len;
+    abi_long ret;
+
+    if (operation != PR_SET_VMA_ANON_NAME) {
+        return -TARGET_EINVAL;
+    }
+    if (name_addr) {
+        name = lock_user_string(name_addr);
+        if (!name) {
+            return -TARGET_EFAULT;
+        }
+    }
+    if (start & ~TARGET_PAGE_MASK) {
+        ret = -TARGET_EINVAL;
+        goto out;
+    }
+    rounded_len = TARGET_PAGE_ALIGN(len);
+    if ((len && !rounded_len) || start + rounded_len < start) {
+        ret = -TARGET_EINVAL;
+        goto out;
+    }
+    if (!rounded_len) {
+        ret = 0;
+        goto out;
+    }
+    if (!page_check_range(start, rounded_len, PAGE_VALID)) {
+        ret = -TARGET_ENOMEM;
+        goto out;
+    }
+
+    ret = get_errno(prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME,
+                          (uintptr_t)g2h_untagged(start), rounded_len,
+                          (uintptr_t)name));
+out:
+    if (name) {
+        unlock_user(name, name_addr, 0);
+    }
+    return ret;
+}
+
+static abi_long guest_mdwe_mmap(CPUState *cpu, abi_ulong len, int prot)
+{
+    TaskState *ts = cpu->opaque;
+    int valid = PROT_READ | PROT_WRITE | PROT_EXEC | TARGET_PROT_SEM;
+
+    if (!(ts->info->prctl_mdwe & TARGET_PR_MDWE_REFUSE_EXEC_GAIN) ||
+        !len || (prot & ~valid)) {
+        return 0;
+    }
+    return (prot & (PROT_WRITE | PROT_EXEC)) ==
+           (PROT_WRITE | PROT_EXEC) ? -TARGET_EACCES : 0;
+}
+
+static abi_long guest_mdwe_mprotect(CPUState *cpu, abi_ulong start,
+                                    abi_ulong len, int prot)
+{
+    TaskState *ts = cpu->opaque;
+    abi_ulong end, addr;
+    int valid = PROT_READ | PROT_WRITE | PROT_EXEC | TARGET_PROT_SEM;
+
+    if (!(ts->info->prctl_mdwe & TARGET_PR_MDWE_REFUSE_EXEC_GAIN) ||
+        !(prot & PROT_EXEC) || (prot & ~valid) ||
+        (start & ~TARGET_PAGE_MASK)) {
+        return 0;
+    }
+    len = TARGET_PAGE_ALIGN(len);
+    end = start + len;
+    if (!len || end < start || !guest_range_valid_untagged(start, len) ||
+        !page_check_range(start, len, PAGE_VALID)) {
+        return 0;
+    }
+    if (prot & PROT_WRITE) {
+        return -TARGET_EACCES;
+    }
+    for (addr = start; addr < end; addr += TARGET_PAGE_SIZE) {
+        if (!(page_get_flags(addr) & PAGE_EXEC)) {
+            return -TARGET_EACCES;
+        }
+    }
+    return 0;
+}
+
+static char *guest_prctl_exec_env(CPUArchState *env, const char *name)
+{
+    TaskState *ts = env_cpu(env)->opaque;
+
+    if (strcmp(name, LATX_GUEST_MDWE_ENV) == 0) {
+        if (ts->info->prctl_mdwe == TARGET_PR_MDWE_REFUSE_EXEC_GAIN) {
+            return g_strdup_printf("%s=1", LATX_GUEST_MDWE_ENV);
+        }
+    } else if (strcmp(name, LATX_GUEST_TSC_ENV) == 0) {
+        CPUX86State *x86_env = (CPUX86State *)env;
+
+        if (x86_env->cr[4] & CR4_TSD_MASK) {
+            return g_strdup_printf("%s=1", LATX_GUEST_TSC_ENV);
+        }
+    }
+    return NULL;
+}
+
+static char **append_guest_prctl_exec_env(CPUArchState *env, char **envp,
+                                          int envc, char **mdwe_env,
+                                          char **tsc_env)
+{
+    int extra = 0;
+
+    *mdwe_env = guest_prctl_exec_env(env, LATX_GUEST_MDWE_ENV);
+    *tsc_env = guest_prctl_exec_env(env, LATX_GUEST_TSC_ENV);
+    extra += *mdwe_env != NULL;
+    extra += *tsc_env != NULL;
+    if (!extra) {
+        return envp;
+    }
+
+    envp = g_renew(char *, envp, envc + extra + 1);
+    if (*mdwe_env) {
+        envp[envc++] = *mdwe_env;
+    }
+    if (*tsc_env) {
+        envp[envc++] = *tsc_env;
+    }
+    envp[envc] = NULL;
+    return envp;
+}
+#endif
 
 /* This is an internal helper for do_syscall so that it is easier
  * to have a single return point, so that actions, such as logging
@@ -12623,6 +13436,10 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
     case TARGET_NR_execveat:
         {
             char **argp, **envp;
+#ifdef TARGET_X86_64
+            char *prctl_mdwe_env = NULL;
+            char *prctl_tsc_env = NULL;
+#endif
             int argc, envc;
             abi_ulong gp;
             abi_ulong guest_argp;
@@ -12685,6 +13502,12 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
             }
             *q = NULL;
 
+#ifdef TARGET_X86_64
+            envp = append_guest_prctl_exec_env(env, envp, envc,
+                                               &prctl_mdwe_env,
+                                               &prctl_tsc_env);
+#endif
+
             p = lock_user_string(arg2);
             if (!(p)) {
                 goto execveat_efault;
@@ -12737,16 +13560,6 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
                 }
             }
 
-            if (is_proc_myself((const char *)p, "exe")) {
-                char real[PATH_MAX], *temp;
-                temp = realpath(exec_path, real);
-
-                if (temp == NULL) {
-                    ret = get_errno(-1);
-                    goto execveat_end;
-                }
-            }
-
             /*
              * Although execve() is not an interruptible syscall it is
              * a special case where we must use the safe_syscall wrapper:
@@ -12758,7 +13571,17 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
              * before the execve completes and makes it the other
              * program's problem.
              */
-            ret = get_errno(safe_execveat(arg1, p, argp, envp, arg5));
+            if (is_proc_myself((const char *)p, "exe")) {
+                char exe_path_buffer[64];
+                const char *exe_pathname =
+                    guest_self_exe_open_path(cpu_env, exe_path_buffer,
+                                             sizeof(exe_path_buffer));
+
+                ret = get_errno(safe_execveat(AT_FDCWD, exe_pathname,
+                                              argp, envp, arg5));
+            } else {
+                ret = get_errno(safe_execveat(arg1, p, argp, envp, arg5));
+            }
             unlock_user(p, arg1, 0);
 
             goto execveat_end;
@@ -12785,6 +13608,10 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
             }
 
             g_free(argp);
+#ifdef TARGET_X86_64
+            g_free(prctl_mdwe_env);
+            g_free(prctl_tsc_env);
+#endif
             g_free(envp);
         }
         return ret;
@@ -12792,6 +13619,10 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
     case TARGET_NR_execve:
         {
             char **argp, **envp;
+#ifdef TARGET_X86_64
+            char *prctl_mdwe_env = NULL;
+            char *prctl_tsc_env = NULL;
+#endif
             int argc, envc;
             abi_ulong gp;
             abi_ulong guest_argp;
@@ -12841,6 +13672,12 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
                     goto execve_efault;
             }
             *q = NULL;
+
+#ifdef TARGET_X86_64
+            envp = append_guest_prctl_exec_env(env, envp, envc,
+                                               &prctl_mdwe_env,
+                                               &prctl_tsc_env);
+#endif
 
             if (!(p = lock_user_string(arg1)))
                 goto execve_efault;
@@ -12893,18 +13730,22 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
             }
 
             if (is_proc_myself((const char *)p, "exe")) {
-                char real[PATH_MAX], *temp;
-                temp = realpath(exec_path, real);
-
-                if (!strcmp((const char *)*argp, "/proc/self/exe")) {
-                    *argp = temp;
-                }
+                char real[PATH_MAX];
+                char exe_path_buffer[64];
+                const char *temp = guest_self_exe_link_path(cpu_env, real,
+                                                            sizeof(real));
+                const char *exe_pathname =
+                    guest_self_exe_open_path(cpu_env, exe_path_buffer,
+                                             sizeof(exe_path_buffer));
 
                 if (temp == NULL) {
                     ret = get_errno(-1);
                     goto execve_end;
                 }
-                ret = get_errno(safe_execve(temp, argp, envp));
+                if (!strcmp((const char *)*argp, "/proc/self/exe")) {
+                    *argp = (char *)temp;
+                }
+                ret = get_errno(safe_execve(exe_pathname, argp, envp));
             } else {
 
                 /* Although execve() is not an interruptible syscall it is
@@ -12943,6 +13784,10 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
             }
 
             g_free(argp);
+#ifdef TARGET_X86_64
+            g_free(prctl_mdwe_env);
+            g_free(prctl_tsc_env);
+#endif
             g_free(envp);
         }
         return ret;
@@ -14238,8 +15083,9 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
                 /* Short circuit this for the magic exe check. */
                 ret = -TARGET_EINVAL;
             } else if (is_proc_myself((const char *)p, "exe")) {
-                char real[PATH_MAX], *temp;
-                temp = realpath(exec_path, real);
+                char real[PATH_MAX];
+                const char *temp = guest_self_exe_link_path(cpu_env, real,
+                                                            sizeof(real));
                 /* Return value is # of bytes that we wrote to the buffer. */
                 if (temp == NULL) {
                     ret = MIN(strlen(real_path), arg3);
@@ -14268,10 +15114,16 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
             if (!p || !p2) {
                 ret = -TARGET_EFAULT;
             } else if (is_proc_myself((const char *)p, "exe")) {
-                char real[PATH_MAX], *temp;
-                temp = realpath(exec_path, real);
-                ret = temp == NULL ? get_errno(-1) : strlen(real) ;
-                snprintf((char *)p2, arg4, "%s", real);
+                char real[PATH_MAX];
+                const char *temp = guest_self_exe_link_path(cpu_env, real,
+                                                            sizeof(real));
+
+                if (temp == NULL) {
+                    ret = get_errno(-1);
+                } else {
+                    ret = MIN(strlen(temp), arg4);
+                    memcpy(p2, temp, ret);
+                }
             } else {
                 ret = get_errno(readlinkat(arg1, path(p), p2, arg4));
             }
@@ -14335,6 +15187,12 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
             }
         }
 
+#ifdef TARGET_X86_64
+        ret = guest_mdwe_mmap(cpu, arg2, arg3);
+        if (ret) {
+            return ret;
+        }
+#endif
         /* mmap pointers are always untagged */
         ret = get_errno(target_mmap(arg1, arg2, arg3,
                                     target_to_host_bitmask(arg4, mmap_flags_tbl),
@@ -14369,6 +15227,12 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
                 arg1 = ts->info->stack_limit;
             }
         }
+#ifdef TARGET_X86_64
+        ret = guest_mdwe_mprotect(cpu, arg1, arg2, arg3);
+        if (ret) {
+            return ret;
+        }
+#endif
         return get_errno(target_mprotect(arg1, arg2, arg3));
 #ifdef TARGET_NR_mremap
     case TARGET_NR_mremap:
@@ -15596,14 +16460,18 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
         case PR_GET_PDEATHSIG:
         {
             int deathsig;
-            ret = get_errno(prctl(arg1, &deathsig, g2h_untagged(arg3),
-                                g2h_untagged(arg4), g2h_untagged(arg5)));
-            if (!is_error(ret) && arg2
-                && put_user_s32(deathsig, arg2)) {
+            ret = get_errno(prctl(PR_GET_PDEATHSIG, &deathsig,
+                                  arg3, arg4, arg5));
+            if (!is_error(ret) &&
+                put_user_s32(host_to_target_signal(deathsig), arg2)) {
                 return -TARGET_EFAULT;
             }
             return ret;
         }
+        case PR_SET_PDEATHSIG:
+            return get_errno(prctl(PR_SET_PDEATHSIG,
+                                   target_to_host_signal(arg2),
+                                   arg3, arg4, arg5));
 #ifdef PR_GET_NAME
         case PR_GET_NAME:
         {
@@ -15611,8 +16479,8 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
             if (!name) {
                 return -TARGET_EFAULT;
             }
-            ret = get_errno(prctl(arg1, (unsigned long)name, g2h_untagged(arg3),
-                                g2h_untagged(arg4), g2h_untagged(arg5)));
+            ret = get_errno(prctl(PR_GET_NAME, (unsigned long)name,
+                                  arg3, arg4, arg5));
             unlock_user(name, arg2, 16);
             return ret;
         }
@@ -15622,8 +16490,8 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
             if (!name) {
                 return -TARGET_EFAULT;
             }
-            ret = get_errno(prctl(arg1, (unsigned long)name, g2h_untagged(arg3),
-                                g2h_untagged(arg4), g2h_untagged(arg5)));
+            ret = get_errno(prctl(PR_SET_NAME, (unsigned long)name,
+                                  arg3, arg4, arg5));
             unlock_user(name, arg2, 0);
             return ret;
         }
@@ -15868,13 +16736,140 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
                 return ret;
             }
 #endif /* AARCH64 */
+        case PR_SET_SYSCALL_USER_DISPATCH:
+            return do_prctl_syscall_user_dispatch(env, arg2, arg3,
+                                                  arg4, arg5);
+#ifdef TARGET_X86_64
+        case PR_GET_TSC:
+            return do_prctl_get_tsc(env, arg2);
+        case PR_SET_TSC:
+            return do_prctl_set_tsc(env, arg2);
+        case PR_GET_AUXV:
+            if (arg4 || arg5) {
+                return -TARGET_EINVAL;
+            }
+            return do_prctl_get_auxv(env, arg2, arg3);
+        case PR_SET_MDWE:
+            return do_prctl_mdwe(env, true, arg2, arg3, arg4, arg5);
+        case PR_GET_MDWE:
+            return do_prctl_mdwe(env, false, arg2, arg3, arg4, arg5);
+        case PR_SET_VMA:
+            return do_prctl_set_vma(arg2, arg3, arg4, arg5);
+        case PR_SET_MM:
+            return do_prctl_set_mm(env, arg2, arg3, arg4, arg5);
+        case PR_GET_SPECULATION_CTRL:
+            return do_prctl_speculation_ctrl(false, arg2, arg3,
+                                             arg4, arg5);
+        case PR_SET_SPECULATION_CTRL:
+            return do_prctl_speculation_ctrl(true, arg2, arg3,
+                                             arg4, arg5);
+#endif
         case PR_GET_SECCOMP:
         case PR_SET_SECCOMP:
             return guest_seccomp_prctl(env, arg1, arg2, arg3);
+        case PR_CAP_AMBIENT:
+        case PR_CAPBSET_READ:
+        case PR_CAPBSET_DROP:
+        case PR_GET_DUMPABLE:
+        case PR_SET_DUMPABLE:
+        case PR_GET_KEEPCAPS:
+        case PR_SET_KEEPCAPS:
+        case PR_GET_SECUREBITS:
+        case PR_SET_SECUREBITS:
+        case PR_GET_TIMING:
+        case PR_SET_TIMING:
+        case PR_GET_TIMERSLACK:
+        case PR_SET_TIMERSLACK:
+        case PR_TASK_PERF_EVENTS_DISABLE:
+        case PR_TASK_PERF_EVENTS_ENABLE:
+        case PR_MCE_KILL:
+        case PR_MCE_KILL_GET:
+        case PR_GET_NO_NEW_PRIVS:
+        case PR_SET_NO_NEW_PRIVS:
+        case PR_GET_IO_FLUSHER:
+        case PR_SET_IO_FLUSHER:
+        case PR_SET_CHILD_SUBREAPER:
+        case PR_SET_PTRACER:
+        case PR_GET_THP_DISABLE:
+        case PR_SET_THP_DISABLE:
+#ifndef TARGET_X86_64
+        case PR_GET_SPECULATION_CTRL:
+        case PR_SET_SPECULATION_CTRL:
+#endif
+        case PR_SET_MEMORY_MERGE:
+        case PR_GET_MEMORY_MERGE:
+            /* These options have only scalar arguments. */
+            return get_errno(prctl(arg1, arg2, arg3, arg4, arg5));
+        case PR_SCHED_CORE:
+            if (arg2 == PR_SCHED_CORE_GET) {
+                uint64_t cookie;
+
+                ret = get_errno(prctl(PR_SCHED_CORE, arg2, arg3, arg4,
+                                      &cookie));
+                if (!is_error(ret) && put_user_u64(cookie, arg5)) {
+                    return -TARGET_EFAULT;
+                }
+                return ret;
+            }
+            return get_errno(prctl(PR_SCHED_CORE, arg2, arg3,
+                                   arg4, arg5));
+        case PR_GET_CHILD_SUBREAPER:
+        {
+            int val;
+
+            ret = get_errno(prctl(PR_GET_CHILD_SUBREAPER, &val,
+                                  arg3, arg4, arg5));
+            if (!is_error(ret) && put_user_s32(val, arg2)) {
+                return -TARGET_EFAULT;
+            }
+            return ret;
+        }
+        case PR_GET_TID_ADDRESS:
+            return put_user_ual(((TaskState *)cpu->opaque)->child_tidptr,
+                                arg2);
+        case PR_GET_FPEXC:
+        case PR_SET_FPEXC:
+        case PR_GET_ENDIAN:
+        case PR_SET_ENDIAN:
+        case PR_GET_FPEMU:
+        case PR_SET_FPEMU:
+#ifndef TARGET_X86_64
+        case PR_SET_MM:
+        case PR_GET_TSC:
+        case PR_SET_TSC:
+#endif
+        case PR_MPX_ENABLE_MANAGEMENT:
+        case PR_MPX_DISABLE_MANAGEMENT:
+#ifdef TARGET_X86_64
+        case PR_GET_UNALIGN:
+        case PR_SET_UNALIGN:
+        case PR_SET_FP_MODE:
+        case PR_GET_FP_MODE:
+        case PR_SVE_SET_VL:
+        case PR_SVE_GET_VL:
+        case PR_PAC_RESET_KEYS:
+        case PR_SET_TAGGED_ADDR_CTRL:
+        case PR_GET_TAGGED_ADDR_CTRL:
+        case PR_PAC_SET_ENABLED_KEYS:
+        case PR_PAC_GET_ENABLED_KEYS:
+        case PR_SME_SET_VL:
+        case PR_SME_GET_VL:
+        case PR_RISCV_V_SET_CONTROL:
+        case PR_RISCV_V_GET_CONTROL:
+        case PR_RISCV_SET_ICACHE_FLUSH_CTX:
+        case PR_PPC_GET_DEXCR:
+        case PR_PPC_SET_DEXCR:
+        case PR_GET_SHADOW_STACK_STATUS:
+        case PR_SET_SHADOW_STACK_STATUS:
+        case PR_LOCK_SHADOW_STACK_STATUS:
+#endif
+            /* Do not let the guest alter host execution state. */
+            return -TARGET_EINVAL;
         default:
-            /* Most prctl options have no pointer arguments */
-            return get_errno(prctl(arg1, g2h_untagged(arg2), g2h_untagged(arg3),
-                                    g2h_untagged(arg4), g2h_untagged(arg5)));
+            qemu_log_mask(LOG_UNIMP,
+                          "Unsupported prctl: " TARGET_ABI_FMT_ld "\n",
+                          arg1);
+            return -TARGET_EINVAL;
         }
         break;
 #ifdef TARGET_NR_arch_prctl
@@ -18557,6 +19552,53 @@ defined(__loongarch__)
     return ret;
 }
 
+static bool syscall_user_dispatch(CPUArchState *env, int num, uint32_t arch)
+{
+    CPUState *cpu = env_cpu(env);
+    TaskState *ts = cpu->opaque;
+    target_ulong pc;
+    target_ulong cs_base;
+    uint32_t flags;
+
+    if (likely(ts->sys_dispatch_len == (abi_ulong)-1)) {
+        return false;
+    }
+
+    cpu_get_tb_cpu_state(env, &pc, &cs_base, &flags);
+    if (likely(pc - ts->sys_dispatch < ts->sys_dispatch_len)) {
+        return false;
+    }
+    if (unlikely(pc == default_sigreturn || pc == default_rt_sigreturn)) {
+        return false;
+    }
+
+    if (likely(ts->sys_dispatch_selector)) {
+        uint8_t selector;
+
+        if (get_user_u8(selector, ts->sys_dispatch_selector)) {
+            force_sig_abort(TARGET_SIGSEGV);
+        }
+        if (likely(selector == SYSCALL_DISPATCH_FILTER_ALLOW)) {
+            return false;
+        }
+        if (unlikely(selector != SYSCALL_DISPATCH_FILTER_BLOCK)) {
+            force_sig_abort(TARGET_SIGSYS);
+        }
+    }
+
+    target_siginfo_t info = {
+        .si_signo = TARGET_SIGSYS,
+        .si_errno = 0,
+        .si_code = TARGET_SYS_USER_DISPATCH,
+        ._sifields._sigsys._call_addr = pc,
+        ._sifields._sigsys._syscall = num,
+        ._sifields._sigsys._arch = arch,
+    };
+
+    queue_signal(env, TARGET_SIGSYS, QEMU_SI_SYS, &info);
+    return true;
+}
+
 abi_long do_syscall_with_seccomp(void *cpu_env, int num, int seccomp_num,
                                 uint32_t seccomp_arch, abi_long arg1,
                                 abi_long arg2, abi_long arg3, abi_long arg4,
@@ -18570,6 +19612,7 @@ abi_long do_syscall_with_seccomp(void *cpu_env, int num, int seccomp_num,
         arg1, arg2, arg3, arg4, arg5, arg6,
     };
     GuestSeccompAction seccomp_action = GUEST_SECCOMP_CONTINUE;
+    bool loader_tunnel = false;
     bool suppress_tunnel = false;
     abi_long ret;
 
@@ -18595,6 +19638,15 @@ abi_long do_syscall_with_seccomp(void *cpu_env, int num, int seccomp_num,
     }
 #endif
 
+#ifdef CONFIG_LATX_TUNNEL_LIB
+    loader_tunnel = num == TUNNEL_VIRTUAL_SYSCALL_ID &&
+                    is_tunnel_loader_notification(env, arg1);
+#endif
+    if (!loader_tunnel &&
+        syscall_user_dispatch(env, seccomp_num, seccomp_arch)) {
+        return -TARGET_QEMU_ESIGRETURN;
+    }
+
     record_syscall_start(cpu, num, arg1,
                          arg2, arg3, arg4, arg5, arg6, arg7, arg8);
     if (unlikely(qemu_loglevel_mask(LOG_STRACE)) ||
@@ -18603,9 +19655,7 @@ abi_long do_syscall_with_seccomp(void *cpu_env, int num, int seccomp_num,
     }
 
 #ifdef CONFIG_LATX_TUNNEL_LIB
-    suppress_tunnel = ts->seccomp_filter &&
-                      num == TUNNEL_VIRTUAL_SYSCALL_ID &&
-                      is_tunnel_loader_notification(env, arg1);
+    suppress_tunnel = ts->seccomp_filter && loader_tunnel;
 #endif
     if (suppress_tunnel) {
         ret = 0;

--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -272,6 +272,9 @@ out_marker:
 #define SYSCALL_DISPATCH_FILTER_ALLOW 0
 #define SYSCALL_DISPATCH_FILTER_BLOCK 1
 #endif
+#ifndef PR_SYS_DISPATCH_INCLUSIVE_ON
+#define PR_SYS_DISPATCH_INCLUSIVE_ON 2
+#endif
 #ifndef PR_SCHED_CORE
 #define PR_SCHED_CORE 62
 #define PR_SCHED_CORE_GET 0
@@ -9831,6 +9834,8 @@ static int do_fork(CPUArchState *env, unsigned int flags, abi_ulong newsp,
             ts->sys_dispatch = 0;
             ts->sys_dispatch_selector = 0;
             ts->sys_dispatch_len = -1;
+            ts->sys_dispatch_inclusive = false;
+            ts->child_tidptr = 0;
             if (flags & CLONE_NEWIPC) {
                 ts->ipc_namespace_isolated = true;
             }
@@ -11265,39 +11270,50 @@ static void regs_to_seccomp_trace(const struct target_pt_regs *regs,
 }
 #endif
 
-/*
- * Once setproctitle called, the argv should be reinterpted as the name
- * set by setproctitle
- */
-static int open_self_cmdline(void *cpu_env, int fd, const char *oldpath)
-{
-    CPUState *cpu = env_cpu((CPUArchState *)cpu_env);
 #ifdef TARGET_X86_64
-    struct image_info *info = ((TaskState *)cpu->opaque)->info;
-    abi_ulong addr;
-    abi_ulong remaining;
-
-    mmap_lock();
-    addr = info->prctl_mm_arg_start;
-    remaining = info->prctl_mm_arg_end - addr;
-    mmap_unlock();
-
-    while (remaining) {
-        size_t len = MIN((abi_ulong)TARGET_PAGE_SIZE, remaining);
-        void *ptr = lock_user(VERIFY_READ, addr, len, 1);
+static int write_guest_proc_range(int fd, abi_ulong start, abi_ulong end)
+{
+    while (start < end) {
+        size_t len = MIN((abi_ulong)TARGET_PAGE_SIZE, end - start);
+        void *ptr = lock_user(VERIFY_READ, start, len, 1);
         ssize_t written;
 
         if (!ptr) {
             return -1;
         }
         written = write(fd, ptr, len);
-        unlock_user(ptr, addr, 0);
+        unlock_user(ptr, start, 0);
         if (written != len) {
             return -1;
         }
-        addr += len;
-        remaining -= len;
+        start += len;
     }
+    return 0;
+}
+#endif
+
+/* Include the environment tail when userspace has overwritten argv. */
+static int open_self_cmdline(void *cpu_env, int fd, const char *oldpath)
+{
+    CPUState *cpu = env_cpu((CPUArchState *)cpu_env);
+#ifdef TARGET_X86_64
+    struct image_info *info = ((TaskState *)cpu->opaque)->info;
+    abi_ulong start, end, env_end;
+    uint8_t last = 0;
+
+    mmap_lock();
+    start = info->prctl_mm_arg_start;
+    end = info->prctl_mm_arg_end;
+    env_end = info->prctl_mm_env_end;
+    mmap_unlock();
+
+    if (end > start && get_user_u8(last, end - 1)) {
+        return -1;
+    }
+    if (last && env_end > end) {
+        end = env_end;
+    }
+    return write_guest_proc_range(fd, start, end);
 #else
     struct linux_binprm *bprm = ((TaskState *)cpu->opaque)->bprm;
     int i;
@@ -11312,6 +11328,20 @@ static int open_self_cmdline(void *cpu_env, int fd, const char *oldpath)
 #endif
     return 0;
 }
+
+#ifdef TARGET_X86_64
+static int open_self_environ(void *cpu_env, int fd, const char *oldpath)
+{
+    TaskState *ts = env_cpu((CPUArchState *)cpu_env)->opaque;
+    abi_ulong start, end;
+
+    mmap_lock();
+    start = ts->info->prctl_mm_env_start;
+    end = ts->info->prctl_mm_env_end;
+    mmap_unlock();
+    return write_guest_proc_range(fd, start, end);
+}
+#endif
 
 static const char *guest_self_exe_open_path(CPUArchState *env, char *buffer,
                                             size_t size, int *owned_fd)
@@ -11343,15 +11373,28 @@ static const char *guest_self_exe_link_path(CPUArchState *env,
 {
 #ifdef TARGET_X86_64
     TaskState *ts = env_cpu(env)->opaque;
+    char fd_path[64];
     bool overridden;
+    ssize_t len;
+    int fd = -1;
 
     mmap_lock();
-    overridden = ts->info->prctl_mm_exe_path != NULL;
+    overridden = ts->info->prctl_mm_exe_fd >= 0;
     if (overridden) {
-        pstrcpy(buffer, size, ts->info->prctl_mm_exe_path);
+        fd = fcntl(ts->info->prctl_mm_exe_fd, F_DUPFD_CLOEXEC, 0);
     }
     mmap_unlock();
     if (overridden) {
+        if (fd < 0) {
+            return NULL;
+        }
+        snprintf(fd_path, sizeof(fd_path), "/proc/self/fd/%d", fd);
+        len = readlink(fd_path, buffer, size - 1);
+        close(fd);
+        if (len < 0) {
+            return NULL;
+        }
+        buffer[len] = 0;
         return buffer;
     }
 #endif
@@ -11368,14 +11411,12 @@ static bool guest_self_exe_exec_paths(CPUArchState *env, char *link_buffer,
 #ifdef TARGET_X86_64
     TaskState *ts = env_cpu(env)->opaque;
     bool overridden;
+    ssize_t len;
 
     mmap_lock();
     overridden = ts->info->prctl_mm_exe_fd >= 0;
     if (overridden) {
         *owned_fd = fcntl(ts->info->prctl_mm_exe_fd, F_DUPFD_CLOEXEC, 0);
-        if (*owned_fd >= 0) {
-            pstrcpy(link_buffer, link_size, ts->info->prctl_mm_exe_path);
-        }
     }
     mmap_unlock();
     if (overridden) {
@@ -11383,6 +11424,13 @@ static bool guest_self_exe_exec_paths(CPUArchState *env, char *link_buffer,
             return false;
         }
         snprintf(open_buffer, open_size, "/proc/self/fd/%d", *owned_fd);
+        len = readlink(open_buffer, link_buffer, link_size - 1);
+        if (len < 0) {
+            close(*owned_fd);
+            *owned_fd = -1;
+            return false;
+        }
+        link_buffer[len] = 0;
         *link_path = link_buffer;
         *open_path = open_buffer;
         return true;
@@ -11747,7 +11795,8 @@ void guest_vma_name_reset(abi_ulong start, abi_ulong len)
 }
 
 void guest_vma_name_remap(abi_ulong old_start, abi_ulong old_len,
-                          abi_ulong new_start, abi_ulong new_len)
+                          abi_ulong new_start, abi_ulong new_len,
+                          bool keep_old)
 {
     GPtrArray *saved = g_ptr_array_new_with_free_func(
         (GDestroyNotify)guest_vma_name_free);
@@ -11773,7 +11822,9 @@ void guest_vma_name_remap(abi_ulong old_start, abi_ulong old_len,
         }
     }
 
-    guest_vma_name_apply_locked(old_start, old_end, NULL);
+    if (!keep_old) {
+        guest_vma_name_apply_locked(old_start, old_end, NULL);
+    }
     guest_vma_name_apply_locked(new_start, new_end, NULL);
     for (i = 0; i < saved->len; i++) {
         GuestVmaName *entry = g_ptr_array_index(saved, i);
@@ -12670,6 +12721,9 @@ static int do_openat(void *cpu_env, int dirfd, const char *pathname, int flags, 
         { "stat", open_self_stat, is_proc_myself },
         { "auxv", open_self_auxv, is_proc_myself },
         { "cmdline", open_self_cmdline, is_proc_myself },
+#ifdef TARGET_X86_64
+        { "environ", open_self_environ, is_proc_myself },
+#endif
         { "cmdline", open_other_cmdline, is_proc_other},
 #ifndef CONFIG_LOONGARCH_NEW_WORLD
         { "status", open_proc_status, is_proc_other },
@@ -12904,16 +12958,10 @@ static int host_to_target_cpu_mask(const unsigned long *host_mask,
     return 0;
 }
 
-static bool is_x86_file(char *file_name)
+static bool is_x86_elf_fd(int fd)
 {
-    int fd = open(file_name, O_RDONLY);
-    if (fd == -1) {
-        return false;
-    }
-
     Elf64_Ehdr ehdr;
-    int read_size = read(fd, &ehdr, sizeof(ehdr));
-    close(fd);
+    ssize_t read_size = pread(fd, &ehdr, sizeof(ehdr), 0);
 
     if (read_size != sizeof(ehdr)) {
         return false;
@@ -12926,6 +12974,49 @@ static bool is_x86_file(char *file_name)
 
     return (ehdr.e_machine == EM_386) || (ehdr.e_machine == EM_X86_64);
 }
+
+static bool is_x86_file_at(int dirfd, const char *file_name, int flags)
+{
+    int fd;
+    bool ret;
+
+    if (!file_name[0] && (flags & AT_EMPTY_PATH)) {
+        return is_x86_elf_fd(dirfd);
+    }
+    fd = openat(dirfd, path(file_name), O_RDONLY | O_CLOEXEC);
+    if (fd < 0) {
+        return false;
+    }
+    ret = is_x86_elf_fd(fd);
+    close(fd);
+    return ret;
+}
+
+#ifdef TARGET_X86_64
+static bool is_self_file_at(int dirfd, const char *file_name, int flags)
+{
+    struct stat target_st, self_st;
+    int fd = -1;
+    bool ret;
+
+    if (!file_name[0] && (flags & AT_EMPTY_PATH)) {
+        fd = dirfd;
+    } else {
+        fd = openat(dirfd, path(file_name), O_PATH | O_CLOEXEC);
+        if (fd < 0) {
+            return false;
+        }
+    }
+    ret = fstat(fd, &target_st) == 0 &&
+          stat("/proc/self/exe", &self_st) == 0 &&
+          target_st.st_dev == self_st.st_dev &&
+          target_st.st_ino == self_st.st_ino;
+    if (fd != dirfd) {
+        close(fd);
+    }
+    return ret;
+}
+#endif
 
 static abi_long do_prctl_syscall_user_dispatch(CPUArchState *env,
                                                abi_ulong mode,
@@ -12942,9 +13033,12 @@ static abi_long do_prctl_syscall_user_dispatch(CPUArchState *env,
             return -TARGET_EINVAL;
         }
         ts->sys_dispatch_len = -1;
+        ts->sys_dispatch_inclusive = false;
         return 0;
     case PR_SYS_DISPATCH_ON:
-        if (offset && offset + length <= offset) {
+    case PR_SYS_DISPATCH_INCLUSIVE_ON:
+        if ((mode == PR_SYS_DISPATCH_INCLUSIVE_ON && !length) ||
+            (offset && offset + length <= offset)) {
             return -TARGET_EINVAL;
         }
         if (selector && !access_ok(cpu, VERIFY_READ, selector, 1)) {
@@ -12953,6 +13047,8 @@ static abi_long do_prctl_syscall_user_dispatch(CPUArchState *env,
         ts->sys_dispatch = offset;
         ts->sys_dispatch_len = length;
         ts->sys_dispatch_selector = selector;
+        ts->sys_dispatch_inclusive =
+            mode == PR_SYS_DISPATCH_INCLUSIVE_ON;
         return 0;
     default:
         return -TARGET_EINVAL;
@@ -13157,7 +13253,6 @@ static abi_long guest_prctl_set_auxv(struct image_info *info,
 
 struct guest_prctl_exe_file {
     int fd;
-    char *path;
 };
 
 static abi_long guest_prctl_prepare_exe_file(unsigned int fd,
@@ -13165,13 +13260,9 @@ static abi_long guest_prctl_prepare_exe_file(unsigned int fd,
 {
     struct stat st;
     struct statvfs fs;
-    char fd_path[64];
-    char path[PATH_MAX];
-    ssize_t path_len;
     int saved_fd;
 
     file->fd = -1;
-    file->path = NULL;
 
     if (fstat(fd, &st) < 0) {
         return get_errno(-1);
@@ -13188,16 +13279,7 @@ static abi_long guest_prctl_prepare_exe_file(unsigned int fd,
     if (saved_fd < 0) {
         return get_errno(-1);
     }
-    snprintf(fd_path, sizeof(fd_path), "/proc/self/fd/%d", fd);
-    path_len = readlink(fd_path, path, sizeof(path) - 1);
-    if (path_len < 0) {
-        close(saved_fd);
-        return get_errno(-1);
-    }
-    path[path_len] = 0;
-
     file->fd = saved_fd;
-    file->path = g_strdup(path);
     return 0;
 }
 
@@ -13206,16 +13288,12 @@ static void guest_prctl_commit_exe_file(struct image_info *info,
                                         struct guest_prctl_exe_file *file)
 {
     int old_fd = info->prctl_mm_exe_fd;
-    char *old_path = info->prctl_mm_exe_path;
 
     info->prctl_mm_exe_fd = file->fd;
-    info->prctl_mm_exe_path = file->path;
     file->fd = -1;
-    file->path = NULL;
     if (old_fd >= 0) {
         close(old_fd);
     }
-    g_free(old_path);
 }
 
 static abi_long guest_prctl_set_exe_file(struct image_info *info,
@@ -13653,16 +13731,18 @@ static bool guest_prctl_exec_env_reserved(const char *entry, const char *name)
 }
 
 static char **prepare_guest_prctl_exec_env(CPUArchState *env, char **envp,
-                                           int envc, char **mdwe_env,
-                                           char **tsc_env)
+                                           int envc, bool restore,
+                                           char **mdwe_env, char **tsc_env)
 {
     char **exec_envp;
     int kept = 0;
     int extra = 0;
     int i;
 
-    *mdwe_env = guest_prctl_exec_env(env, LATX_GUEST_MDWE_ENV);
-    *tsc_env = guest_prctl_exec_env(env, LATX_GUEST_TSC_ENV);
+    *mdwe_env = restore ?
+        guest_prctl_exec_env(env, LATX_GUEST_MDWE_ENV) : NULL;
+    *tsc_env = restore ?
+        guest_prctl_exec_env(env, LATX_GUEST_TSC_ENV) : NULL;
     extra += *mdwe_env != NULL;
     extra += *tsc_env != NULL;
     exec_envp = g_new(char *, envc + extra + 1);
@@ -13683,7 +13763,8 @@ static char **prepare_guest_prctl_exec_env(CPUArchState *env, char **envp,
 }
 #endif
 
-/* This is an internal helper for do_syscall so that it is easier
+/*
+ * This is an internal helper for do_syscall so that it is easier
  * to have a single return point, so that actions, such as logging
  * of syscall results, can be performed.
  * All errnos that do_syscall() returns must be -TARGET_<errcode>.
@@ -13994,24 +14075,25 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
             }
             *q = NULL;
 
-#ifdef TARGET_X86_64
-            exec_envp = prepare_guest_prctl_exec_env(env, envp, envc,
-                                                     &prctl_mdwe_env,
-                                                     &prctl_tsc_env);
-#else
-            exec_envp = envp;
-#endif
-
             p = lock_user_string(arg2);
             if (!(p)) {
                 goto execveat_efault;
             }
 
-            char* pname = strrchr(p, '/');
-            bool x86_file;
-            if (p) {
-                x86_file = is_x86_file(p);
-            }
+            char *pname = strrchr(p, '/');
+            bool self_exe = is_proc_myself((const char *)p, "exe");
+            bool x86_file = self_exe || is_x86_file_at(arg1, p, arg5);
+#ifdef TARGET_X86_64
+            bool restore_prctl = x86_file ||
+                                 is_self_file_at(arg1, p, arg5);
+
+            exec_envp = prepare_guest_prctl_exec_env(env, envp, envc,
+                                                     restore_prctl,
+                                                     &prctl_mdwe_env,
+                                                     &prctl_tsc_env);
+#else
+            exec_envp = envp;
+#endif
             if (argp[0] && p && pname && strcmp(p, argp[0]) &&
                     strcmp(pname + 1, argp[0]) && x86_file) {
                 argc = argc + 3;
@@ -14065,7 +14147,7 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
              * before the execve completes and makes it the other
              * program's problem.
              */
-            if (is_proc_myself((const char *)p, "exe")) {
+            if (self_exe) {
                 char exe_path_buffer[64];
                 const char *exe_pathname;
                 int exe_fd;
@@ -14086,7 +14168,7 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
                 ret = get_errno(safe_execveat(arg1, p, argp, exec_envp,
                                               arg5));
             }
-            unlock_user(p, arg1, 0);
+            unlock_user(p, arg2, 0);
 
             goto execveat_end;
 
@@ -14180,22 +14262,26 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
             }
             *q = NULL;
 
+            p = lock_user_string(arg1);
+            if (!p) {
+                goto execve_efault;
+            }
+
+            char *pname = strrchr(p, '/');
+            bool self_exe = is_proc_myself((const char *)p, "exe");
+            bool x86_file = self_exe ||
+                            is_x86_file_at(AT_FDCWD, p, 0);
 #ifdef TARGET_X86_64
+            bool restore_prctl = x86_file ||
+                                 is_self_file_at(AT_FDCWD, p, 0);
+
             exec_envp = prepare_guest_prctl_exec_env(env, envp, envc,
+                                                     restore_prctl,
                                                      &prctl_mdwe_env,
                                                      &prctl_tsc_env);
 #else
             exec_envp = envp;
 #endif
-
-            if (!(p = lock_user_string(arg1)))
-                goto execve_efault;
-
-            char* pname = strrchr(p, '/');
-            bool x86_file;
-            if (p) {
-                x86_file = is_x86_file(p);
-            }
             if (argp[0] && p && pname && strcmp(p, argp[0]) &&
                     strcmp(pname + 1, argp[0]) && x86_file) {
                 argc = argc + 3;
@@ -14238,7 +14324,7 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
                 }
             }
 
-            if (is_proc_myself((const char *)p, "exe")) {
+            if (self_exe) {
                 char real[PATH_MAX];
                 char exe_path_buffer[64];
                 const char *temp;
@@ -20086,7 +20172,8 @@ static bool syscall_user_dispatch(CPUArchState *env, int num, uint32_t arch)
     }
 
     cpu_get_tb_cpu_state(env, &pc, &cs_base, &flags);
-    if (likely(pc - ts->sys_dispatch < ts->sys_dispatch_len)) {
+    if (likely((pc - ts->sys_dispatch < ts->sys_dispatch_len) !=
+               ts->sys_dispatch_inclusive)) {
         return false;
     }
     if (unlikely(pc == default_sigreturn || pc == default_rt_sigreturn)) {

--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -340,6 +340,14 @@ out_marker:
 #endif
 #ifndef PR_RSEQ_SLICE_EXTENSION
 #define PR_RSEQ_SLICE_EXTENSION 79
+#define PR_RSEQ_SLICE_EXTENSION_GET 1
+#define PR_RSEQ_SLICE_EXTENSION_SET 2
+#define PR_RSEQ_SLICE_EXT_ENABLE 0x01
+#endif
+#ifndef PR_GET_CFI
+#define PR_GET_CFI 80
+#define PR_SET_CFI 81
+#define PR_CFI_BRANCH_LANDING_PADS 0
 #endif
 #ifdef CONFIG_LATX
 #define IMAGE_NT_SIGNATURE 0x00004550
@@ -962,17 +970,23 @@ _syscall4(int, sys_prlimit64, pid_t, pid, int, resource,
 #define TIMER_MAGIC 0x0caf0000
 static timer_t g_posix_timers[32];
 static target_timer_t g_posix_timer_ids[32];
-static bool g_posix_timer_used[32];
+typedef enum PosixTimerSlotState {
+    POSIX_TIMER_FREE,
+    POSIX_TIMER_RESERVED,
+    POSIX_TIMER_ACTIVE,
+} PosixTimerSlotState;
+static PosixTimerSlotState g_posix_timer_state[32];
 static pthread_mutex_t posix_timer_lock = PTHREAD_MUTEX_INITIALIZER;
 
-static int reserve_host_timer(target_timer_t requested, bool exact)
+static int reserve_host_timer(target_timer_t requested, bool exact,
+                              target_timer_t *allocated)
 {
     int free_slot = -1;
     int k;
 
     pthread_mutex_lock(&posix_timer_lock);
     for (k = 0; k < ARRAY_SIZE(g_posix_timers); k++) {
-        if (g_posix_timer_used[k]) {
+        if (g_posix_timer_state[k] != POSIX_TIMER_FREE) {
             if (exact && g_posix_timer_ids[k] == requested) {
                 pthread_mutex_unlock(&posix_timer_lock);
                 return -TARGET_EBUSY;
@@ -986,7 +1000,7 @@ static int reserve_host_timer(target_timer_t requested, bool exact)
             }
             requested = TIMER_MAGIC | k;
             for (j = 0; j < ARRAY_SIZE(g_posix_timers); j++) {
-                if (g_posix_timer_used[j] &&
+                if (g_posix_timer_state[j] != POSIX_TIMER_FREE &&
                     g_posix_timer_ids[j] == requested) {
                     break;
                 }
@@ -1001,18 +1015,37 @@ static int reserve_host_timer(target_timer_t requested, bool exact)
         return -TARGET_EAGAIN;
     }
 
-    g_posix_timer_used[free_slot] = true;
+    g_posix_timer_state[free_slot] = POSIX_TIMER_RESERVED;
     g_posix_timer_ids[free_slot] = requested;
+    *allocated = requested;
     pthread_mutex_unlock(&posix_timer_lock);
     return free_slot;
 }
 
-static void release_host_timer(int slot)
+static bool publish_host_timer(int slot, target_timer_t timerid, timer_t timer)
+{
+    bool reserved;
+
+    pthread_mutex_lock(&posix_timer_lock);
+    reserved = g_posix_timer_state[slot] == POSIX_TIMER_RESERVED &&
+               g_posix_timer_ids[slot] == timerid;
+    if (reserved) {
+        g_posix_timers[slot] = timer;
+        g_posix_timer_state[slot] = POSIX_TIMER_ACTIVE;
+    }
+    pthread_mutex_unlock(&posix_timer_lock);
+    return reserved;
+}
+
+static void release_host_timer(int slot, target_timer_t timerid)
 {
     pthread_mutex_lock(&posix_timer_lock);
-    g_posix_timer_used[slot] = false;
-    g_posix_timer_ids[slot] = 0;
-    g_posix_timers[slot] = (timer_t)0;
+    if (g_posix_timer_state[slot] == POSIX_TIMER_RESERVED &&
+        g_posix_timer_ids[slot] == timerid) {
+        g_posix_timer_state[slot] = POSIX_TIMER_FREE;
+        g_posix_timer_ids[slot] = 0;
+        g_posix_timers[slot] = (timer_t)0;
+    }
     pthread_mutex_unlock(&posix_timer_lock);
 }
 
@@ -1029,7 +1062,7 @@ static void posix_timer_fork_end(bool child)
     }
 
     pthread_mutex_init(&posix_timer_lock, NULL);
-    memset(g_posix_timer_used, 0, sizeof(g_posix_timer_used));
+    memset(g_posix_timer_state, 0, sizeof(g_posix_timer_state));
     memset(g_posix_timer_ids, 0, sizeof(g_posix_timer_ids));
     memset(g_posix_timers, 0, sizeof(g_posix_timers));
 }
@@ -5896,7 +5929,7 @@ abi_ulong latx_is_shm(abi_ulong maddr)
     }
     return 0;
 }
-#ifdef TARGET_X86_64
+#ifdef TARGET_I386
 static abi_long guest_mdwe_mmap(CPUState *cpu, abi_ulong len, int prot);
 #endif
 static inline abi_ulong do_shmat(CPUArchState *cpu_env,
@@ -5933,7 +5966,7 @@ static inline abi_ulong do_shmat(CPUArchState *cpu_env,
 
     mmap_lock();
 
-#ifdef TARGET_X86_64
+#ifdef TARGET_I386
     ret = guest_mdwe_mmap(cpu, shm_info.shm_segsz,
                           PROT_READ |
                           (shmflg & SHM_RDONLY ? 0 : PROT_WRITE) |
@@ -5981,7 +6014,7 @@ static inline abi_ulong do_shmat(CPUArchState *cpu_env,
     }
     raddr=h2g((unsigned long)host_raddr);
 
-#ifdef TARGET_X86_64
+#ifdef TARGET_I386
     guest_vma_name_reset(raddr, shm_info.shm_segsz);
 #endif
     page_set_flags(raddr, raddr + shm_info.shm_segsz,
@@ -6017,7 +6050,7 @@ static inline abi_long do_shmdt(abi_ulong shmaddr)
     if (!is_error(rv)) {
         for (i = 0; i < N_SHM_REGIONS; ++i) {
             if (shm_regions[i].in_use && shm_regions[i].start == shmaddr) {
-#ifdef TARGET_X86_64
+#ifdef TARGET_I386
                 guest_vma_name_reset(shmaddr, shm_regions[i].size);
 #endif
                 page_set_flags(shmaddr, shmaddr + shm_regions[i].size, 0);
@@ -9894,12 +9927,18 @@ static int do_fork(CPUArchState *env, unsigned int flags, abi_ulong newsp,
                 put_user_u32(sys_gettid(), child_tidptr);
             ts = (TaskState *)cpu->opaque;
             /* Linux clears syscall user dispatch in every fork child. */
+#ifdef TARGET_I386
             ts->sys_dispatch = 0;
             ts->sys_dispatch_selector = 0;
             ts->sys_dispatch_len = -1;
             ts->sys_dispatch_inclusive = false;
+#endif
             ts->child_tidptr = 0;
-#ifdef TARGET_X86_64
+#ifdef TARGET_I386
+            if (!(flags & CLONE_VM) &&
+                (ts->info->prctl_mdwe & TARGET_PR_MDWE_NO_INHERIT)) {
+                ts->info->prctl_mdwe = 0;
+            }
             ts->info->prctl_timer_restore_ids = false;
             ts->info->prctl_futex_hash_slots = 0;
             ts->info->prctl_futex_hash_custom = false;
@@ -11341,7 +11380,7 @@ static void regs_to_seccomp_trace(const struct target_pt_regs *regs,
 }
 #endif
 
-#ifdef TARGET_X86_64
+#ifdef TARGET_I386
 static int write_guest_proc_range(int fd, abi_ulong start, abi_ulong end)
 {
     while (start < end) {
@@ -11367,7 +11406,7 @@ static int write_guest_proc_range(int fd, abi_ulong start, abi_ulong end)
 static int open_self_cmdline(void *cpu_env, int fd, const char *oldpath)
 {
     CPUState *cpu = env_cpu((CPUArchState *)cpu_env);
-#ifdef TARGET_X86_64
+#ifdef TARGET_I386
     struct image_info *info = ((TaskState *)cpu->opaque)->info;
     abi_ulong start, end, env_end;
     uint8_t last = 0;
@@ -11400,7 +11439,7 @@ static int open_self_cmdline(void *cpu_env, int fd, const char *oldpath)
     return 0;
 }
 
-#ifdef TARGET_X86_64
+#ifdef TARGET_I386
 static int open_self_environ(void *cpu_env, int fd, const char *oldpath)
 {
     TaskState *ts = env_cpu((CPUArchState *)cpu_env)->opaque;
@@ -11418,7 +11457,7 @@ static const char *guest_self_exe_open_path(CPUArchState *env, char *buffer,
                                             size_t size, int *owned_fd)
 {
     *owned_fd = -1;
-#ifdef TARGET_X86_64
+#ifdef TARGET_I386
     TaskState *ts = env_cpu(env)->opaque;
     bool overridden;
 
@@ -11442,7 +11481,7 @@ static const char *guest_self_exe_open_path(CPUArchState *env, char *buffer,
 static const char *guest_self_exe_link_path(CPUArchState *env,
                                             char *buffer, size_t size)
 {
-#ifdef TARGET_X86_64
+#ifdef TARGET_I386
     TaskState *ts = env_cpu(env)->opaque;
     char fd_path[64];
     bool overridden;
@@ -11479,7 +11518,7 @@ static bool guest_self_exe_exec_paths(CPUArchState *env, char *link_buffer,
                                       const char **open_path, int *owned_fd)
 {
     *owned_fd = -1;
-#ifdef TARGET_X86_64
+#ifdef TARGET_I386
     TaskState *ts = env_cpu(env)->opaque;
     bool overridden;
     ssize_t len;
@@ -11745,7 +11784,7 @@ struct open_self_maps_data {
     bool smaps;
 };
 
-#ifdef TARGET_X86_64
+#ifdef TARGET_I386
 typedef struct GuestVmaName {
     abi_ulong start;
     abi_ulong end;
@@ -11944,7 +11983,7 @@ static void open_self_maps_4_line(const struct open_self_maps_data *d,
         path = named_path;
     } else if (test_stack(start, end, info->stack_limit)) {
         path = "[stack]";
-#ifdef TARGET_X86_64
+#ifdef TARGET_I386
     } else if (start == info->prctl_mm_start_brk) {
         path = "[heap]";
 #else
@@ -12026,7 +12065,7 @@ static void open_self_maps_4(const struct open_self_maps_data *d,
                              const MapInfo *mi, abi_ptr start,
                              abi_ptr end, unsigned flags)
 {
-#ifdef TARGET_X86_64
+#ifdef TARGET_I386
     while (start < end) {
         abi_ulong next;
         const GuestVmaName *entry = guest_vma_name_find_locked(start, &next);
@@ -12146,7 +12185,7 @@ static int open_self_maps_1(CPUArchState *cpu_env, int fd, bool smaps)
     CPUState *cpu = env_cpu((CPUArchState *)cpu_env);
     TaskState *ts = cpu->opaque;
     IntervalTreeRoot *map_info = read_self_maps();
-#ifdef TARGET_X86_64
+#ifdef TARGET_I386
     struct open_self_maps_data data = {
         .ts = ts,
         .host_maps = map_info,
@@ -12167,7 +12206,7 @@ static int open_self_maps_1(CPUArchState *cpu_env, int fd, bool smaps)
             unsigned long max = e->itree.last + 1;
             int flags = page_get_flags(h2g(min));
             const char *path;
-#ifdef TARGET_X86_64
+#ifdef TARGET_I386
             abi_ulong next_name;
             const GuestVmaName *name;
 #endif
@@ -12179,7 +12218,7 @@ static int open_self_maps_1(CPUArchState *cpu_env, int fd, bool smaps)
                 continue;
             }
 
-#ifdef TARGET_X86_64
+#ifdef TARGET_I386
             name = guest_vma_name_find_locked(h2g(min), &next_name);
             if (name || next_name < h2g(max - 1) + 1) {
                 open_self_maps_4(&data, e, h2g(min), h2g(max - 1) + 1,
@@ -12247,7 +12286,7 @@ static int open_self_maps_1(CPUArchState *cpu_env, int fd, bool smaps)
 
 static int open_self_maps(void *cpu_env, int fd, const char *oldpath)
 {
-#ifdef TARGET_X86_64
+#ifdef TARGET_I386
     bool have_guest_vma_names;
 
     mmap_lock();
@@ -12263,7 +12302,7 @@ static int open_self_maps(void *cpu_env, int fd, const char *oldpath)
 
 static int open_self_smaps(void *cpu_env, int fd, const char *oldpath)
 {
-#ifdef TARGET_X86_64
+#ifdef TARGET_I386
     bool have_guest_vma_names;
 
     mmap_lock();
@@ -12309,7 +12348,7 @@ static int open_self_stat(void *cpu_env, int fd, const char *oldpath)
     char *word = NULL;
     size_t orig_len = 0;
     int word_len = 0;
-#ifdef TARGET_X86_64
+#ifdef TARGET_I386
     struct {
         abi_ulong start_code;
         abi_ulong end_code;
@@ -12357,7 +12396,7 @@ static int open_self_stat(void *cpu_env, int fd, const char *oldpath)
         word = strchr(orig, ' ');
 
         /* last word */
-        if (NULL == word) {
+        if (word == NULL) {
             /* Find a pointer to '\0' */
             word = strchr(orig, '\0');
             if (word == NULL) {
@@ -12380,7 +12419,7 @@ static int open_self_stat(void *cpu_env, int fd, const char *oldpath)
             /* Hide translator-only threads from the guest process view. */
             g_string_printf(buf, "%u ", latx_guest_thread_count());
 #endif
-#ifdef TARGET_X86_64
+#ifdef TARGET_I386
         } else if (i == 25) {
             g_string_printf(buf, TARGET_ABI_FMT_ld " ",
                             mm.start_code);
@@ -12447,20 +12486,24 @@ static int open_self_auxv(void *cpu_env, int fd, const char *oldpath)
 {
     CPUState *cpu = env_cpu((CPUArchState *)cpu_env);
     TaskState *ts = cpu->opaque;
-#ifdef TARGET_X86_64
-    abi_ulong auxv[TARGET_X86_64_PRCTL_AUXV_WORDS];
-    size_t words;
+#ifdef TARGET_I386
+    uint8_t auxv[TARGET_X86_PRCTL_AUXV_SIZE];
+    size_t offset;
     size_t len;
 
     mmap_lock();
     memcpy(auxv, ts->info->prctl_auxv, sizeof(auxv));
     mmap_unlock();
-    for (words = 0; words + 1 < ARRAY_SIZE(auxv); words += 2) {
-        if (auxv[words] == 0) {
+    for (offset = 0; offset + 2 * sizeof(abi_ulong) <= sizeof(auxv);
+         offset += 2 * sizeof(abi_ulong)) {
+        abi_ulong type;
+
+        memcpy(&type, auxv + offset, sizeof(type));
+        if (tswapal(type) == 0) {
             break;
         }
     }
-    len = MIN(words + 2, ARRAY_SIZE(auxv)) * sizeof(auxv[0]);
+    len = MIN(offset + 2 * sizeof(abi_ulong), sizeof(auxv));
     if (qemu_write_full(fd, auxv, len) != len) {
         return -1;
     }
@@ -12799,7 +12842,7 @@ static int do_openat(void *cpu_env, int dirfd, const char *pathname, int flags, 
         { "stat", open_self_stat, is_proc_myself },
         { "auxv", open_self_auxv, is_proc_myself },
         { "cmdline", open_self_cmdline, is_proc_myself },
-#ifdef TARGET_X86_64
+#ifdef TARGET_I386
         { "environ", open_self_environ, is_proc_myself },
 #endif
         { "cmdline", open_other_cmdline, is_proc_other},
@@ -12963,7 +13006,8 @@ static target_timer_t lock_host_timer(abi_long arg)
 
     pthread_mutex_lock(&posix_timer_lock);
     for (k = 0; k < ARRAY_SIZE(g_posix_timers); k++) {
-        if (g_posix_timer_used[k] && g_posix_timer_ids[k] == timerid) {
+        if (g_posix_timer_state[k] == POSIX_TIMER_ACTIVE &&
+            g_posix_timer_ids[k] == timerid) {
             return k;
         }
     }
@@ -13041,7 +13085,20 @@ static int host_to_target_cpu_mask(const unsigned long *host_mask,
 static bool is_x86_elf_fd(int fd)
 {
     Elf64_Ehdr ehdr;
-    ssize_t read_size = pread(fd, &ehdr, sizeof(ehdr), 0);
+    char fd_path[64];
+    int read_fd = fd;
+    ssize_t read_size;
+
+    read_size = pread(read_fd, &ehdr, sizeof(ehdr), 0);
+    if (read_size < 0 && errno == EBADF) {
+        snprintf(fd_path, sizeof(fd_path), "/proc/self/fd/%d", fd);
+        read_fd = open(fd_path, O_RDONLY | O_CLOEXEC);
+        if (read_fd < 0) {
+            return false;
+        }
+        read_size = pread(read_fd, &ehdr, sizeof(ehdr), 0);
+        close(read_fd);
+    }
 
     if (read_size != sizeof(ehdr)) {
         return false;
@@ -13058,13 +13115,15 @@ static bool is_x86_elf_fd(int fd)
 static int open_exec_inspection_file(int dirfd, const char *file_name,
                                      int flags)
 {
-    char fd_path[64];
+    int open_flags = O_RDONLY | O_CLOEXEC;
 
     if (!file_name[0] && (flags & AT_EMPTY_PATH)) {
-        snprintf(fd_path, sizeof(fd_path), "/proc/self/fd/%d", dirfd);
-        return open(fd_path, O_RDONLY | O_CLOEXEC);
+        return fcntl(dirfd, F_DUPFD_CLOEXEC, 0);
     }
-    return openat(dirfd, file_name, O_RDONLY | O_CLOEXEC);
+    if (flags & AT_SYMLINK_NOFOLLOW) {
+        open_flags |= O_NOFOLLOW;
+    }
+    return openat(dirfd, file_name, open_flags);
 }
 
 static bool is_x86_file_at(int dirfd, const char *file_name, int flags)
@@ -13081,117 +13140,284 @@ static bool is_x86_file_at(int dirfd, const char *file_name, int flags)
     return ret;
 }
 
-#ifdef TARGET_X86_64
-static bool is_self_file_at(int dirfd, const char *file_name, int flags)
+#ifdef TARGET_I386
+static bool is_self_exec_fd(int fd)
 {
     struct stat target_st, self_st;
-    int fd;
-    bool owned = false;
-    bool ret;
 
-    if (!file_name[0] && (flags & AT_EMPTY_PATH)) {
-        fd = dirfd;
-    } else {
-        fd = openat(dirfd, file_name, O_PATH | O_CLOEXEC);
-        if (fd < 0) {
-            return false;
+    return fstat(fd, &target_st) == 0 &&
+           stat("/proc/self/exe", &self_st) == 0 &&
+           target_st.st_dev == self_st.st_dev &&
+           target_st.st_ino == self_st.st_ino;
+}
+
+typedef enum GuestScriptParseResult {
+    GUEST_SCRIPT_NONE,
+    GUEST_SCRIPT_VALID,
+    GUEST_SCRIPT_INVALID,
+} GuestScriptParseResult;
+
+#define GUEST_EXEC_MAX_SCRIPTS 5
+
+typedef struct GuestExecScript {
+    int fd;
+    char *fd_path;
+    char *interpreter;
+    char *argument;
+} GuestExecScript;
+
+typedef struct GuestExecResolution {
+    int terminal_fd;
+    bool initial_is_x86;
+    bool restore_prctl;
+    unsigned int script_count;
+    GuestExecScript scripts[GUEST_EXEC_MAX_SCRIPTS];
+} GuestExecResolution;
+
+static ssize_t guest_exec_pread(int fd, void *buffer, size_t size)
+{
+    char fd_path[64];
+    int read_fd;
+    ssize_t ret;
+
+    ret = pread(fd, buffer, size, 0);
+    if (ret >= 0 || errno != EBADF) {
+        return ret;
+    }
+    snprintf(fd_path, sizeof(fd_path), "/proc/self/fd/%d", fd);
+    read_fd = open(fd_path, O_RDONLY | O_CLOEXEC);
+    if (read_fd < 0) {
+        return -1;
+    }
+    ret = pread(read_fd, buffer, size, 0);
+    close(read_fd);
+    return ret;
+}
+
+static const char *guest_script_nonspace(const char *first, const char *last)
+{
+    while (first <= last) {
+        if (*first != ' ' && *first != '\t') {
+            return first;
         }
-        owned = true;
+        first++;
     }
-    ret = fstat(fd, &target_st) == 0 &&
-          stat("/proc/self/exe", &self_st) == 0 &&
-          target_st.st_dev == self_st.st_dev &&
-          target_st.st_ino == self_st.st_ino;
-    if (owned) {
-        close(fd);
-    }
-    return ret;
+    return NULL;
 }
 
-static bool exec_file_restores_guest_state_at(int dirfd,
-                                               const char *file_name,
-                                               int flags, unsigned int depth)
+static const char *guest_script_terminator(const char *first,
+                                           const char *last)
 {
-    char header[256];
-    char interpreter[PATH_MAX];
-    ssize_t len;
-    size_t start, end;
+    while (first <= last) {
+        if (*first == ' ' || *first == '\t' || *first == '\0') {
+            return first;
+        }
+        first++;
+    }
+    return NULL;
+}
+
+static GuestScriptParseResult guest_exec_parse_script(int fd,
+                                                       char **interpreter,
+                                                       char **argument)
+{
+    char header[256] = { 0 };
+    const char *buffer_end = header + sizeof(header) - 1;
+    const char *name, *separator, *arg, *end;
+    ssize_t len = guest_exec_pread(fd, header, sizeof(header));
+
+    *interpreter = NULL;
+    *argument = NULL;
+    if (len < 2 || header[0] != '#' || header[1] != '!') {
+        return GUEST_SCRIPT_NONE;
+    }
+    end = memchr(header, '\n', sizeof(header));
+    if (!end) {
+        end = guest_script_nonspace(header + 2, buffer_end);
+        if (!end || !guest_script_terminator(end, buffer_end)) {
+            return GUEST_SCRIPT_INVALID;
+        }
+        end = buffer_end;
+    }
+    while (end > header + 2 && (end[-1] == ' ' || end[-1] == '\t')) {
+        end--;
+    }
+    name = guest_script_nonspace(header + 2, end);
+    if (!name || name == end || *name == '\0') {
+        return GUEST_SCRIPT_INVALID;
+    }
+    separator = guest_script_terminator(name, end);
+    if (!separator) {
+        separator = end;
+    }
+    *interpreter = g_strndup(name, separator - name);
+    if (separator < end && *separator != '\0') {
+        arg = guest_script_nonspace(separator, end);
+        if (arg && arg < end && *arg != '\0') {
+            *argument = g_strndup(arg, end - arg);
+        }
+    }
+    return GUEST_SCRIPT_VALID;
+}
+
+static int guest_self_exe_dup_fd(CPUArchState *env)
+{
+    char path_buffer[64];
+    const char *exe_pathname;
+    int owned_fd;
+
+    exe_pathname = guest_self_exe_open_path(env, path_buffer,
+                                            sizeof(path_buffer), &owned_fd);
+    if (!exe_pathname) {
+        return -1;
+    }
+    if (owned_fd >= 0) {
+        return owned_fd;
+    }
+    return open(exe_pathname, O_RDONLY | O_CLOEXEC);
+}
+
+static void guest_exec_resolution_cleanup(GuestExecResolution *resolution)
+{
+    unsigned int i;
+
+    if (resolution->terminal_fd >= 0) {
+        close(resolution->terminal_fd);
+    }
+    for (i = 0; i < resolution->script_count; i++) {
+        close(resolution->scripts[i].fd);
+        g_free(resolution->scripts[i].fd_path);
+        g_free(resolution->scripts[i].interpreter);
+        g_free(resolution->scripts[i].argument);
+    }
+    memset(resolution, 0, sizeof(*resolution));
+    resolution->terminal_fd = -1;
+}
+
+static int guest_exec_resolve(CPUArchState *env, int dirfd,
+                              const char *file_name, int flags,
+                              bool self_exe, GuestExecResolution *resolution)
+{
+    int fd_flags;
     int fd;
 
-    if (depth > 4 || is_self_file_at(dirfd, file_name, flags)) {
-        return depth <= 4;
+    memset(resolution, 0, sizeof(*resolution));
+    resolution->terminal_fd = -1;
+    if (flags & ~(AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW)) {
+        errno = EINVAL;
+        return -1;
     }
-    fd = open_exec_inspection_file(dirfd, file_name, flags);
+    fd = self_exe ? guest_self_exe_dup_fd(env) :
+         open_exec_inspection_file(dirfd, file_name, flags);
     if (fd < 0) {
-        return false;
+        return -1;
     }
-    if (is_x86_elf_fd(fd)) {
-        close(fd);
-        return true;
-    }
-    len = pread(fd, header, sizeof(header), 0);
-    close(fd);
-    if (len < 2 || header[0] != '#' || header[1] != '!') {
-        return false;
-    }
+    resolution->initial_is_x86 = is_x86_elf_fd(fd);
+    while (true) {
+        GuestExecScript *script;
+        GuestScriptParseResult parsed;
+        char *interpreter;
+        char *argument;
+        int interpreter_fd;
 
-    start = 2;
-    while (start < len && (header[start] == ' ' || header[start] == '\t')) {
-        start++;
+        parsed = guest_exec_parse_script(fd, &interpreter, &argument);
+        if (parsed != GUEST_SCRIPT_VALID) {
+            resolution->terminal_fd = fd;
+            resolution->restore_prctl = is_x86_elf_fd(fd) ||
+                                         is_self_exec_fd(fd);
+            return 0;
+        }
+        if (resolution->script_count == GUEST_EXEC_MAX_SCRIPTS) {
+            g_free(interpreter);
+            g_free(argument);
+            close(fd);
+            errno = ELOOP;
+            guest_exec_resolution_cleanup(resolution);
+            return -1;
+        }
+        interpreter_fd = open(interpreter, O_RDONLY | O_CLOEXEC);
+        if (interpreter_fd < 0) {
+            int saved_errno = errno;
+
+            g_free(interpreter);
+            g_free(argument);
+            close(fd);
+            guest_exec_resolution_cleanup(resolution);
+            errno = saved_errno;
+            return -1;
+        }
+        /*
+         * Linux requires the script fd to survive execveat(AT_EMPTY_PATH):
+         * closing it during exec makes /proc/self/fd/N unavailable to the
+         * interpreter and yields ENOENT.  Keep one carrier fd per script
+         * layer.  GUEST_EXEC_MAX_SCRIPTS bounds one resolution; as with
+         * native execveat(), the interpreter owns the inherited fd lifetime.
+         */
+        fd_flags = fcntl(fd, F_GETFD);
+        if (fd_flags < 0 || fcntl(fd, F_SETFD, fd_flags & ~FD_CLOEXEC) < 0) {
+            int saved_errno = errno;
+
+            g_free(interpreter);
+            g_free(argument);
+            close(interpreter_fd);
+            close(fd);
+            guest_exec_resolution_cleanup(resolution);
+            errno = saved_errno;
+            return -1;
+        }
+        script = &resolution->scripts[resolution->script_count++];
+        script->fd = fd;
+        script->fd_path = g_strdup_printf("/proc/self/fd/%d", fd);
+        script->interpreter = interpreter;
+        script->argument = argument;
+        fd = interpreter_fd;
     }
-    end = start;
-    while (end < len && header[end] != ' ' && header[end] != '\t' &&
-           header[end] != '\n' && header[end] != '\r') {
-        end++;
-    }
-    if (end == start || end - start >= sizeof(interpreter)) {
-        return false;
-    }
-    memcpy(interpreter, header + start, end - start);
-    interpreter[end - start] = 0;
-    return exec_file_restores_guest_state_at(AT_FDCWD, interpreter, 0,
-                                              depth + 1);
 }
 
-static bool guest_self_exe_restores_guest_state(CPUArchState *env)
+static char **guest_exec_script_argv(const GuestExecResolution *resolution,
+                                     char **argp)
 {
-    char path_buffer[64];
-    const char *exe_pathname;
-    bool ret;
-    int owned_fd;
+    char **current = argp;
+    size_t current_count = g_strv_length(current);
+    unsigned int i;
 
-    exe_pathname = guest_self_exe_open_path(env, path_buffer,
-                                            sizeof(path_buffer), &owned_fd);
-    if (!exe_pathname) {
-        return false;
+    for (i = 0; i < resolution->script_count; i++) {
+        const GuestExecScript *script = &resolution->scripts[i];
+        size_t tail_count = current_count ? current_count - 1 : 0;
+        size_t prefix_count = script->argument ? 3 : 2;
+        char **next = g_new0(char *, prefix_count + tail_count + 1);
+        size_t pos = 0;
+
+        next[pos++] = script->interpreter;
+        if (script->argument) {
+            next[pos++] = script->argument;
+        }
+        next[pos++] = script->fd_path;
+        if (tail_count) {
+            memcpy(next + pos, current + 1, tail_count * sizeof(*next));
+        }
+        if (current != argp) {
+            g_free(current);
+        }
+        current = next;
+        current_count = prefix_count + tail_count;
     }
-    ret = exec_file_restores_guest_state_at(AT_FDCWD, exe_pathname, 0, 0);
-    if (owned_fd >= 0) {
-        close(owned_fd);
-    }
-    return ret;
+    return current;
 }
 
-static bool guest_self_exe_is_x86(CPUArchState *env)
+static bool guest_prctl_exec_state_active(CPUArchState *env)
 {
-    char path_buffer[64];
-    const char *exe_pathname;
-    bool ret;
-    int owned_fd;
+    TaskState *ts = env_cpu(env)->opaque;
+    unsigned int mdwe;
 
-    exe_pathname = guest_self_exe_open_path(env, path_buffer,
-                                            sizeof(path_buffer), &owned_fd);
-    if (!exe_pathname) {
-        return false;
-    }
-    ret = is_x86_file_at(AT_FDCWD, exe_pathname, 0);
-    if (owned_fd >= 0) {
-        close(owned_fd);
-    }
-    return ret;
+    mmap_lock();
+    mdwe = ts->info->prctl_mdwe;
+    mmap_unlock();
+    return mdwe || (((CPUX86State *)env)->cr[4] & CR4_TSD_MASK);
 }
-#endif
+#endif /* TARGET_I386 */
 
+#ifdef TARGET_I386
 static abi_long do_prctl_syscall_user_dispatch(CPUArchState *env,
                                                abi_ulong mode,
                                                abi_ulong offset,
@@ -13228,8 +13454,9 @@ static abi_long do_prctl_syscall_user_dispatch(CPUArchState *env,
         return -TARGET_EINVAL;
     }
 }
+#endif
 
-#ifdef TARGET_X86_64
+#ifdef TARGET_I386
 typedef struct TargetPrctlMmMap {
     uint64_t start_code;
     uint64_t end_code;
@@ -13289,6 +13516,12 @@ static abi_long do_prctl_get_auxv(CPUArchState *env, abi_ulong addr,
     }
     mmap_unlock();
     return sizeof(info->prctl_auxv);
+}
+
+static void guest_prctl_auxv_terminate(uint8_t *auxv)
+{
+    memset(auxv + TARGET_X86_PRCTL_AUXV_SIZE - 2 * sizeof(uint64_t), 0,
+           2 * sizeof(uint64_t));
 }
 
 static bool guest_has_capability(unsigned int capability)
@@ -13405,7 +13638,7 @@ static abi_long guest_prctl_set_auxv(struct image_info *info,
                                      abi_ulong addr, abi_ulong len,
                                      bool replace_all)
 {
-    abi_ulong auxv[TARGET_X86_64_PRCTL_AUXV_WORDS] = { };
+    uint8_t auxv[TARGET_X86_PRCTL_AUXV_SIZE] = { };
 
     if (len > sizeof(auxv)) {
         return -TARGET_EINVAL;
@@ -13413,8 +13646,7 @@ static abi_long guest_prctl_set_auxv(struct image_info *info,
     if (len && copy_from_user(auxv, addr, len)) {
         return -TARGET_EFAULT;
     }
-    auxv[ARRAY_SIZE(auxv) - 2] = 0;
-    auxv[ARRAY_SIZE(auxv) - 1] = 0;
+    guest_prctl_auxv_terminate(auxv);
     mmap_lock();
     if (replace_all) {
         memcpy(info->prctl_auxv, auxv, sizeof(auxv));
@@ -13511,8 +13743,9 @@ static abi_long do_prctl_set_mm(CPUArchState *env, abi_ulong option,
 
     if (option == PR_SET_MM_MAP) {
         TargetPrctlMmMap *target_map;
-        abi_ulong new_auxv[TARGET_X86_64_PRCTL_AUXV_WORDS] = { };
+        uint8_t new_auxv[TARGET_X86_PRCTL_AUXV_SIZE] = { };
         GuestPrctlExeFile new_exe = { .fd = -1 };
+        uint64_t auxv64;
         abi_ulong auxv;
         uint32_t auxv_size, exe_fd;
         bool replace_exe = false;
@@ -13523,23 +13756,47 @@ static abi_long do_prctl_set_mm(CPUArchState *env, abi_ulong option,
         if (!lock_user_struct(VERIFY_READ, target_map, addr, 1)) {
             return -TARGET_EFAULT;
         }
-        map = (GuestPrctlMmMap) {
-            .start_code = tswap64(target_map->start_code),
-            .end_code = tswap64(target_map->end_code),
-            .start_data = tswap64(target_map->start_data),
-            .end_data = tswap64(target_map->end_data),
-            .start_brk = tswap64(target_map->start_brk),
-            .brk = tswap64(target_map->brk),
-            .start_stack = tswap64(target_map->start_stack),
-            .arg_start = tswap64(target_map->arg_start),
-            .arg_end = tswap64(target_map->arg_end),
-            .env_start = tswap64(target_map->env_start),
-            .env_end = tswap64(target_map->env_end),
-        };
-        auxv = tswap64(target_map->auxv);
+        {
+            const uint64_t values[] = {
+                tswap64(target_map->start_code),
+                tswap64(target_map->end_code),
+                tswap64(target_map->start_data),
+                tswap64(target_map->end_data),
+                tswap64(target_map->start_brk),
+                tswap64(target_map->brk),
+                tswap64(target_map->start_stack),
+                tswap64(target_map->arg_start),
+                tswap64(target_map->arg_end),
+                tswap64(target_map->env_start),
+                tswap64(target_map->env_end),
+            };
+            abi_ulong *fields[] = {
+                &map.start_code, &map.end_code,
+                &map.start_data, &map.end_data,
+                &map.start_brk, &map.brk,
+                &map.start_stack,
+                &map.arg_start, &map.arg_end,
+                &map.env_start, &map.env_end,
+            };
+            size_t i;
+
+            for (i = 0; i < ARRAY_SIZE(values); i++) {
+                if (values[i] > GUEST_ADDR_MAX) {
+                    unlock_user_struct(target_map, addr, 0);
+                    return -TARGET_EINVAL;
+                }
+                *fields[i] = values[i];
+            }
+        }
+        auxv64 = tswap64(target_map->auxv);
         auxv_size = tswap32(target_map->auxv_size);
         exe_fd = tswap32(target_map->exe_fd);
         unlock_user_struct(target_map, addr, 0);
+
+        if (auxv_size && auxv64 > GUEST_ADDR_MAX) {
+            return -TARGET_EINVAL;
+        }
+        auxv = auxv64;
 
         ret = guest_prctl_mm_validate(&map);
         if (ret) {
@@ -13552,8 +13809,7 @@ static abi_long do_prctl_set_mm(CPUArchState *env, abi_ulong option,
             if (copy_from_user(new_auxv, auxv, auxv_size)) {
                 return -TARGET_EFAULT;
             }
-            new_auxv[ARRAY_SIZE(new_auxv) - 2] = 0;
-            new_auxv[ARRAY_SIZE(new_auxv) - 1] = 0;
+            guest_prctl_auxv_terminate(new_auxv);
         }
         if (exe_fd != UINT32_MAX) {
             unsigned int checkpoint_cap =
@@ -13751,22 +14007,30 @@ static abi_long do_prctl_timer_create_restore_ids(CPUArchState *env,
                                                    abi_ulong arg5)
 {
     TaskState *ts = env_cpu(env)->opaque;
+    abi_long ret;
 
     if (arg3 || arg4 || arg5) {
         return -TARGET_EINVAL;
     }
+    mmap_lock();
     switch (control) {
     case PR_TIMER_CREATE_RESTORE_IDS_OFF:
         ts->info->prctl_timer_restore_ids = false;
-        return 0;
+        ret = 0;
+        break;
     case PR_TIMER_CREATE_RESTORE_IDS_ON:
         ts->info->prctl_timer_restore_ids = true;
-        return 0;
+        ret = 0;
+        break;
     case PR_TIMER_CREATE_RESTORE_IDS_GET:
-        return ts->info->prctl_timer_restore_ids;
+        ret = ts->info->prctl_timer_restore_ids;
+        break;
     default:
-        return -TARGET_EINVAL;
+        ret = -TARGET_EINVAL;
+        break;
     }
+    mmap_unlock();
+    return ret;
 }
 
 static abi_long do_prctl_futex_hash(CPUArchState *env, abi_ulong operation,
@@ -13951,7 +14215,7 @@ static char *guest_prctl_exec_env(CPUArchState *env, const char *name)
         mdwe = ts->info->prctl_mdwe;
         mmap_unlock();
         if (mdwe == TARGET_PR_MDWE_REFUSE_EXEC_GAIN) {
-            return g_strdup_printf("%s=1", LATX_GUEST_MDWE_ENV);
+            return g_strdup_printf("%s=%u", LATX_GUEST_MDWE_ENV, mdwe);
         }
     } else if (strcmp(name, LATX_GUEST_TSC_ENV) == 0) {
         CPUX86State *x86_env = (CPUX86State *)env;
@@ -14256,9 +14520,11 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
             const char *exec_pathname;
             bool self_exe;
             bool x86_file;
-#ifdef TARGET_X86_64
+#ifdef TARGET_I386
+            GuestExecResolution exec_resolution = { .terminal_fd = -1 };
             char *prctl_mdwe_env = NULL;
             char *prctl_tsc_env = NULL;
+            bool pinned_exec;
             bool restore_prctl;
 #endif
             int argc, envc;
@@ -14333,13 +14599,21 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
             pname = strrchr(p, '/');
             exec_pathname = path(p);
             self_exe = is_proc_myself((const char *)p, "exe");
-#ifdef TARGET_X86_64
-            x86_file = self_exe ? guest_self_exe_is_x86(env) :
-                       is_x86_file_at(arg1, exec_pathname, arg5);
-            restore_prctl = self_exe ?
-                guest_self_exe_restores_guest_state(env) :
-                exec_file_restores_guest_state_at(arg1, exec_pathname,
-                                                  arg5, 0);
+#ifdef TARGET_I386
+            pinned_exec = guest_prctl_exec_state_active(env);
+            if (pinned_exec) {
+                if (guest_exec_resolve(env, arg1, exec_pathname, arg5,
+                                       self_exe, &exec_resolution) < 0) {
+                    ret = get_errno(-1);
+                    goto execveat_end;
+                }
+                x86_file = exec_resolution.initial_is_x86;
+                restore_prctl = exec_resolution.restore_prctl;
+            } else {
+                x86_file = self_exe ||
+                           is_x86_file_at(arg1, exec_pathname, arg5);
+                restore_prctl = false;
+            }
 
             exec_envp = prepare_guest_prctl_exec_env(env, envp, envc,
                                                      restore_prctl,
@@ -14412,7 +14686,19 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
              * before the execve completes and makes it the other
              * program's problem.
              */
-            if (self_exe) {
+            if (pinned_exec) {
+                char **before_script_argp = exec_argp;
+
+                exec_argp = guest_exec_script_argv(&exec_resolution,
+                                                    exec_argp);
+                if (before_script_argp != argp &&
+                    before_script_argp != exec_argp) {
+                    g_free(before_script_argp);
+                }
+                ret = get_errno(safe_execveat(exec_resolution.terminal_fd,
+                                              "", exec_argp, exec_envp,
+                                              AT_EMPTY_PATH));
+            } else if (self_exe) {
                 char exe_path_buffer[64];
                 const char *exe_pathname;
                 int exe_fd;
@@ -14464,7 +14750,8 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
             g_free(pidof_arg);
             g_free(hash_str);
             g_free(argp);
-#ifdef TARGET_X86_64
+#ifdef TARGET_I386
+            guest_exec_resolution_cleanup(&exec_resolution);
             g_free(prctl_mdwe_env);
             g_free(prctl_tsc_env);
 #endif
@@ -14484,9 +14771,11 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
             const char *pname;
             bool self_exe;
             bool x86_file;
-#ifdef TARGET_X86_64
+#ifdef TARGET_I386
+            GuestExecResolution exec_resolution = { .terminal_fd = -1 };
             char *prctl_mdwe_env = NULL;
             char *prctl_tsc_env = NULL;
+            bool pinned_exec;
             bool restore_prctl;
 #endif
             int argc, envc;
@@ -14548,12 +14837,21 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
 
             pname = strrchr(p, '/');
             self_exe = is_proc_myself((const char *)p, "exe");
-#ifdef TARGET_X86_64
-            x86_file = self_exe ? guest_self_exe_is_x86(env) :
-                       is_x86_file_at(AT_FDCWD, path(p), 0);
-            restore_prctl = self_exe ?
-                guest_self_exe_restores_guest_state(env) :
-                exec_file_restores_guest_state_at(AT_FDCWD, path(p), 0, 0);
+#ifdef TARGET_I386
+            pinned_exec = guest_prctl_exec_state_active(env);
+            if (pinned_exec) {
+                if (guest_exec_resolve(env, AT_FDCWD, path(p), 0,
+                                       self_exe, &exec_resolution) < 0) {
+                    ret = get_errno(-1);
+                    goto execve_end;
+                }
+                x86_file = exec_resolution.initial_is_x86;
+                restore_prctl = exec_resolution.restore_prctl;
+            } else {
+                x86_file = self_exe ||
+                           is_x86_file_at(AT_FDCWD, path(p), 0);
+                restore_prctl = false;
+            }
 
             exec_envp = prepare_guest_prctl_exec_env(env, envp, envc,
                                                      restore_prctl,
@@ -14622,10 +14920,19 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
                 const char *exe_pathname;
                 int exe_fd;
 
-                if (!guest_self_exe_exec_paths(
-                        cpu_env, real, sizeof(real), &temp,
-                        exe_path_buffer, sizeof(exe_path_buffer),
-                        &exe_pathname, &exe_fd)) {
+                if (pinned_exec) {
+                    temp = guest_self_exe_link_path(cpu_env, real,
+                                                    sizeof(real));
+                    if (!temp) {
+                        ret = get_errno(-1);
+                        goto execve_end;
+                    }
+                    exe_pathname = NULL;
+                    exe_fd = -1;
+                } else if (!guest_self_exe_exec_paths(
+                               cpu_env, real, sizeof(real), &temp,
+                               exe_path_buffer, sizeof(exe_path_buffer),
+                               &exe_pathname, &exe_fd)) {
                     ret = get_errno(-1);
                     if (exe_fd >= 0) {
                         close(exe_fd);
@@ -14641,11 +14948,37 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
                     }
                     *exec_argp = (char *)temp;
                 }
-                ret = get_errno(safe_execve(exe_pathname, exec_argp,
-                                            exec_envp));
+                if (pinned_exec) {
+                    char **before_script_argp = exec_argp;
+
+                    exec_argp = guest_exec_script_argv(&exec_resolution,
+                                                        exec_argp);
+                    if (before_script_argp != argp &&
+                        before_script_argp != exec_argp) {
+                        g_free(before_script_argp);
+                    }
+                    ret = get_errno(safe_execveat(
+                                        exec_resolution.terminal_fd, "",
+                                        exec_argp, exec_envp, AT_EMPTY_PATH));
+                } else {
+                    ret = get_errno(safe_execve(exe_pathname, exec_argp,
+                                                exec_envp));
+                }
                 if (exe_fd >= 0) {
                     close(exe_fd);
                 }
+            } else if (pinned_exec) {
+                char **before_script_argp = exec_argp;
+
+                exec_argp = guest_exec_script_argv(&exec_resolution,
+                                                    exec_argp);
+                if (before_script_argp != argp &&
+                    before_script_argp != exec_argp) {
+                    g_free(before_script_argp);
+                }
+                ret = get_errno(safe_execveat(exec_resolution.terminal_fd,
+                                              "", exec_argp, exec_envp,
+                                              AT_EMPTY_PATH));
             } else {
 
                 /* Although execve() is not an interruptible syscall it is
@@ -14689,7 +15022,8 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
             g_free(pidof_arg);
             g_free(hash_str);
             g_free(argp);
-#ifdef TARGET_X86_64
+#ifdef TARGET_I386
+            guest_exec_resolution_cleanup(&exec_resolution);
             g_free(prctl_mdwe_env);
             g_free(prctl_tsc_env);
 #endif
@@ -16086,9 +16420,20 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
             v5 = tswapal(v[4]);
             v6 = tswapal(v[5]);
             unlock_user(v, arg1, 0);
+#ifdef TARGET_I386
+            mmap_lock();
+            ret = guest_mdwe_mmap(cpu, v2, v3);
+            if (ret) {
+                mmap_unlock();
+                return ret;
+            }
+#endif
             ret = get_errno(target_mmap(v1, v2, v3,
                                         target_to_host_bitmask(v4, mmap_flags_tbl),
                                         v5, v6, 1));
+#ifdef TARGET_I386
+            mmap_unlock();
+#endif
         }
 #else
 
@@ -16102,7 +16447,7 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
             }
         }
 
-#ifdef TARGET_X86_64
+#ifdef TARGET_I386
         mmap_lock();
         ret = guest_mdwe_mmap(cpu, arg2, arg3);
         if (ret) {
@@ -16115,7 +16460,7 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
                                     target_to_host_bitmask(arg4, mmap_flags_tbl),
                                     arg5,
                                     arg6, 1));
-#ifdef TARGET_X86_64
+#ifdef TARGET_I386
         mmap_unlock();
 #endif
 #endif
@@ -16126,9 +16471,20 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
 #ifndef MMAP_SHIFT
 #define MMAP_SHIFT 12
 #endif
+#ifdef TARGET_I386
+        mmap_lock();
+        ret = guest_mdwe_mmap(cpu, arg2, arg3);
+        if (ret) {
+            mmap_unlock();
+            return ret;
+        }
+#endif
         ret = target_mmap(arg1, arg2, arg3,
                           target_to_host_bitmask(arg4, mmap_flags_tbl),
                           arg5, (uint64_t)arg6 << MMAP_SHIFT, 1);
+#ifdef TARGET_I386
+        mmap_unlock();
+#endif
         return get_errno(ret);
 #endif
     case TARGET_NR_munmap:
@@ -16147,7 +16503,7 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
                 arg1 = ts->info->stack_limit;
             }
         }
-#ifdef TARGET_X86_64
+#ifdef TARGET_I386
         mmap_lock();
         ret = guest_mdwe_mprotect(cpu, arg1, arg2, arg3);
         if (ret) {
@@ -16156,7 +16512,7 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
         }
 #endif
         ret = get_errno(target_mprotect(arg1, arg2, arg3));
-#ifdef TARGET_X86_64
+#ifdef TARGET_I386
         mmap_unlock();
 #endif
         return ret;
@@ -17662,10 +18018,10 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
                 return ret;
             }
 #endif /* AARCH64 */
+#ifdef TARGET_I386
         case PR_SET_SYSCALL_USER_DISPATCH:
             return do_prctl_syscall_user_dispatch(env, arg2, arg3,
                                                   arg4, arg5);
-#ifdef TARGET_X86_64
         case PR_GET_TSC:
             return do_prctl_get_tsc(env, arg2);
         case PR_SET_TSC:
@@ -17695,7 +18051,16 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
         case PR_FUTEX_HASH:
             return do_prctl_futex_hash(env, arg2, arg3, arg4);
         case PR_RSEQ_SLICE_EXTENSION:
+            /* linux-user has no rseq-v2 slice ABI to enable. */
             return arg4 || arg5 ? -TARGET_EINVAL : -TARGET_EOPNOTSUPP;
+        case PR_SET_MEMORY_MERGE:
+        case PR_GET_MEMORY_MERGE:
+            /* KSM state belongs to the guest mm, not the translator mm. */
+            return -TARGET_EINVAL;
+        case PR_GET_CFI:
+        case PR_SET_CFI:
+            /* Native x86 has no branch-landing-pad prctl implementation. */
+            return -TARGET_EINVAL;
 #endif
         case PR_GET_SECCOMP:
         case PR_SET_SECCOMP:
@@ -17725,12 +18090,14 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
         case PR_SET_PTRACER:
         case PR_GET_THP_DISABLE:
         case PR_SET_THP_DISABLE:
-#ifndef TARGET_X86_64
+#ifndef TARGET_I386
         case PR_GET_SPECULATION_CTRL:
         case PR_SET_SPECULATION_CTRL:
 #endif
+#ifndef TARGET_I386
         case PR_SET_MEMORY_MERGE:
         case PR_GET_MEMORY_MERGE:
+#endif
             /* These options have only scalar arguments. */
             return get_errno(prctl(arg1, arg2, arg3, arg4, arg5));
         case PR_SCHED_CORE:
@@ -17766,7 +18133,7 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
         case PR_SET_ENDIAN:
         case PR_GET_FPEMU:
         case PR_SET_FPEMU:
-#ifndef TARGET_X86_64
+#ifndef TARGET_I386
         case PR_SET_MM:
         case PR_GET_TSC:
         case PR_SET_TSC:
@@ -17776,10 +18143,18 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
             /* Do not let the guest alter host execution state. */
             return -TARGET_EINVAL;
         default:
+#ifdef TARGET_I386
             qemu_log_mask(LOG_UNIMP,
                           "Unsupported prctl: " TARGET_ABI_FMT_ld "\n",
                           arg1);
             return -TARGET_EINVAL;
+#else
+            /* Preserve the generic linux-user behavior for other guests. */
+            return get_errno(prctl(arg1, g2h_untagged(arg2),
+                                   g2h_untagged(arg3),
+                                   g2h_untagged(arg4),
+                                   g2h_untagged(arg5)));
+#endif
         }
         break;
 #ifdef TARGET_NR_arch_prctl
@@ -19990,12 +20365,14 @@ defined(__loongarch__)
         /* args: clockid_t clockid, struct sigevent *sevp, timer_t *timerid */
 
         struct sigevent host_sevp = { {0}, }, *phost_sevp = NULL;
+        target_timer_t allocated;
         target_timer_t requested = 0;
+        timer_t host_timer;
         bool exact = false;
         int clkid = arg1;
         int timer_index;
 
-#ifdef TARGET_X86_64
+#ifdef TARGET_I386
         mmap_lock();
         exact = ((TaskState *)cpu->opaque)->info->prctl_timer_restore_ids;
         mmap_unlock();
@@ -20006,30 +20383,29 @@ defined(__loongarch__)
         if (exact && requested < 0) {
             return -TARGET_EINVAL;
         }
-        timer_index = reserve_host_timer(requested, exact);
+        if (arg2) {
+            phost_sevp = &host_sevp;
+            ret = target_to_host_sigevent(phost_sevp, arg2);
+            if (ret != 0) {
+                return ret;
+            }
+        }
+        timer_index = reserve_host_timer(requested, exact, &allocated);
 
         if (timer_index < 0) {
             ret = timer_index;
         } else {
-            timer_t *phtimer = g_posix_timers  + timer_index;
-
-            if (arg2) {
-                phost_sevp = &host_sevp;
-                ret = target_to_host_sigevent(phost_sevp, arg2);
-                if (ret != 0) {
-                    release_host_timer(timer_index);
-                    return ret;
-                }
-            }
-
-            ret = get_errno(timer_create(clkid, phost_sevp, phtimer));
+            ret = get_errno(timer_create(clkid, phost_sevp, &host_timer));
             if (ret) {
-                release_host_timer(timer_index);
-            } else if (put_user(g_posix_timer_ids[timer_index], arg3,
-                                target_timer_t)) {
-                timer_delete(*phtimer);
-                release_host_timer(timer_index);
+                release_host_timer(timer_index, allocated);
+            } else if (put_user(allocated, arg3, target_timer_t)) {
+                timer_delete(host_timer);
+                release_host_timer(timer_index, allocated);
                 return -TARGET_EFAULT;
+            } else if (!publish_host_timer(timer_index, allocated,
+                                           host_timer)) {
+                timer_delete(host_timer);
+                return -TARGET_EINVAL;
             }
         }
         return ret;
@@ -20177,7 +20553,7 @@ defined(__loongarch__)
             timer_t htimer = g_posix_timers[timerid];
             ret = get_errno(timer_delete(htimer));
             if (!ret) {
-                g_posix_timer_used[timerid] = false;
+                g_posix_timer_state[timerid] = POSIX_TIMER_FREE;
                 g_posix_timer_ids[timerid] = 0;
                 g_posix_timers[timerid] = (timer_t)0;
             }
@@ -20497,6 +20873,7 @@ defined(__loongarch__)
     return ret;
 }
 
+#ifdef TARGET_I386
 static bool syscall_user_dispatch(CPUArchState *env, int num, uint32_t arch)
 {
     CPUState *cpu = env_cpu(env);
@@ -20545,6 +20922,7 @@ static bool syscall_user_dispatch(CPUArchState *env, int num, uint32_t arch)
     queue_signal(env, TARGET_SIGSYS, QEMU_SI_SYS, &info);
     return true;
 }
+#endif
 
 abi_long do_syscall_with_seccomp(void *cpu_env, int num, int seccomp_num,
                                 uint32_t seccomp_arch, abi_long arg1,
@@ -20589,10 +20967,12 @@ abi_long do_syscall_with_seccomp(void *cpu_env, int num, int seccomp_num,
     loader_tunnel = num == TUNNEL_VIRTUAL_SYSCALL_ID &&
                     is_tunnel_loader_notification(env, arg1);
 #endif
+#ifdef TARGET_I386
     if (!loader_tunnel &&
         syscall_user_dispatch(env, seccomp_num, seccomp_arch)) {
         return -TARGET_QEMU_ESIGRETURN;
     }
+#endif
 
     record_syscall_start(cpu, num, arg1,
                          arg2, arg3, arg4, arg5, arg6, arg7, arg8);

--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -327,21 +327,20 @@ out_marker:
 #define PR_SPEC_FORCE_DISABLE (1UL << 3)
 #define PR_SPEC_DISABLE_NOEXEC (1UL << 4)
 #endif
-#ifndef PR_RISCV_V_SET_CONTROL
-#define PR_RISCV_V_SET_CONTROL 69
-#define PR_RISCV_V_GET_CONTROL 70
-#define PR_RISCV_SET_ICACHE_FLUSH_CTX 71
+#ifndef PR_TIMER_CREATE_RESTORE_IDS
+#define PR_TIMER_CREATE_RESTORE_IDS 77
+#define PR_TIMER_CREATE_RESTORE_IDS_OFF 0
+#define PR_TIMER_CREATE_RESTORE_IDS_ON 1
+#define PR_TIMER_CREATE_RESTORE_IDS_GET 2
 #endif
-#ifndef PR_PPC_GET_DEXCR
-#define PR_PPC_GET_DEXCR 72
-#define PR_PPC_SET_DEXCR 73
+#ifndef PR_FUTEX_HASH
+#define PR_FUTEX_HASH 78
+#define PR_FUTEX_HASH_SET_SLOTS 1
+#define PR_FUTEX_HASH_GET_SLOTS 2
 #endif
-#ifndef PR_GET_SHADOW_STACK_STATUS
-#define PR_GET_SHADOW_STACK_STATUS 74
-#define PR_SET_SHADOW_STACK_STATUS 75
-#define PR_LOCK_SHADOW_STACK_STATUS 76
+#ifndef PR_RSEQ_SLICE_EXTENSION
+#define PR_RSEQ_SLICE_EXTENSION 79
 #endif
-
 #ifdef CONFIG_LATX
 #define IMAGE_NT_SIGNATURE 0x00004550
 #define IMAGE_FILE_RELOCS_STRIPPED 0x0001
@@ -960,19 +959,79 @@ _syscall4(int, sys_prlimit64, pid_t, pid, int, resource,
 
 #if defined(TARGET_NR_timer_create)
 /* Maximum of 32 active POSIX timers allowed at any one time. */
-static timer_t g_posix_timers[32] = { 0, } ;
+#define TIMER_MAGIC 0x0caf0000
+static timer_t g_posix_timers[32];
+static target_timer_t g_posix_timer_ids[32];
+static bool g_posix_timer_used[32];
+static pthread_mutex_t posix_timer_lock = PTHREAD_MUTEX_INITIALIZER;
 
-static inline int next_free_host_timer(void)
+static int reserve_host_timer(target_timer_t requested, bool exact)
 {
-    int k ;
-    /* FIXME: Does finding the next free slot require a lock? */
+    int free_slot = -1;
+    int k;
+
+    pthread_mutex_lock(&posix_timer_lock);
     for (k = 0; k < ARRAY_SIZE(g_posix_timers); k++) {
-        if (g_posix_timers[k] == 0) {
-            g_posix_timers[k] = (timer_t) 1;
-            return k;
+        if (g_posix_timer_used[k]) {
+            if (exact && g_posix_timer_ids[k] == requested) {
+                pthread_mutex_unlock(&posix_timer_lock);
+                return -TARGET_EBUSY;
+            }
+        } else if (free_slot < 0) {
+            int j;
+
+            if (exact) {
+                free_slot = k;
+                continue;
+            }
+            requested = TIMER_MAGIC | k;
+            for (j = 0; j < ARRAY_SIZE(g_posix_timers); j++) {
+                if (g_posix_timer_used[j] &&
+                    g_posix_timer_ids[j] == requested) {
+                    break;
+                }
+            }
+            if (j == ARRAY_SIZE(g_posix_timers)) {
+                free_slot = k;
+            }
         }
     }
-    return -1;
+    if (free_slot < 0) {
+        pthread_mutex_unlock(&posix_timer_lock);
+        return -TARGET_EAGAIN;
+    }
+
+    g_posix_timer_used[free_slot] = true;
+    g_posix_timer_ids[free_slot] = requested;
+    pthread_mutex_unlock(&posix_timer_lock);
+    return free_slot;
+}
+
+static void release_host_timer(int slot)
+{
+    pthread_mutex_lock(&posix_timer_lock);
+    g_posix_timer_used[slot] = false;
+    g_posix_timer_ids[slot] = 0;
+    g_posix_timers[slot] = (timer_t)0;
+    pthread_mutex_unlock(&posix_timer_lock);
+}
+
+static void posix_timer_fork_start(void)
+{
+    pthread_mutex_lock(&posix_timer_lock);
+}
+
+static void posix_timer_fork_end(bool child)
+{
+    if (!child) {
+        pthread_mutex_unlock(&posix_timer_lock);
+        return;
+    }
+
+    pthread_mutex_init(&posix_timer_lock, NULL);
+    memset(g_posix_timer_used, 0, sizeof(g_posix_timer_used));
+    memset(g_posix_timer_ids, 0, sizeof(g_posix_timer_ids));
+    memset(g_posix_timers, 0, sizeof(g_posix_timers));
 }
 #endif
 
@@ -9781,6 +9840,9 @@ static int do_fork(CPUArchState *env, unsigned int flags, abi_ulong newsp,
         }
 
         fork_start();
+#if defined(TARGET_NR_timer_create)
+        posix_timer_fork_start();
+#endif
         if (userns_via_unshare) {
             rcu_child_was_deferred = rcu_defer_atfork_child();
         }
@@ -9819,6 +9881,9 @@ static int do_fork(CPUArchState *env, unsigned int flags, abi_ulong newsp,
             /* Child Process.  */
             cpu_clone_regs_child(env, newsp, flags);
             fork_end(1);
+#if defined(TARGET_NR_timer_create)
+            posix_timer_fork_end(true);
+#endif
             /* There is a race condition here.  The parent process could
                theoretically read the TID in the child process before the child
                tid is set.  This would require using either ptrace
@@ -9834,6 +9899,11 @@ static int do_fork(CPUArchState *env, unsigned int flags, abi_ulong newsp,
             ts->sys_dispatch_len = -1;
             ts->sys_dispatch_inclusive = false;
             ts->child_tidptr = 0;
+#ifdef TARGET_X86_64
+            ts->info->prctl_timer_restore_ids = false;
+            ts->info->prctl_futex_hash_slots = 0;
+            ts->info->prctl_futex_hash_custom = false;
+#endif
             if (flags & CLONE_NEWIPC) {
                 ts->ipc_namespace_isolated = true;
             }
@@ -9851,6 +9921,9 @@ static int do_fork(CPUArchState *env, unsigned int flags, abi_ulong newsp,
             }
             cpu_clone_regs_parent(env, flags);
             fork_end(0);
+#if defined(TARGET_NR_timer_create)
+            posix_timer_fork_end(false);
+#endif
 
             if (userns_via_unshare && ret > 0) {
                 do {
@@ -12878,25 +12951,24 @@ static int proc_self_fstat(int ofd, struct stat *st)
     return ret;
 }
 
-#define TIMER_MAGIC 0x0caf0000
-#define TIMER_MAGIC_MASK 0xffff0000
-
-/* Convert QEMU provided timer ID back to internal 16bit index format */
-static target_timer_t get_timer_id(abi_long arg)
+/* Return a fixed-table index while holding posix_timer_lock on success. */
+static target_timer_t lock_host_timer(abi_long arg)
 {
     target_timer_t timerid = arg;
+    int k;
 
-    if ((timerid & TIMER_MAGIC_MASK) != TIMER_MAGIC) {
+    if (timerid < 0) {
         return -TARGET_EINVAL;
     }
 
-    timerid &= 0xffff;
-
-    if (timerid >= ARRAY_SIZE(g_posix_timers)) {
-        return -TARGET_EINVAL;
+    pthread_mutex_lock(&posix_timer_lock);
+    for (k = 0; k < ARRAY_SIZE(g_posix_timers); k++) {
+        if (g_posix_timer_used[k] && g_posix_timer_ids[k] == timerid) {
+            return k;
+        }
     }
-
-    return timerid;
+    pthread_mutex_unlock(&posix_timer_lock);
+    return -TARGET_EINVAL;
 }
 
 static int target_to_host_cpu_mask(unsigned long *host_mask,
@@ -13670,6 +13742,69 @@ static abi_long do_prctl_mdwe(CPUArchState *env, bool set,
     info->prctl_mdwe = arg2;
     mmap_unlock();
     return 0;
+}
+
+static abi_long do_prctl_timer_create_restore_ids(CPUArchState *env,
+                                                   abi_ulong control,
+                                                   abi_ulong arg3,
+                                                   abi_ulong arg4,
+                                                   abi_ulong arg5)
+{
+    TaskState *ts = env_cpu(env)->opaque;
+
+    if (arg3 || arg4 || arg5) {
+        return -TARGET_EINVAL;
+    }
+    switch (control) {
+    case PR_TIMER_CREATE_RESTORE_IDS_OFF:
+        ts->info->prctl_timer_restore_ids = false;
+        return 0;
+    case PR_TIMER_CREATE_RESTORE_IDS_ON:
+        ts->info->prctl_timer_restore_ids = true;
+        return 0;
+    case PR_TIMER_CREATE_RESTORE_IDS_GET:
+        return ts->info->prctl_timer_restore_ids;
+    default:
+        return -TARGET_EINVAL;
+    }
+}
+
+static abi_long do_prctl_futex_hash(CPUArchState *env, abi_ulong operation,
+                                    abi_ulong arg3, abi_ulong arg4)
+{
+    TaskState *ts = env_cpu(env)->opaque;
+    unsigned int slots = arg3;
+    abi_long ret;
+
+    /*
+     * Private hash sizing is a performance control; host futex operations
+     * remain functionally equivalent on the global hash.  Keep the guest MM
+     * state here instead of retuning the translator's own host futexes.
+     */
+    switch (operation) {
+    case PR_FUTEX_HASH_SET_SLOTS:
+        if (arg4 || (slots && (slots == 1 || (slots & (slots - 1))))) {
+            return -TARGET_EINVAL;
+        }
+        mmap_lock();
+        if (ts->info->prctl_futex_hash_custom &&
+            !ts->info->prctl_futex_hash_slots) {
+            ret = -TARGET_EBUSY;
+        } else {
+            ts->info->prctl_futex_hash_slots = slots;
+            ts->info->prctl_futex_hash_custom = true;
+            ret = 0;
+        }
+        mmap_unlock();
+        return ret;
+    case PR_FUTEX_HASH_GET_SLOTS:
+        mmap_lock();
+        ret = ts->info->prctl_futex_hash_slots;
+        mmap_unlock();
+        return ret;
+    default:
+        return -TARGET_EINVAL;
+    }
 }
 
 static abi_long do_prctl_set_vma(abi_ulong operation, abi_ulong start,
@@ -17554,6 +17689,13 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
         case PR_SET_SPECULATION_CTRL:
             return do_prctl_speculation_ctrl(true, arg2, arg3,
                                              arg4, arg5);
+        case PR_TIMER_CREATE_RESTORE_IDS:
+            return do_prctl_timer_create_restore_ids(env, arg2, arg3,
+                                                     arg4, arg5);
+        case PR_FUTEX_HASH:
+            return do_prctl_futex_hash(env, arg2, arg3, arg4);
+        case PR_RSEQ_SLICE_EXTENSION:
+            return arg4 || arg5 ? -TARGET_EINVAL : -TARGET_EOPNOTSUPP;
 #endif
         case PR_GET_SECCOMP:
         case PR_SET_SECCOMP:
@@ -17631,29 +17773,6 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
 #endif
         case PR_MPX_ENABLE_MANAGEMENT:
         case PR_MPX_DISABLE_MANAGEMENT:
-#ifdef TARGET_X86_64
-        case PR_GET_UNALIGN:
-        case PR_SET_UNALIGN:
-        case PR_SET_FP_MODE:
-        case PR_GET_FP_MODE:
-        case PR_SVE_SET_VL:
-        case PR_SVE_GET_VL:
-        case PR_PAC_RESET_KEYS:
-        case PR_SET_TAGGED_ADDR_CTRL:
-        case PR_GET_TAGGED_ADDR_CTRL:
-        case PR_PAC_SET_ENABLED_KEYS:
-        case PR_PAC_GET_ENABLED_KEYS:
-        case PR_SME_SET_VL:
-        case PR_SME_GET_VL:
-        case PR_RISCV_V_SET_CONTROL:
-        case PR_RISCV_V_GET_CONTROL:
-        case PR_RISCV_SET_ICACHE_FLUSH_CTX:
-        case PR_PPC_GET_DEXCR:
-        case PR_PPC_SET_DEXCR:
-        case PR_GET_SHADOW_STACK_STATUS:
-        case PR_SET_SHADOW_STACK_STATUS:
-        case PR_LOCK_SHADOW_STACK_STATUS:
-#endif
             /* Do not let the guest alter host execution state. */
             return -TARGET_EINVAL;
         default:
@@ -19871,12 +19990,26 @@ defined(__loongarch__)
         /* args: clockid_t clockid, struct sigevent *sevp, timer_t *timerid */
 
         struct sigevent host_sevp = { {0}, }, *phost_sevp = NULL;
-
+        target_timer_t requested = 0;
+        bool exact = false;
         int clkid = arg1;
-        int timer_index = next_free_host_timer();
+        int timer_index;
+
+#ifdef TARGET_X86_64
+        mmap_lock();
+        exact = ((TaskState *)cpu->opaque)->info->prctl_timer_restore_ids;
+        mmap_unlock();
+#endif
+        if (exact && get_user(requested, arg3, target_timer_t)) {
+            return -TARGET_EFAULT;
+        }
+        if (exact && requested < 0) {
+            return -TARGET_EINVAL;
+        }
+        timer_index = reserve_host_timer(requested, exact);
 
         if (timer_index < 0) {
-            ret = -TARGET_EAGAIN;
+            ret = timer_index;
         } else {
             timer_t *phtimer = g_posix_timers  + timer_index;
 
@@ -19884,17 +20017,19 @@ defined(__loongarch__)
                 phost_sevp = &host_sevp;
                 ret = target_to_host_sigevent(phost_sevp, arg2);
                 if (ret != 0) {
+                    release_host_timer(timer_index);
                     return ret;
                 }
             }
 
             ret = get_errno(timer_create(clkid, phost_sevp, phtimer));
             if (ret) {
-                phtimer = NULL;
-            } else {
-                if (put_user(TIMER_MAGIC | timer_index, arg3, target_timer_t)) {
-                    return -TARGET_EFAULT;
-                }
+                release_host_timer(timer_index);
+            } else if (put_user(g_posix_timer_ids[timer_index], arg3,
+                                target_timer_t)) {
+                timer_delete(*phtimer);
+                release_host_timer(timer_index);
+                return -TARGET_EFAULT;
             }
         }
         return ret;
@@ -19906,24 +20041,28 @@ defined(__loongarch__)
     {
         /* args: timer_t timerid, int flags, const struct itimerspec *new_value,
          * struct itimerspec * old_value */
-        target_timer_t timerid = get_timer_id(arg1);
+        target_timer_t timerid = lock_host_timer(arg1);
 
         if (timerid < 0) {
             ret = timerid;
         } else if (arg3 == 0) {
             ret = -TARGET_EINVAL;
+            pthread_mutex_unlock(&posix_timer_lock);
         } else {
             timer_t htimer = g_posix_timers[timerid];
             struct itimerspec hspec_new = {{0},}, hspec_old = {{0},};
 
             if (target_to_host_itimerspec(&hspec_new, arg3)) {
+                pthread_mutex_unlock(&posix_timer_lock);
                 return -TARGET_EFAULT;
             }
             ret = get_errno(
                           timer_settime(htimer, arg2, &hspec_new, &hspec_old));
-            if (arg4 && host_to_target_itimerspec(arg4, &hspec_old)) {
-                return -TARGET_EFAULT;
+            if (!ret && arg4 &&
+                host_to_target_itimerspec(arg4, &hspec_old)) {
+                ret = -TARGET_EFAULT;
             }
+            pthread_mutex_unlock(&posix_timer_lock);
         }
         return ret;
     }
@@ -19932,24 +20071,28 @@ defined(__loongarch__)
 #ifdef TARGET_NR_timer_settime64
     case TARGET_NR_timer_settime64:
     {
-        target_timer_t timerid = get_timer_id(arg1);
+        target_timer_t timerid = lock_host_timer(arg1);
 
         if (timerid < 0) {
             ret = timerid;
         } else if (arg3 == 0) {
             ret = -TARGET_EINVAL;
+            pthread_mutex_unlock(&posix_timer_lock);
         } else {
             timer_t htimer = g_posix_timers[timerid];
             struct itimerspec hspec_new = {{0},}, hspec_old = {{0},};
 
             if (target_to_host_itimerspec64(&hspec_new, arg3)) {
+                pthread_mutex_unlock(&posix_timer_lock);
                 return -TARGET_EFAULT;
             }
             ret = get_errno(
                           timer_settime(htimer, arg2, &hspec_new, &hspec_old));
-            if (arg4 && host_to_target_itimerspec64(arg4, &hspec_old)) {
-                return -TARGET_EFAULT;
+            if (!ret && arg4 &&
+                host_to_target_itimerspec64(arg4, &hspec_old)) {
+                ret = -TARGET_EFAULT;
             }
+            pthread_mutex_unlock(&posix_timer_lock);
         }
         return ret;
     }
@@ -19959,20 +20102,22 @@ defined(__loongarch__)
     case TARGET_NR_timer_gettime:
     {
         /* args: timer_t timerid, struct itimerspec *curr_value */
-        target_timer_t timerid = get_timer_id(arg1);
+        target_timer_t timerid = lock_host_timer(arg1);
 
         if (timerid < 0) {
             ret = timerid;
         } else if (!arg2) {
             ret = -TARGET_EFAULT;
+            pthread_mutex_unlock(&posix_timer_lock);
         } else {
             timer_t htimer = g_posix_timers[timerid];
             struct itimerspec hspec;
             ret = get_errno(timer_gettime(htimer, &hspec));
 
-            if (host_to_target_itimerspec(arg2, &hspec)) {
+            if (!ret && host_to_target_itimerspec(arg2, &hspec)) {
                 ret = -TARGET_EFAULT;
             }
+            pthread_mutex_unlock(&posix_timer_lock);
         }
         return ret;
     }
@@ -19982,20 +20127,22 @@ defined(__loongarch__)
     case TARGET_NR_timer_gettime64:
     {
         /* args: timer_t timerid, struct itimerspec64 *curr_value */
-        target_timer_t timerid = get_timer_id(arg1);
+        target_timer_t timerid = lock_host_timer(arg1);
 
         if (timerid < 0) {
             ret = timerid;
         } else if (!arg2) {
             ret = -TARGET_EFAULT;
+            pthread_mutex_unlock(&posix_timer_lock);
         } else {
             timer_t htimer = g_posix_timers[timerid];
             struct itimerspec hspec;
             ret = get_errno(timer_gettime(htimer, &hspec));
 
-            if (host_to_target_itimerspec64(arg2, &hspec)) {
+            if (!ret && host_to_target_itimerspec64(arg2, &hspec)) {
                 ret = -TARGET_EFAULT;
             }
+            pthread_mutex_unlock(&posix_timer_lock);
         }
         return ret;
     }
@@ -20005,13 +20152,14 @@ defined(__loongarch__)
     case TARGET_NR_timer_getoverrun:
     {
         /* args: timer_t timerid */
-        target_timer_t timerid = get_timer_id(arg1);
+        target_timer_t timerid = lock_host_timer(arg1);
 
         if (timerid < 0) {
             ret = timerid;
         } else {
             timer_t htimer = g_posix_timers[timerid];
             ret = get_errno(timer_getoverrun(htimer));
+            pthread_mutex_unlock(&posix_timer_lock);
         }
         return ret;
     }
@@ -20021,14 +20169,19 @@ defined(__loongarch__)
     case TARGET_NR_timer_delete:
     {
         /* args: timer_t timerid */
-        target_timer_t timerid = get_timer_id(arg1);
+        target_timer_t timerid = lock_host_timer(arg1);
 
         if (timerid < 0) {
             ret = timerid;
         } else {
             timer_t htimer = g_posix_timers[timerid];
             ret = get_errno(timer_delete(htimer));
-            g_posix_timers[timerid] = 0;
+            if (!ret) {
+                g_posix_timer_used[timerid] = false;
+                g_posix_timer_ids[timerid] = 0;
+                g_posix_timers[timerid] = (timer_t)0;
+            }
+            pthread_mutex_unlock(&posix_timer_lock);
         }
         return ret;
     }

--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -12287,7 +12287,7 @@ static int open_self_stat(void *cpu_env, int fd, const char *oldpath)
         if (NULL == word) {
             /* Find a pointer to '\0' */
             word = strchr(orig, '\0');
-            if (NULL == word) {
+            if (word == NULL) {
                 goto fail;
             }
             /* \0 not needed */
@@ -13158,7 +13158,7 @@ static abi_long do_prctl_syscall_user_dispatch(CPUArchState *env,
 }
 
 #ifdef TARGET_X86_64
-struct target_prctl_mm_map {
+typedef struct TargetPrctlMmMap {
     uint64_t start_code;
     uint64_t end_code;
     uint64_t start_data;
@@ -13173,9 +13173,9 @@ struct target_prctl_mm_map {
     uint64_t auxv;
     uint32_t auxv_size;
     uint32_t exe_fd;
-};
+} TargetPrctlMmMap;
 
-struct guest_prctl_mm_map {
+typedef struct GuestPrctlMmMap {
     abi_ulong start_code;
     abi_ulong end_code;
     abi_ulong start_data;
@@ -13187,7 +13187,7 @@ struct guest_prctl_mm_map {
     abi_ulong arg_end;
     abi_ulong env_start;
     abi_ulong env_end;
-};
+} GuestPrctlMmMap;
 
 static abi_long do_prctl_get_auxv(CPUArchState *env, abi_ulong addr,
                                   abi_ulong len)
@@ -13253,9 +13253,9 @@ static abi_ulong guest_mmap_min_addr(void)
 }
 
 static void guest_prctl_mm_read(const struct image_info *info,
-                                struct guest_prctl_mm_map *map)
+                                GuestPrctlMmMap *map)
 {
-    *map = (struct guest_prctl_mm_map) {
+    *map = (GuestPrctlMmMap) {
         .start_code = info->prctl_mm_start_code,
         .end_code = info->prctl_mm_end_code,
         .start_data = info->prctl_mm_start_data,
@@ -13271,7 +13271,7 @@ static void guest_prctl_mm_read(const struct image_info *info,
 }
 
 static void guest_prctl_mm_write(struct image_info *info,
-                                 const struct guest_prctl_mm_map *map)
+                                 const GuestPrctlMmMap *map)
 {
     info->prctl_mm_start_code = info->start_code = map->start_code;
     info->prctl_mm_end_code = info->end_code = map->end_code;
@@ -13290,7 +13290,7 @@ static void guest_prctl_mm_write(struct image_info *info,
     brk_page = HOST_PAGE_ALIGN(target_brk);
 }
 
-static abi_long guest_prctl_mm_validate(const struct guest_prctl_mm_map *map)
+static abi_long guest_prctl_mm_validate(const GuestPrctlMmMap *map)
 {
     const abi_ulong value[] = {
         map->start_code, map->end_code,
@@ -13353,12 +13353,12 @@ static abi_long guest_prctl_set_auxv(struct image_info *info,
     return 0;
 }
 
-struct guest_prctl_exe_file {
+typedef struct GuestPrctlExeFile {
     int fd;
-};
+} GuestPrctlExeFile;
 
 static abi_long guest_prctl_prepare_exe_file(unsigned int fd,
-                                             struct guest_prctl_exe_file *file)
+                                             GuestPrctlExeFile *file)
 {
     struct stat st;
     struct statvfs fs;
@@ -13392,7 +13392,7 @@ static abi_long guest_prctl_prepare_exe_file(unsigned int fd,
 
 /* Called with the linux-user mmap lock held. */
 static void guest_prctl_commit_exe_file(struct image_info *info,
-                                        struct guest_prctl_exe_file *file)
+                                        GuestPrctlExeFile *file)
 {
     int old_fd = info->prctl_mm_exe_fd;
 
@@ -13406,7 +13406,7 @@ static void guest_prctl_commit_exe_file(struct image_info *info,
 static abi_long guest_prctl_set_exe_file(struct image_info *info,
                                          unsigned int fd)
 {
-    struct guest_prctl_exe_file file;
+    GuestPrctlExeFile file;
     abi_long ret = guest_prctl_prepare_exe_file(fd, &file);
 
     if (ret) {
@@ -13423,7 +13423,7 @@ static abi_long do_prctl_set_mm(CPUArchState *env, abi_ulong option,
                                 abi_ulong arg5)
 {
     struct image_info *info = ((TaskState *)env_cpu(env)->opaque)->info;
-    struct guest_prctl_mm_map map;
+    GuestPrctlMmMap map;
     abi_long ret;
 
     if (arg5 || (arg4 && option != PR_SET_MM_AUXV &&
@@ -13433,14 +13433,14 @@ static abi_long do_prctl_set_mm(CPUArchState *env, abi_ulong option,
     }
 
     if (option == PR_SET_MM_MAP_SIZE) {
-        return put_user_u32(sizeof(struct target_prctl_mm_map), addr) ?
+        return put_user_u32(sizeof(TargetPrctlMmMap), addr) ?
                -TARGET_EFAULT : 0;
     }
 
     if (option == PR_SET_MM_MAP) {
-        struct target_prctl_mm_map *target_map;
+        TargetPrctlMmMap *target_map;
         abi_ulong new_auxv[TARGET_X86_64_PRCTL_AUXV_WORDS] = { };
-        struct guest_prctl_exe_file new_exe = { .fd = -1 };
+        GuestPrctlExeFile new_exe = { .fd = -1 };
         abi_ulong auxv;
         uint32_t auxv_size, exe_fd;
         bool replace_exe = false;
@@ -13451,7 +13451,7 @@ static abi_long do_prctl_set_mm(CPUArchState *env, abi_ulong option,
         if (!lock_user_struct(VERIFY_READ, target_map, addr, 1)) {
             return -TARGET_EFAULT;
         }
-        map = (struct guest_prctl_mm_map) {
+        map = (GuestPrctlMmMap) {
             .start_code = tswap64(target_map->start_code),
             .end_code = tswap64(target_map->end_code),
             .start_data = tswap64(target_map->start_data),
@@ -14117,9 +14117,14 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
             char **exec_argp = NULL;
             char *hash_str = NULL;
             char *pidof_arg = NULL;
+            const char *pname;
+            const char *exec_pathname;
+            bool self_exe;
+            bool x86_file;
 #ifdef TARGET_X86_64
             char *prctl_mdwe_env = NULL;
             char *prctl_tsc_env = NULL;
+            bool restore_prctl;
 #endif
             int argc, envc;
             abi_ulong gp;
@@ -14190,13 +14195,13 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
                 goto execveat_efault;
             }
 
-            char *pname = strrchr(p, '/');
-            const char *exec_pathname = path(p);
-            bool self_exe = is_proc_myself((const char *)p, "exe");
+            pname = strrchr(p, '/');
+            exec_pathname = path(p);
+            self_exe = is_proc_myself((const char *)p, "exe");
 #ifdef TARGET_X86_64
-            bool x86_file = self_exe ? guest_self_exe_is_x86(env) :
-                            is_x86_file_at(arg1, exec_pathname, arg5);
-            bool restore_prctl = self_exe ?
+            x86_file = self_exe ? guest_self_exe_is_x86(env) :
+                       is_x86_file_at(arg1, exec_pathname, arg5);
+            restore_prctl = self_exe ?
                 guest_self_exe_restores_guest_state(env) :
                 exec_file_restores_guest_state_at(arg1, exec_pathname,
                                                   arg5, 0);
@@ -14206,8 +14211,8 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
                                                      &prctl_mdwe_env,
                                                      &prctl_tsc_env);
 #else
-            bool x86_file = self_exe ||
-                            is_x86_file_at(arg1, exec_pathname, arg5);
+            x86_file = self_exe ||
+                       is_x86_file_at(arg1, exec_pathname, arg5);
 
             exec_envp = envp;
 #endif
@@ -14341,9 +14346,13 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
             char **exec_argp = NULL;
             char *hash_str = NULL;
             char *pidof_arg = NULL;
+            const char *pname;
+            bool self_exe;
+            bool x86_file;
 #ifdef TARGET_X86_64
             char *prctl_mdwe_env = NULL;
             char *prctl_tsc_env = NULL;
+            bool restore_prctl;
 #endif
             int argc, envc;
             abi_ulong gp;
@@ -14402,12 +14411,12 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
                 goto execve_efault;
             }
 
-            char *pname = strrchr(p, '/');
-            bool self_exe = is_proc_myself((const char *)p, "exe");
+            pname = strrchr(p, '/');
+            self_exe = is_proc_myself((const char *)p, "exe");
 #ifdef TARGET_X86_64
-            bool x86_file = self_exe ? guest_self_exe_is_x86(env) :
-                            is_x86_file_at(AT_FDCWD, path(p), 0);
-            bool restore_prctl = self_exe ?
+            x86_file = self_exe ? guest_self_exe_is_x86(env) :
+                       is_x86_file_at(AT_FDCWD, path(p), 0);
+            restore_prctl = self_exe ?
                 guest_self_exe_restores_guest_state(env) :
                 exec_file_restores_guest_state_at(AT_FDCWD, path(p), 0, 0);
 
@@ -14416,8 +14425,8 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
                                                      &prctl_mdwe_env,
                                                      &prctl_tsc_env);
 #else
-            bool x86_file = self_exe ||
-                            is_x86_file_at(AT_FDCWD, path(p), 0);
+            x86_file = self_exe ||
+                       is_x86_file_at(AT_FDCWD, path(p), 0);
 
             exec_envp = envp;
 #endif

--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -283,8 +283,10 @@ out_marker:
 #ifndef PR_SET_MDWE
 #define PR_SET_MDWE 65
 #define PR_MDWE_REFUSE_EXEC_GAIN (1UL << 0)
-#define PR_MDWE_NO_INHERIT (1UL << 1)
 #define PR_GET_MDWE 66
+#endif
+#ifndef PR_MDWE_NO_INHERIT
+#define PR_MDWE_NO_INHERIT (1UL << 1)
 #endif
 #ifndef PR_GET_AUXV
 #define PR_GET_AUXV 0x41555856
@@ -5857,16 +5859,6 @@ static inline abi_ulong do_shmat(CPUArchState *cpu_env,
         return ret;
     }
 
-#ifdef TARGET_X86_64
-    ret = guest_mdwe_mmap(cpu, shm_info.shm_segsz,
-                          PROT_READ |
-                          (shmflg & SHM_RDONLY ? 0 : PROT_WRITE) |
-                          (shmflg & SHM_EXEC ? PROT_EXEC : 0));
-    if (ret) {
-        return ret;
-    }
-#endif
-
     shmlba = target_shmlba(cpu_env);
 
     if (shmaddr & (shmlba - 1)) {
@@ -5881,6 +5873,17 @@ static inline abi_ulong do_shmat(CPUArchState *cpu_env,
     }
 
     mmap_lock();
+
+#ifdef TARGET_X86_64
+    ret = guest_mdwe_mmap(cpu, shm_info.shm_segsz,
+                          PROT_READ |
+                          (shmflg & SHM_RDONLY ? 0 : PROT_WRITE) |
+                          (shmflg & SHM_EXEC ? PROT_EXEC : 0));
+    if (ret) {
+        mmap_unlock();
+        return ret;
+    }
+#endif
 
     /*
      * We're mapping shared memory, so ensure we generate code for parallel
@@ -13747,6 +13750,7 @@ static abi_long do_prctl_set_vma(abi_ulong operation, abi_ulong start,
     return ret;
 }
 
+/* Called with the linux-user mmap lock held. */
 static abi_long guest_mdwe_mmap(CPUState *cpu, abi_ulong len, int prot)
 {
     TaskState *ts = cpu->opaque;
@@ -13754,9 +13758,7 @@ static abi_long guest_mdwe_mmap(CPUState *cpu, abi_ulong len, int prot)
     int valid = PROT_READ | PROT_WRITE | PROT_EXEC | TARGET_PROT_SEM;
     int current_personality;
 
-    mmap_lock();
     mdwe = ts->info->prctl_mdwe;
-    mmap_unlock();
     if (!(mdwe & TARGET_PR_MDWE_REFUSE_EXEC_GAIN) ||
         !len || (prot & ~valid)) {
         return 0;
@@ -13770,6 +13772,7 @@ static abi_long guest_mdwe_mmap(CPUState *cpu, abi_ulong len, int prot)
            (PROT_WRITE | PROT_EXEC) ? -TARGET_EACCES : 0;
 }
 
+/* Called with the linux-user mmap lock held. */
 static abi_long guest_mdwe_mprotect(CPUState *cpu, abi_ulong start,
                                     abi_ulong len, int prot)
 {
@@ -13778,9 +13781,7 @@ static abi_long guest_mdwe_mprotect(CPUState *cpu, abi_ulong start,
     unsigned int mdwe;
     int valid = PROT_READ | PROT_WRITE | PROT_EXEC | TARGET_PROT_SEM;
 
-    mmap_lock();
     mdwe = ts->info->prctl_mdwe;
-    mmap_unlock();
     if (!(mdwe & TARGET_PR_MDWE_REFUSE_EXEC_GAIN) ||
         !(prot & PROT_EXEC) || (prot & ~valid) ||
         (start & ~TARGET_PAGE_MASK)) {
@@ -15957,8 +15958,10 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
         }
 
 #ifdef TARGET_X86_64
+        mmap_lock();
         ret = guest_mdwe_mmap(cpu, arg2, arg3);
         if (ret) {
+            mmap_unlock();
             return ret;
         }
 #endif
@@ -15967,6 +15970,9 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
                                     target_to_host_bitmask(arg4, mmap_flags_tbl),
                                     arg5,
                                     arg6, 1));
+#ifdef TARGET_X86_64
+        mmap_unlock();
+#endif
 #endif
         return ret;
 #endif
@@ -15997,12 +16003,18 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
             }
         }
 #ifdef TARGET_X86_64
+        mmap_lock();
         ret = guest_mdwe_mprotect(cpu, arg1, arg2, arg3);
         if (ret) {
+            mmap_unlock();
             return ret;
         }
 #endif
-        return get_errno(target_mprotect(arg1, arg2, arg3));
+        ret = get_errno(target_mprotect(arg1, arg2, arg3));
+#ifdef TARGET_X86_64
+        mmap_unlock();
+#endif
+        return ret;
 #ifdef TARGET_NR_mremap
     case TARGET_NR_mremap:
         arg1 = cpu_untagged_addr(cpu, arg1);

--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -5834,6 +5834,9 @@ abi_ulong latx_is_shm(abi_ulong maddr)
     }
     return 0;
 }
+#ifdef TARGET_X86_64
+static abi_long guest_mdwe_mmap(CPUState *cpu, abi_ulong len, int prot);
+#endif
 static inline abi_ulong do_shmat(CPUArchState *cpu_env,
                                  int shmid, abi_ulong shmaddr, int shmflg)
 {
@@ -5852,6 +5855,16 @@ static inline abi_ulong do_shmat(CPUArchState *cpu_env,
         /* can't get length, bail out */
         return ret;
     }
+
+#ifdef TARGET_X86_64
+    ret = guest_mdwe_mmap(cpu, shm_info.shm_segsz,
+                          PROT_READ |
+                          (shmflg & SHM_RDONLY ? 0 : PROT_WRITE) |
+                          (shmflg & SHM_EXEC ? PROT_EXEC : 0));
+    if (ret) {
+        return ret;
+    }
+#endif
 
     shmlba = target_shmlba(cpu_env);
 
@@ -5907,7 +5920,8 @@ static inline abi_ulong do_shmat(CPUArchState *cpu_env,
 
     page_set_flags(raddr, raddr + shm_info.shm_segsz,
                    PAGE_VALID | PAGE_RESET | PAGE_READ |
-                   (shmflg & SHM_RDONLY ? 0 : PAGE_WRITE));
+                   (shmflg & SHM_RDONLY ? 0 : PAGE_WRITE) |
+                   (shmflg & SHM_EXEC ? PAGE_EXEC : 0));
 
     for (i = 0; i < N_SHM_REGIONS; i++) {
         if (!shm_regions[i].in_use) {
@@ -11549,6 +11563,173 @@ struct open_self_maps_data {
     bool smaps;
 };
 
+#ifdef TARGET_X86_64
+typedef struct GuestVmaName {
+    abi_ulong start;
+    abi_ulong end;
+    char *name;
+} GuestVmaName;
+
+static GList *guest_vma_names;
+
+static GuestVmaName *guest_vma_name_new(abi_ulong start, abi_ulong end,
+                                        const char *name)
+{
+    GuestVmaName *entry = g_new(GuestVmaName, 1);
+
+    entry->start = start;
+    entry->end = end;
+    entry->name = g_strdup(name);
+    return entry;
+}
+
+static void guest_vma_name_free(GuestVmaName *entry)
+{
+    g_free(entry->name);
+    g_free(entry);
+}
+
+static gint guest_vma_name_compare(gconstpointer lhs, gconstpointer rhs)
+{
+    const GuestVmaName *a = lhs;
+    const GuestVmaName *b = rhs;
+
+    return a->start < b->start ? -1 : a->start != b->start;
+}
+
+static void guest_vma_name_merge_locked(void)
+{
+    GList *link = guest_vma_names;
+
+    guest_vma_names = g_list_sort(guest_vma_names, guest_vma_name_compare);
+    link = guest_vma_names;
+    while (link && link->next) {
+        GuestVmaName *entry = link->data;
+        GuestVmaName *next = link->next->data;
+
+        if (entry->end == next->start &&
+            strcmp(entry->name, next->name) == 0) {
+            GList *next_link = link->next;
+
+            entry->end = next->end;
+            guest_vma_names = g_list_delete_link(guest_vma_names,
+                                                  next_link);
+            guest_vma_name_free(next);
+        } else {
+            link = link->next;
+        }
+    }
+}
+
+static void guest_vma_name_apply_locked(abi_ulong start, abi_ulong end,
+                                        const char *name)
+{
+    GList *link;
+
+    for (link = guest_vma_names; link; ) {
+        GList *next_link = link->next;
+        GuestVmaName *entry = link->data;
+
+        if (entry->start < end && start < entry->end) {
+            if (entry->start < start) {
+                guest_vma_names = g_list_prepend(
+                    guest_vma_names,
+                    guest_vma_name_new(entry->start, start, entry->name));
+            }
+            if (end < entry->end) {
+                guest_vma_names = g_list_prepend(
+                    guest_vma_names,
+                    guest_vma_name_new(end, entry->end, entry->name));
+            }
+            guest_vma_names = g_list_delete_link(guest_vma_names, link);
+            guest_vma_name_free(entry);
+        }
+        link = next_link;
+    }
+    if (name) {
+        guest_vma_names = g_list_prepend(
+            guest_vma_names, guest_vma_name_new(start, end, name));
+    }
+    guest_vma_name_merge_locked();
+}
+
+static const GuestVmaName *guest_vma_name_find_locked(abi_ulong addr,
+                                                       abi_ulong *next)
+{
+    GList *link;
+
+    for (link = guest_vma_names; link; link = link->next) {
+        const GuestVmaName *entry = link->data;
+
+        if (addr < entry->start) {
+            *next = entry->start;
+            return NULL;
+        }
+        if (addr < entry->end) {
+            *next = entry->end;
+            return entry;
+        }
+    }
+    *next = -1;
+    return NULL;
+}
+
+void guest_vma_name_reset(abi_ulong start, abi_ulong len)
+{
+    abi_ulong end = start + len;
+
+    if (len && end > start) {
+        guest_vma_name_apply_locked(start, end, NULL);
+    }
+}
+
+void guest_vma_name_remap(abi_ulong old_start, abi_ulong old_len,
+                          abi_ulong new_start, abi_ulong new_len)
+{
+    GPtrArray *saved = g_ptr_array_new_with_free_func(
+        (GDestroyNotify)guest_vma_name_free);
+    abi_ulong old_end = old_start + old_len;
+    abi_ulong new_end = new_start + new_len;
+    char *tail_name = NULL;
+    GList *link;
+    guint i;
+
+    for (link = guest_vma_names; link; link = link->next) {
+        GuestVmaName *entry = link->data;
+        abi_ulong start = MAX(entry->start, old_start);
+        abi_ulong end = MIN(entry->end, old_end);
+
+        if (start < end) {
+            g_ptr_array_add(saved, guest_vma_name_new(start - old_start,
+                                                      end - old_start,
+                                                      entry->name));
+            if (end == old_end) {
+                g_free(tail_name);
+                tail_name = g_strdup(entry->name);
+            }
+        }
+    }
+
+    guest_vma_name_apply_locked(old_start, old_end, NULL);
+    guest_vma_name_apply_locked(new_start, new_end, NULL);
+    for (i = 0; i < saved->len; i++) {
+        GuestVmaName *entry = g_ptr_array_index(saved, i);
+
+        if (entry->start >= new_len) {
+            continue;
+        }
+        guest_vma_name_apply_locked(new_start + entry->start,
+                                    new_start + MIN(entry->end, new_len),
+                                    entry->name);
+    }
+    if (new_len > old_len && tail_name) {
+        guest_vma_name_apply_locked(new_start + old_len, new_end, tail_name);
+    }
+    g_free(tail_name);
+    g_ptr_array_free(saved, true);
+}
+#endif
+
 /*
  * Subroutine to output one line of /proc/self/maps,
  * or one region of /proc/self/smaps.
@@ -11660,7 +11841,19 @@ static void open_self_maps_4(const struct open_self_maps_data *d,
                              const MapInfo *mi, abi_ptr start,
                              abi_ptr end, unsigned flags)
 {
+#ifdef TARGET_X86_64
+    while (start < end) {
+        abi_ulong next;
+        const GuestVmaName *entry = guest_vma_name_find_locked(start, &next);
+
+        next = MIN(next, end);
+        open_self_maps_4_line(d, mi, start, next, flags,
+                              entry ? entry->name : NULL);
+        start = next;
+    }
+#else
     open_self_maps_4_line(d, mi, start, end, flags, NULL);
+#endif
 }
 
 /*
@@ -11768,9 +11961,18 @@ static int open_self_maps_1(CPUArchState *cpu_env, int fd, bool smaps)
     CPUState *cpu = env_cpu((CPUArchState *)cpu_env);
     TaskState *ts = cpu->opaque;
     IntervalTreeRoot *map_info = read_self_maps();
+#ifdef TARGET_X86_64
+    struct open_self_maps_data data = {
+        .ts = ts,
+        .host_maps = map_info,
+        .fd = fd,
+        .smaps = smaps,
+    };
+#endif
     IntervalTreeNode *s;
     int count;
 
+    mmap_lock();
     for (s = interval_tree_iter_first(map_info, 0, -1); s;
          s = interval_tree_iter_next(s, 0, -1)) {
         MapInfo *e = container_of(s, MapInfo, itree);
@@ -11780,6 +11982,10 @@ static int open_self_maps_1(CPUArchState *cpu_env, int fd, bool smaps)
             unsigned long max = e->itree.last + 1;
             int flags = page_get_flags(h2g(min));
             const char *path;
+#ifdef TARGET_X86_64
+            abi_ulong next_name;
+            const GuestVmaName *name;
+#endif
 
             max = h2g_valid(max - 1) ?
                 max : (uintptr_t) g2h_untagged(GUEST_ADDR_MAX) + 1;
@@ -11787,6 +11993,15 @@ static int open_self_maps_1(CPUArchState *cpu_env, int fd, bool smaps)
             if (!page_check_range(h2g(min), max - min, flags)) {
                 continue;
             }
+
+#ifdef TARGET_X86_64
+            name = guest_vma_name_find_locked(h2g(min), &next_name);
+            if (name || next_name < h2g(max - 1) + 1) {
+                open_self_maps_4(&data, e, h2g(min), h2g(max - 1) + 1,
+                                 flags);
+                continue;
+            }
+#endif
 
             if (h2g(min) == ts->info->stack_limit) {
                 path = "[stack]";
@@ -11823,6 +12038,7 @@ static int open_self_maps_1(CPUArchState *cpu_env, int fd, bool smaps)
             }
         }
     }
+    mmap_unlock();
 
     free_self_maps(map_info);
 
@@ -13077,44 +13293,78 @@ static abi_long do_prctl_set_vma(abi_ulong operation, abi_ulong start,
                                  abi_ulong len,
                                  abi_ulong name_addr)
 {
-    char *name = NULL;
+    char name_buffer[80];
+    const char *name = NULL;
     abi_ulong rounded_len;
+    abi_ulong end;
+    abi_ulong addr;
+    abi_ulong anon_start = 0;
+    bool in_anon = false;
     abi_long ret;
+    size_t name_len;
 
     if (operation != PR_SET_VMA_ANON_NAME) {
         return -TARGET_EINVAL;
     }
     if (name_addr) {
-        name = lock_user_string(name_addr);
-        if (!name) {
-            return -TARGET_EFAULT;
+        for (name_len = 0; name_len < sizeof(name_buffer); name_len++) {
+            uint8_t ch;
+
+            if (get_user_u8(ch, name_addr + name_len)) {
+                return -TARGET_EFAULT;
+            }
+            name_buffer[name_len] = ch;
+            if (!ch) {
+                break;
+            }
+            if (ch <= 0x1f || ch >= 0x7f || strchr("\\`$[]", ch)) {
+                return -TARGET_EINVAL;
+            }
         }
+        if (name_len == sizeof(name_buffer)) {
+            return -TARGET_ENAMETOOLONG;
+        }
+        name = name_buffer;
     }
     if (start & ~TARGET_PAGE_MASK) {
-        ret = -TARGET_EINVAL;
-        goto out;
+        return -TARGET_EINVAL;
     }
     rounded_len = TARGET_PAGE_ALIGN(len);
     if ((len && !rounded_len) || start + rounded_len < start) {
-        ret = -TARGET_EINVAL;
-        goto out;
+        return -TARGET_EINVAL;
     }
     if (!rounded_len) {
-        ret = 0;
-        goto out;
+        return 0;
     }
-    if (!page_check_range(start, rounded_len, PAGE_VALID)) {
-        ret = -TARGET_ENOMEM;
-        goto out;
-    }
+    end = start + rounded_len;
+    ret = 0;
 
-    ret = get_errno(prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME,
-                          (uintptr_t)g2h_untagged(start), rounded_len,
-                          (uintptr_t)name));
-out:
-    if (name) {
-        unlock_user(name, name_addr, 0);
+    mmap_lock();
+    for (addr = start; addr < end; addr += TARGET_PAGE_SIZE) {
+        int flags = page_get_flags(addr);
+
+        if ((flags & (PAGE_VALID | PAGE_ANON)) ==
+            (PAGE_VALID | PAGE_ANON)) {
+            if (!in_anon) {
+                anon_start = addr;
+                in_anon = true;
+            }
+            continue;
+        }
+        if (in_anon) {
+            guest_vma_name_apply_locked(anon_start, addr, name);
+            in_anon = false;
+        }
+        if (flags & PAGE_VALID) {
+            ret = -TARGET_EBADF;
+            break;
+        }
+        ret = -TARGET_ENOMEM;
     }
+    if (in_anon) {
+        guest_vma_name_apply_locked(anon_start, addr, name);
+    }
+    mmap_unlock();
     return ret;
 }
 
@@ -13122,10 +13372,16 @@ static abi_long guest_mdwe_mmap(CPUState *cpu, abi_ulong len, int prot)
 {
     TaskState *ts = cpu->opaque;
     int valid = PROT_READ | PROT_WRITE | PROT_EXEC | TARGET_PROT_SEM;
+    int current_personality;
 
     if (!(ts->info->prctl_mdwe & TARGET_PR_MDWE_REFUSE_EXEC_GAIN) ||
         !len || (prot & ~valid)) {
         return 0;
+    }
+    current_personality = personality(0xffffffffUL);
+    if ((prot & PROT_READ) && current_personality != -1 &&
+        (current_personality & READ_IMPLIES_EXEC)) {
+        prot |= PROT_EXEC;
     }
     return (prot & (PROT_WRITE | PROT_EXEC)) ==
            (PROT_WRITE | PROT_EXEC) ? -TARGET_EACCES : 0;
@@ -18353,9 +18609,10 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
     }
 #endif
 
-#if defined(TARGET_NR_set_tid_address) && defined(__NR_set_tid_address)
+#ifdef TARGET_NR_set_tid_address
     case TARGET_NR_set_tid_address:
-        return get_errno(set_tid_address((int *)g2h(cpu, arg1)));
+        ((TaskState *)cpu->opaque)->child_tidptr = arg1;
+        return get_errno(sys_gettid());
 #endif
 
     case TARGET_NR_tkill:

--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -5926,7 +5926,8 @@ static inline abi_ulong do_shmat(CPUArchState *cpu_env,
     guest_vma_name_reset(raddr, shm_info.shm_segsz);
 #endif
     page_set_flags(raddr, raddr + shm_info.shm_segsz,
-                   PAGE_VALID | PAGE_RESET | PAGE_ANON | PAGE_READ |
+                   PAGE_VALID | PAGE_RESET | PAGE_ANON | PAGE_MEMSHARE |
+                   PAGE_READ |
                    (shmflg & SHM_RDONLY ? 0 : PAGE_WRITE) |
                    (shmflg & SHM_EXEC ? PAGE_EXEC : 0));
 

--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -757,9 +757,6 @@ _syscall3(int,sys_syslog,int,type,char*,bufp,int,len)
 #ifdef __NR_exit_group
 _syscall1(int,exit_group,int,error_code)
 #endif
-#if defined(TARGET_NR_set_tid_address) && defined(__NR_set_tid_address)
-_syscall1(int,set_tid_address,int *,tidptr)
-#endif
 #if defined(__NR_futex)
 _syscall6(int,sys_futex,int *,uaddr,int,op,int,val,
           const struct timespec *,timeout,int *,uaddr2,int,val3)
@@ -12062,12 +12059,22 @@ static int open_self_maps_1(CPUArchState *cpu_env, int fd, bool smaps)
 
 static int open_self_maps(void *cpu_env, int fd, const char *oldpath)
 {
+#ifdef TARGET_X86_64
+    if (guest_vma_names) {
+        return open_self_maps_1_real((CPUArchState *)cpu_env, fd, false);
+    }
+#endif
     return option_real_maps ? open_self_maps_1_real((CPUArchState *)cpu_env, fd, false)
         : open_self_maps_1((CPUArchState *)cpu_env, fd, false);
 }
 
 static int open_self_smaps(void *cpu_env, int fd, const char *oldpath)
 {
+#ifdef TARGET_X86_64
+    if (guest_vma_names) {
+        return open_self_maps_1_real((CPUArchState *)cpu_env, fd, true);
+    }
+#endif
     return option_real_maps ? open_self_maps_1_real((CPUArchState *)cpu_env, fd, true)
         : open_self_maps_1((CPUArchState *)cpu_env, fd, true);
 }

--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -5915,8 +5915,11 @@ static inline abi_ulong do_shmat(CPUArchState *cpu_env,
     }
     raddr=h2g((unsigned long)host_raddr);
 
+#ifdef TARGET_X86_64
+    guest_vma_name_reset(raddr, shm_info.shm_segsz);
+#endif
     page_set_flags(raddr, raddr + shm_info.shm_segsz,
-                   PAGE_VALID | PAGE_RESET | PAGE_READ |
+                   PAGE_VALID | PAGE_RESET | PAGE_ANON | PAGE_READ |
                    (shmflg & SHM_RDONLY ? 0 : PAGE_WRITE) |
                    (shmflg & SHM_EXEC ? PAGE_EXEC : 0));
 
@@ -5943,14 +5946,19 @@ static inline abi_long do_shmdt(abi_ulong shmaddr)
 
     mmap_lock();
 
-    for (i = 0; i < N_SHM_REGIONS; ++i) {
-        if (shm_regions[i].in_use && shm_regions[i].start == shmaddr) {
-            shm_regions[i].in_use = false;
-            page_set_flags(shmaddr, shmaddr + shm_regions[i].size, 0);
-            break;
+    rv = get_errno(shmdt(g2h_untagged(shmaddr)));
+    if (!is_error(rv)) {
+        for (i = 0; i < N_SHM_REGIONS; ++i) {
+            if (shm_regions[i].in_use && shm_regions[i].start == shmaddr) {
+#ifdef TARGET_X86_64
+                guest_vma_name_reset(shmaddr, shm_regions[i].size);
+#endif
+                page_set_flags(shmaddr, shmaddr + shm_regions[i].size, 0);
+                shm_regions[i].in_use = false;
+                break;
+            }
         }
     }
-    rv = get_errno(shmdt(g2h_untagged(shmaddr)));
 
     mmap_unlock();
 
@@ -9813,9 +9821,11 @@ static int do_fork(CPUArchState *env, unsigned int flags, abi_ulong newsp,
                 put_user_u32(sys_gettid(), child_tidptr);
             ts = (TaskState *)cpu->opaque;
 #ifdef TARGET_X86_64
+            mmap_lock();
             if (ts->info->prctl_mdwe & TARGET_PR_MDWE_NO_INHERIT) {
                 ts->info->prctl_mdwe = 0;
             }
+            mmap_unlock();
 #endif
             /* Linux clears syscall user dispatch in every fork child. */
             ts->sys_dispatch = 0;
@@ -11264,8 +11274,13 @@ static int open_self_cmdline(void *cpu_env, int fd, const char *oldpath)
     CPUState *cpu = env_cpu((CPUArchState *)cpu_env);
 #ifdef TARGET_X86_64
     struct image_info *info = ((TaskState *)cpu->opaque)->info;
-    abi_ulong addr = info->prctl_mm_arg_start;
-    abi_ulong remaining = info->prctl_mm_arg_end - addr;
+    abi_ulong addr;
+    abi_ulong remaining;
+
+    mmap_lock();
+    addr = info->prctl_mm_arg_start;
+    remaining = info->prctl_mm_arg_end - addr;
+    mmap_unlock();
 
     while (remaining) {
         size_t len = MIN((abi_ulong)TARGET_PAGE_SIZE, remaining);
@@ -11298,15 +11313,25 @@ static int open_self_cmdline(void *cpu_env, int fd, const char *oldpath)
     return 0;
 }
 
-static const char *guest_self_exe_open_path(CPUArchState *env,
-                                            char *buffer, size_t size)
+static const char *guest_self_exe_open_path(CPUArchState *env, char *buffer,
+                                            size_t size, int *owned_fd)
 {
+    *owned_fd = -1;
 #ifdef TARGET_X86_64
     TaskState *ts = env_cpu(env)->opaque;
+    bool overridden;
 
-    if (ts->info->prctl_mm_exe_fd >= 0) {
-        snprintf(buffer, size, "/proc/self/fd/%d",
-                 ts->info->prctl_mm_exe_fd);
+    mmap_lock();
+    overridden = ts->info->prctl_mm_exe_fd >= 0;
+    if (overridden) {
+        *owned_fd = fcntl(ts->info->prctl_mm_exe_fd, F_DUPFD_CLOEXEC, 0);
+    }
+    mmap_unlock();
+    if (overridden) {
+        if (*owned_fd < 0) {
+            return NULL;
+        }
+        snprintf(buffer, size, "/proc/self/fd/%d", *owned_fd);
         return buffer;
     }
 #endif
@@ -11318,13 +11343,54 @@ static const char *guest_self_exe_link_path(CPUArchState *env,
 {
 #ifdef TARGET_X86_64
     TaskState *ts = env_cpu(env)->opaque;
+    bool overridden;
 
-    if (ts->info->prctl_mm_exe_path) {
+    mmap_lock();
+    overridden = ts->info->prctl_mm_exe_path != NULL;
+    if (overridden) {
         pstrcpy(buffer, size, ts->info->prctl_mm_exe_path);
+    }
+    mmap_unlock();
+    if (overridden) {
         return buffer;
     }
 #endif
     return realpath(exec_path, buffer);
+}
+
+static bool guest_self_exe_exec_paths(CPUArchState *env, char *link_buffer,
+                                      size_t link_size,
+                                      const char **link_path,
+                                      char *open_buffer, size_t open_size,
+                                      const char **open_path, int *owned_fd)
+{
+    *owned_fd = -1;
+#ifdef TARGET_X86_64
+    TaskState *ts = env_cpu(env)->opaque;
+    bool overridden;
+
+    mmap_lock();
+    overridden = ts->info->prctl_mm_exe_fd >= 0;
+    if (overridden) {
+        *owned_fd = fcntl(ts->info->prctl_mm_exe_fd, F_DUPFD_CLOEXEC, 0);
+        if (*owned_fd >= 0) {
+            pstrcpy(link_buffer, link_size, ts->info->prctl_mm_exe_path);
+        }
+    }
+    mmap_unlock();
+    if (overridden) {
+        if (*owned_fd < 0) {
+            return false;
+        }
+        snprintf(open_buffer, open_size, "/proc/self/fd/%d", *owned_fd);
+        *link_path = link_buffer;
+        *open_path = open_buffer;
+        return true;
+    }
+#endif
+    *link_path = realpath(exec_path, link_buffer);
+    *open_path = exec_path;
+    return *link_path != NULL;
 }
 
 static char * get_key_value_from_file(const char * key, char * real_path)
@@ -12060,7 +12126,12 @@ static int open_self_maps_1(CPUArchState *cpu_env, int fd, bool smaps)
 static int open_self_maps(void *cpu_env, int fd, const char *oldpath)
 {
 #ifdef TARGET_X86_64
-    if (guest_vma_names) {
+    bool have_guest_vma_names;
+
+    mmap_lock();
+    have_guest_vma_names = guest_vma_names != NULL;
+    mmap_unlock();
+    if (have_guest_vma_names) {
         return open_self_maps_1_real((CPUArchState *)cpu_env, fd, false);
     }
 #endif
@@ -12071,7 +12142,12 @@ static int open_self_maps(void *cpu_env, int fd, const char *oldpath)
 static int open_self_smaps(void *cpu_env, int fd, const char *oldpath)
 {
 #ifdef TARGET_X86_64
-    if (guest_vma_names) {
+    bool have_guest_vma_names;
+
+    mmap_lock();
+    have_guest_vma_names = guest_vma_names != NULL;
+    mmap_unlock();
+    if (have_guest_vma_names) {
         return open_self_maps_1_real((CPUArchState *)cpu_env, fd, true);
     }
 #endif
@@ -12105,12 +12181,38 @@ static int open_self_stat(void *cpu_env, int fd, const char *oldpath)
     TaskState *ts = cpu->opaque;
     g_autoptr(GString) buf = g_string_new(NULL);
     int i = 0;
-
     FILE *fp;
     char *orig = NULL;
     char *word = NULL;
     size_t orig_len = 0;
     int word_len = 0;
+#ifdef TARGET_X86_64
+    struct {
+        abi_ulong start_code;
+        abi_ulong end_code;
+        abi_ulong start_stack;
+        abi_ulong start_data;
+        abi_ulong end_data;
+        abi_ulong start_brk;
+        abi_ulong arg_start;
+        abi_ulong arg_end;
+        abi_ulong env_start;
+        abi_ulong env_end;
+    } mm;
+
+    mmap_lock();
+    mm.start_code = ts->info->prctl_mm_start_code;
+    mm.end_code = ts->info->prctl_mm_end_code;
+    mm.start_stack = ts->info->prctl_mm_start_stack;
+    mm.start_data = ts->info->prctl_mm_start_data;
+    mm.end_data = ts->info->prctl_mm_end_data;
+    mm.start_brk = ts->info->prctl_mm_start_brk;
+    mm.arg_start = ts->info->prctl_mm_arg_start;
+    mm.arg_end = ts->info->prctl_mm_arg_end;
+    mm.env_start = ts->info->prctl_mm_env_start;
+    mm.env_end = ts->info->prctl_mm_env_end;
+    mmap_unlock();
+#endif
 
     fp = fopen("/proc/self/stat", "r");
     if (fp == NULL || getline(&orig, &orig_len, fp) == -1)
@@ -12148,35 +12250,35 @@ static int open_self_stat(void *cpu_env, int fd, const char *oldpath)
 #ifdef TARGET_X86_64
         } else if (i == 25) {
             g_string_printf(buf, TARGET_ABI_FMT_ld " ",
-                            ts->info->prctl_mm_start_code);
+                            mm.start_code);
         } else if (i == 26) {
             g_string_printf(buf, TARGET_ABI_FMT_ld " ",
-                            ts->info->prctl_mm_end_code);
+                            mm.end_code);
         } else if (i == 27) {
             /* stack bottom */
             g_string_printf(buf, TARGET_ABI_FMT_ld " ",
-                            ts->info->prctl_mm_start_stack);
+                            mm.start_stack);
         } else if (i == 44) {
             g_string_printf(buf, TARGET_ABI_FMT_ld " ",
-                            ts->info->prctl_mm_start_data);
+                            mm.start_data);
         } else if (i == 45) {
             g_string_printf(buf, TARGET_ABI_FMT_ld " ",
-                            ts->info->prctl_mm_end_data);
+                            mm.end_data);
         } else if (i == 46) {
             g_string_printf(buf, TARGET_ABI_FMT_ld " ",
-                            ts->info->prctl_mm_start_brk);
+                            mm.start_brk);
         } else if (i == 47) {
             g_string_printf(buf, TARGET_ABI_FMT_ld " ",
-                            ts->info->prctl_mm_arg_start);
+                            mm.arg_start);
         } else if (i == 48) {
             g_string_printf(buf, TARGET_ABI_FMT_ld " ",
-                            ts->info->prctl_mm_arg_end);
+                            mm.arg_end);
         } else if (i == 49) {
             g_string_printf(buf, TARGET_ABI_FMT_ld " ",
-                            ts->info->prctl_mm_env_start);
+                            mm.env_start);
         } else if (i == 50) {
             g_string_printf(buf, TARGET_ABI_FMT_ld " ",
-                            ts->info->prctl_mm_env_end);
+                            mm.env_end);
 #else
         } else if (i == 27) {
             /* stack bottom */
@@ -12204,8 +12306,20 @@ static int open_self_auxv(void *cpu_env, int fd, const char *oldpath)
     CPUState *cpu = env_cpu((CPUArchState *)cpu_env);
     TaskState *ts = cpu->opaque;
 #ifdef TARGET_X86_64
-    const char *ptr = (const char *)ts->info->prctl_auxv;
-    size_t len = sizeof(ts->info->prctl_auxv);
+    abi_ulong auxv[TARGET_X86_64_PRCTL_AUXV_WORDS];
+    const char *ptr = (const char *)auxv;
+    size_t words;
+    size_t len;
+
+    mmap_lock();
+    memcpy(auxv, ts->info->prctl_auxv, sizeof(auxv));
+    mmap_unlock();
+    for (words = 0; words + 1 < ARRAY_SIZE(auxv); words += 2) {
+        if (auxv[words] == 0) {
+            break;
+        }
+    }
+    len = MIN(words + 2, ARRAY_SIZE(auxv)) * sizeof(auxv[0]);
 
     while (len > 0) {
         ssize_t written = write(fd, ptr, len);
@@ -12576,12 +12690,21 @@ static int do_openat(void *cpu_env, int dirfd, const char *pathname, int flags, 
 
     if (is_proc_myself(pathname, "exe")) {
         char exe_path_buffer[64];
+        int exe_fd;
         const char *exe_pathname;
+        int ret;
 
         exe_pathname = guest_self_exe_open_path(cpu_env, exe_path_buffer,
-                                                sizeof(exe_path_buffer));
-
-        return safe_openat(AT_FDCWD, exe_pathname, flags, mode);
+                                                sizeof(exe_path_buffer),
+                                                &exe_fd);
+        if (!exe_pathname) {
+            return -1;
+        }
+        ret = safe_openat(AT_FDCWD, exe_pathname, flags, mode);
+        if (exe_fd >= 0) {
+            close(exe_fd);
+        }
+        return ret;
     }
 
     for (fake_open = fakes; fake_open->filename; fake_open++) {
@@ -12875,6 +12998,7 @@ static abi_long do_prctl_get_auxv(CPUArchState *env, abi_ulong addr,
     struct image_info *info = ts->info;
     size_t size = MIN((size_t)len, sizeof(info->prctl_auxv));
 
+    mmap_lock();
     if (!info->prctl_auxv_initialized) {
         size_t initial_size = MIN((size_t)info->auxv_len,
                                   sizeof(info->prctl_auxv));
@@ -12883,14 +13007,17 @@ static abi_long do_prctl_get_auxv(CPUArchState *env, abi_ulong addr,
         if (initial_size && copy_from_user(info->prctl_auxv,
                                            info->saved_auxv,
                                            initial_size)) {
+            mmap_unlock();
             return -TARGET_EFAULT;
         }
         info->prctl_auxv_initialized = true;
     }
 
     if (size && copy_to_user(addr, info->prctl_auxv, size)) {
+        mmap_unlock();
         return -TARGET_EFAULT;
     }
+    mmap_unlock();
     return sizeof(info->prctl_auxv);
 }
 
@@ -12905,6 +13032,11 @@ static bool guest_has_capability(unsigned int capability)
 
     return word < ARRAY_SIZE(data) && capget(&header, data) == 0 &&
            (data[word].effective & (1U << (capability % 32)));
+}
+
+static bool guest_has_initial_sys_resource_capability(void)
+{
+    return prctl(PR_GET_IO_FLUSHER, 0, 0, 0, 0) >= 0;
 }
 
 static abi_ulong guest_mmap_min_addr(void)
@@ -13013,16 +13145,23 @@ static abi_long guest_prctl_set_auxv(struct image_info *info,
     }
     auxv[ARRAY_SIZE(auxv) - 2] = 0;
     auxv[ARRAY_SIZE(auxv) - 1] = 0;
+    mmap_lock();
     if (replace_all) {
         memcpy(info->prctl_auxv, auxv, sizeof(auxv));
     } else {
         memcpy(info->prctl_auxv, auxv, len);
     }
+    mmap_unlock();
     return 0;
 }
 
-static abi_long guest_prctl_set_exe_file(struct image_info *info,
-                                         unsigned int fd)
+struct guest_prctl_exe_file {
+    int fd;
+    char *path;
+};
+
+static abi_long guest_prctl_prepare_exe_file(unsigned int fd,
+                                             struct guest_prctl_exe_file *file)
 {
     struct stat st;
     struct statvfs fs;
@@ -13030,6 +13169,9 @@ static abi_long guest_prctl_set_exe_file(struct image_info *info,
     char path[PATH_MAX];
     ssize_t path_len;
     int saved_fd;
+
+    file->fd = -1;
+    file->path = NULL;
 
     if (fstat(fd, &st) < 0) {
         return get_errno(-1);
@@ -13054,12 +13196,40 @@ static abi_long guest_prctl_set_exe_file(struct image_info *info,
     }
     path[path_len] = 0;
 
-    if (info->prctl_mm_exe_fd >= 0) {
-        close(info->prctl_mm_exe_fd);
+    file->fd = saved_fd;
+    file->path = g_strdup(path);
+    return 0;
+}
+
+/* Called with the linux-user mmap lock held. */
+static void guest_prctl_commit_exe_file(struct image_info *info,
+                                        struct guest_prctl_exe_file *file)
+{
+    int old_fd = info->prctl_mm_exe_fd;
+    char *old_path = info->prctl_mm_exe_path;
+
+    info->prctl_mm_exe_fd = file->fd;
+    info->prctl_mm_exe_path = file->path;
+    file->fd = -1;
+    file->path = NULL;
+    if (old_fd >= 0) {
+        close(old_fd);
     }
-    g_free(info->prctl_mm_exe_path);
-    info->prctl_mm_exe_fd = saved_fd;
-    info->prctl_mm_exe_path = g_strdup(path);
+    g_free(old_path);
+}
+
+static abi_long guest_prctl_set_exe_file(struct image_info *info,
+                                         unsigned int fd)
+{
+    struct guest_prctl_exe_file file;
+    abi_long ret = guest_prctl_prepare_exe_file(fd, &file);
+
+    if (ret) {
+        return ret;
+    }
+    mmap_lock();
+    guest_prctl_commit_exe_file(info, &file);
+    mmap_unlock();
     return 0;
 }
 
@@ -13085,8 +13255,10 @@ static abi_long do_prctl_set_mm(CPUArchState *env, abi_ulong option,
     if (option == PR_SET_MM_MAP) {
         struct target_prctl_mm_map *target_map;
         abi_ulong new_auxv[TARGET_X86_64_PRCTL_AUXV_WORDS] = { };
+        struct guest_prctl_exe_file new_exe = { .fd = -1 };
         abi_ulong auxv;
         uint32_t auxv_size, exe_fd;
+        bool replace_exe = false;
 
         if (arg4 != sizeof(*target_map)) {
             return -TARGET_EINVAL;
@@ -13137,19 +13309,25 @@ static abi_long do_prctl_set_mm(CPUArchState *env, abi_ulong option,
                 !guest_has_capability(checkpoint_cap)) {
                 return -TARGET_EPERM;
             }
-            ret = guest_prctl_set_exe_file(info, exe_fd);
+            ret = guest_prctl_prepare_exe_file(exe_fd, &new_exe);
             if (ret) {
                 return ret;
             }
+            replace_exe = true;
         }
+        mmap_lock();
         if (auxv_size) {
             memcpy(info->prctl_auxv, new_auxv, sizeof(new_auxv));
         }
+        if (replace_exe) {
+            guest_prctl_commit_exe_file(info, &new_exe);
+        }
         guest_prctl_mm_write(info, &map);
+        mmap_unlock();
         return 0;
     }
 
-    if (!guest_has_capability(CAP_SYS_RESOURCE)) {
+    if (!guest_has_initial_sys_resource_capability()) {
         return -TARGET_EPERM;
     }
     if (option == PR_SET_MM_AUXV) {
@@ -13162,6 +13340,7 @@ static abi_long do_prctl_set_mm(CPUArchState *env, abi_ulong option,
         return -TARGET_EINVAL;
     }
 
+    mmap_lock();
     guest_prctl_mm_read(info, &map);
     switch (option) {
     case PR_SET_MM_START_CODE:
@@ -13198,11 +13377,13 @@ static abi_long do_prctl_set_mm(CPUArchState *env, abi_ulong option,
         map.env_end = addr;
         break;
     default:
+        mmap_unlock();
         return -TARGET_EINVAL;
     }
 
     ret = guest_prctl_mm_validate(&map);
     if (ret) {
+        mmap_unlock();
         return ret;
     }
     switch (option) {
@@ -13212,10 +13393,12 @@ static abi_long do_prctl_set_mm(CPUArchState *env, abi_ulong option,
     case PR_SET_MM_ENV_START:
     case PR_SET_MM_ENV_END:
         if (!page_get_flags(addr)) {
+            mmap_unlock();
             return -TARGET_EFAULT;
         }
     }
     guest_prctl_mm_write(info, &map);
+    mmap_unlock();
     return 0;
 }
 
@@ -13277,22 +13460,30 @@ static abi_long do_prctl_mdwe(CPUArchState *env, bool set,
 {
     struct image_info *info = ((TaskState *)env_cpu(env)->opaque)->info;
     unsigned long valid = PR_MDWE_REFUSE_EXEC_GAIN | PR_MDWE_NO_INHERIT;
+    abi_long ret;
 
+    mmap_lock();
     if (!set) {
         if (arg2 || arg3 || arg4 || arg5) {
+            mmap_unlock();
             return -TARGET_EINVAL;
         }
-        return info->prctl_mdwe;
+        ret = info->prctl_mdwe;
+        mmap_unlock();
+        return ret;
     }
     if (arg3 || arg4 || arg5 || (arg2 & ~valid) ||
         ((arg2 & PR_MDWE_NO_INHERIT) &&
          !(arg2 & PR_MDWE_REFUSE_EXEC_GAIN))) {
+        mmap_unlock();
         return -TARGET_EINVAL;
     }
     if (info->prctl_mdwe && info->prctl_mdwe != arg2) {
+        mmap_unlock();
         return -TARGET_EPERM;
     }
     info->prctl_mdwe = arg2;
+    mmap_unlock();
     return 0;
 }
 
@@ -13378,10 +13569,14 @@ static abi_long do_prctl_set_vma(abi_ulong operation, abi_ulong start,
 static abi_long guest_mdwe_mmap(CPUState *cpu, abi_ulong len, int prot)
 {
     TaskState *ts = cpu->opaque;
+    unsigned int mdwe;
     int valid = PROT_READ | PROT_WRITE | PROT_EXEC | TARGET_PROT_SEM;
     int current_personality;
 
-    if (!(ts->info->prctl_mdwe & TARGET_PR_MDWE_REFUSE_EXEC_GAIN) ||
+    mmap_lock();
+    mdwe = ts->info->prctl_mdwe;
+    mmap_unlock();
+    if (!(mdwe & TARGET_PR_MDWE_REFUSE_EXEC_GAIN) ||
         !len || (prot & ~valid)) {
         return 0;
     }
@@ -13399,9 +13594,13 @@ static abi_long guest_mdwe_mprotect(CPUState *cpu, abi_ulong start,
 {
     TaskState *ts = cpu->opaque;
     abi_ulong end, addr;
+    unsigned int mdwe;
     int valid = PROT_READ | PROT_WRITE | PROT_EXEC | TARGET_PROT_SEM;
 
-    if (!(ts->info->prctl_mdwe & TARGET_PR_MDWE_REFUSE_EXEC_GAIN) ||
+    mmap_lock();
+    mdwe = ts->info->prctl_mdwe;
+    mmap_unlock();
+    if (!(mdwe & TARGET_PR_MDWE_REFUSE_EXEC_GAIN) ||
         !(prot & PROT_EXEC) || (prot & ~valid) ||
         (start & ~TARGET_PAGE_MASK)) {
         return 0;
@@ -13428,7 +13627,12 @@ static char *guest_prctl_exec_env(CPUArchState *env, const char *name)
     TaskState *ts = env_cpu(env)->opaque;
 
     if (strcmp(name, LATX_GUEST_MDWE_ENV) == 0) {
-        if (ts->info->prctl_mdwe == TARGET_PR_MDWE_REFUSE_EXEC_GAIN) {
+        unsigned int mdwe;
+
+        mmap_lock();
+        mdwe = ts->info->prctl_mdwe;
+        mmap_unlock();
+        if (mdwe == TARGET_PR_MDWE_REFUSE_EXEC_GAIN) {
             return g_strdup_printf("%s=1", LATX_GUEST_MDWE_ENV);
         }
     } else if (strcmp(name, LATX_GUEST_TSC_ENV) == 0) {
@@ -13441,29 +13645,41 @@ static char *guest_prctl_exec_env(CPUArchState *env, const char *name)
     return NULL;
 }
 
-static char **append_guest_prctl_exec_env(CPUArchState *env, char **envp,
-                                          int envc, char **mdwe_env,
-                                          char **tsc_env)
+static bool guest_prctl_exec_env_reserved(const char *entry, const char *name)
 {
+    size_t len = strlen(name);
+
+    return strncmp(entry, name, len) == 0 && entry[len] == '=';
+}
+
+static char **prepare_guest_prctl_exec_env(CPUArchState *env, char **envp,
+                                           int envc, char **mdwe_env,
+                                           char **tsc_env)
+{
+    char **exec_envp;
+    int kept = 0;
     int extra = 0;
+    int i;
 
     *mdwe_env = guest_prctl_exec_env(env, LATX_GUEST_MDWE_ENV);
     *tsc_env = guest_prctl_exec_env(env, LATX_GUEST_TSC_ENV);
     extra += *mdwe_env != NULL;
     extra += *tsc_env != NULL;
-    if (!extra) {
-        return envp;
+    exec_envp = g_new(char *, envc + extra + 1);
+    for (i = 0; i < envc; i++) {
+        if (!guest_prctl_exec_env_reserved(envp[i], LATX_GUEST_MDWE_ENV) &&
+            !guest_prctl_exec_env_reserved(envp[i], LATX_GUEST_TSC_ENV)) {
+            exec_envp[kept++] = envp[i];
+        }
     }
-
-    envp = g_renew(char *, envp, envc + extra + 1);
     if (*mdwe_env) {
-        envp[envc++] = *mdwe_env;
+        exec_envp[kept++] = *mdwe_env;
     }
     if (*tsc_env) {
-        envp[envc++] = *tsc_env;
+        exec_envp[kept++] = *tsc_env;
     }
-    envp[envc] = NULL;
-    return envp;
+    exec_envp[kept] = NULL;
+    return exec_envp;
 }
 #endif
 
@@ -13711,7 +13927,7 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
 #ifdef TARGET_NR_execveat
     case TARGET_NR_execveat:
         {
-            char **argp, **envp;
+            char **argp, **envp, **exec_envp = NULL;
 #ifdef TARGET_X86_64
             char *prctl_mdwe_env = NULL;
             char *prctl_tsc_env = NULL;
@@ -13779,9 +13995,11 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
             *q = NULL;
 
 #ifdef TARGET_X86_64
-            envp = append_guest_prctl_exec_env(env, envp, envc,
-                                               &prctl_mdwe_env,
-                                               &prctl_tsc_env);
+            exec_envp = prepare_guest_prctl_exec_env(env, envp, envc,
+                                                     &prctl_mdwe_env,
+                                                     &prctl_tsc_env);
+#else
+            exec_envp = envp;
 #endif
 
             p = lock_user_string(arg2);
@@ -13849,14 +14067,24 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
              */
             if (is_proc_myself((const char *)p, "exe")) {
                 char exe_path_buffer[64];
-                const char *exe_pathname =
-                    guest_self_exe_open_path(cpu_env, exe_path_buffer,
-                                             sizeof(exe_path_buffer));
+                const char *exe_pathname;
+                int exe_fd;
 
-                ret = get_errno(safe_execveat(AT_FDCWD, exe_pathname,
-                                              argp, envp, arg5));
+                exe_pathname = guest_self_exe_open_path(
+                    cpu_env, exe_path_buffer, sizeof(exe_path_buffer),
+                    &exe_fd);
+                if (!exe_pathname) {
+                    ret = get_errno(-1);
+                } else {
+                    ret = get_errno(safe_execveat(AT_FDCWD, exe_pathname,
+                                                  argp, exec_envp, arg5));
+                    if (exe_fd >= 0) {
+                        close(exe_fd);
+                    }
+                }
             } else {
-                ret = get_errno(safe_execveat(arg1, p, argp, envp, arg5));
+                ret = get_errno(safe_execveat(arg1, p, argp, exec_envp,
+                                              arg5));
             }
             unlock_user(p, arg1, 0);
 
@@ -13888,13 +14116,16 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
             g_free(prctl_mdwe_env);
             g_free(prctl_tsc_env);
 #endif
+            if (exec_envp != envp) {
+                g_free(exec_envp);
+            }
             g_free(envp);
         }
         return ret;
 #endif
     case TARGET_NR_execve:
         {
-            char **argp, **envp;
+            char **argp, **envp, **exec_envp = NULL;
 #ifdef TARGET_X86_64
             char *prctl_mdwe_env = NULL;
             char *prctl_tsc_env = NULL;
@@ -13950,9 +14181,11 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
             *q = NULL;
 
 #ifdef TARGET_X86_64
-            envp = append_guest_prctl_exec_env(env, envp, envc,
-                                               &prctl_mdwe_env,
-                                               &prctl_tsc_env);
+            exec_envp = prepare_guest_prctl_exec_env(env, envp, envc,
+                                                     &prctl_mdwe_env,
+                                                     &prctl_tsc_env);
+#else
+            exec_envp = envp;
 #endif
 
             if (!(p = lock_user_string(arg1)))
@@ -14008,20 +14241,27 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
             if (is_proc_myself((const char *)p, "exe")) {
                 char real[PATH_MAX];
                 char exe_path_buffer[64];
-                const char *temp = guest_self_exe_link_path(cpu_env, real,
-                                                            sizeof(real));
-                const char *exe_pathname =
-                    guest_self_exe_open_path(cpu_env, exe_path_buffer,
-                                             sizeof(exe_path_buffer));
+                const char *temp;
+                const char *exe_pathname;
+                int exe_fd;
 
-                if (temp == NULL) {
+                if (!guest_self_exe_exec_paths(
+                        cpu_env, real, sizeof(real), &temp,
+                        exe_path_buffer, sizeof(exe_path_buffer),
+                        &exe_pathname, &exe_fd)) {
                     ret = get_errno(-1);
+                    if (exe_fd >= 0) {
+                        close(exe_fd);
+                    }
                     goto execve_end;
                 }
                 if (!strcmp((const char *)*argp, "/proc/self/exe")) {
                     *argp = (char *)temp;
                 }
-                ret = get_errno(safe_execve(exe_pathname, argp, envp));
+                ret = get_errno(safe_execve(exe_pathname, argp, exec_envp));
+                if (exe_fd >= 0) {
+                    close(exe_fd);
+                }
             } else {
 
                 /* Although execve() is not an interruptible syscall it is
@@ -14034,7 +14274,7 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
                  * before the execve completes and makes it the other
                  * program's problem.
                  */
-                ret = get_errno(safe_execve(path(p), argp, envp));
+                ret = get_errno(safe_execve(path(p), argp, exec_envp));
             }
             unlock_user(p, arg1, 0);
 
@@ -14064,6 +14304,9 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
             g_free(prctl_mdwe_env);
             g_free(prctl_tsc_env);
 #endif
+            if (exec_envp != envp) {
+                g_free(exec_envp);
+            }
             g_free(envp);
         }
         return ret;
@@ -19833,6 +20076,7 @@ static bool syscall_user_dispatch(CPUArchState *env, int num, uint32_t arch)
 {
     CPUState *cpu = env_cpu(env);
     TaskState *ts = cpu->opaque;
+    target_siginfo_t info;
     target_ulong pc;
     target_ulong cs_base;
     uint32_t flags;
@@ -19863,7 +20107,7 @@ static bool syscall_user_dispatch(CPUArchState *env, int num, uint32_t arch)
         }
     }
 
-    target_siginfo_t info = {
+    info = (target_siginfo_t) {
         .si_signo = TARGET_SIGSYS,
         .si_errno = 0,
         .si_code = TARGET_SYS_USER_DISPATCH,

--- a/linux-user/syscall_defs.h
+++ b/linux-user/syscall_defs.h
@@ -693,6 +693,7 @@ typedef struct target_siginfo {
 } target_siginfo_t;
 
 #define TARGET_SYS_SECCOMP 1
+#define TARGET_SYS_USER_DISPATCH 2
 
 /*
  * si_code values

--- a/target/i386/latx/translator/tr-misc.c
+++ b/target/i386/latx/translator/tr-misc.c
@@ -1347,6 +1347,24 @@ bool translate_hlt(IR1_INST *pir1)
 
 bool translate_rdtsc(IR1_INST *pir1)
 {
+    IR2_OPND tsc_mode = ra_alloc_itemp();
+    IR2_OPND tsc_enabled = ra_alloc_label();
+
+    la_ld_d(tsc_mode, env_ir2_opnd, offsetof(CPUX86State, cr[4]));
+    la_andi(tsc_mode, tsc_mode, CR4_TSD_MASK);
+    la_beqz(tsc_mode, tsc_enabled);
+
+    IR2_OPND eip_opnd = ra_alloc_dbt_arg2();
+    li_d(eip_opnd, ir1_addr(pir1));
+    la_store_addrx(eip_opnd, env_ir2_opnd, lsenv_offset_of_eip(lsenv));
+    tr_save_registers_to_env(0xff, 0xff, option_save_xmm, options_to_save());
+    aot_load_host_addr(tsc_mode, (ADDR)helper_raise_gpf,
+                       LOAD_HELPER_RAISE_GPF, 0);
+    la_jirl(zero_ir2_opnd, tsc_mode, 0);
+
+    la_label(tsc_enabled);
+    ra_free_temp(tsc_mode);
+
     IR2_OPND ir2_eax = ra_alloc_gpr(eax_index);
     IR2_OPND ir2_edx = ra_alloc_gpr(edx_index);
     la_rdtime_d(ir2_eax, zero_ir2_opnd);
@@ -1358,6 +1376,24 @@ bool translate_rdtsc(IR1_INST *pir1)
 
 bool translate_rdtscp(IR1_INST *pir1)
 {
+    IR2_OPND tsc_mode = ra_alloc_itemp();
+    IR2_OPND tsc_enabled = ra_alloc_label();
+
+    la_ld_d(tsc_mode, env_ir2_opnd, offsetof(CPUX86State, cr[4]));
+    la_andi(tsc_mode, tsc_mode, CR4_TSD_MASK);
+    la_beqz(tsc_mode, tsc_enabled);
+
+    IR2_OPND eip_opnd = ra_alloc_dbt_arg2();
+    li_d(eip_opnd, ir1_addr(pir1));
+    la_store_addrx(eip_opnd, env_ir2_opnd, lsenv_offset_of_eip(lsenv));
+    tr_save_registers_to_env(0xff, 0xff, option_save_xmm, options_to_save());
+    aot_load_host_addr(tsc_mode, (ADDR)helper_raise_gpf,
+                       LOAD_HELPER_RAISE_GPF, 0);
+    la_jirl(zero_ir2_opnd, tsc_mode, 0);
+
+    la_label(tsc_enabled);
+    ra_free_temp(tsc_mode);
+
     IR2_OPND ir2_eax = ra_alloc_gpr(eax_index);
     IR2_OPND ir2_ecx = ra_alloc_gpr(ecx_index);
     IR2_OPND ir2_edx = ra_alloc_gpr(edx_index);

--- a/target/i386/latx/translator/tr-misc.c
+++ b/target/i386/latx/translator/tr-misc.c
@@ -1349,12 +1349,15 @@ bool translate_rdtsc(IR1_INST *pir1)
 {
     IR2_OPND tsc_mode = ra_alloc_itemp();
     IR2_OPND tsc_enabled = ra_alloc_label();
+    IR2_OPND eip_opnd;
+    IR2_OPND ir2_eax;
+    IR2_OPND ir2_edx;
 
     la_ld_d(tsc_mode, env_ir2_opnd, offsetof(CPUX86State, cr[4]));
     la_andi(tsc_mode, tsc_mode, CR4_TSD_MASK);
     la_beqz(tsc_mode, tsc_enabled);
 
-    IR2_OPND eip_opnd = ra_alloc_dbt_arg2();
+    eip_opnd = ra_alloc_dbt_arg2();
     li_d(eip_opnd, ir1_addr(pir1));
     la_store_addrx(eip_opnd, env_ir2_opnd, lsenv_offset_of_eip(lsenv));
     tr_save_registers_to_env(0xff, 0xff, option_save_xmm, options_to_save());
@@ -1365,8 +1368,8 @@ bool translate_rdtsc(IR1_INST *pir1)
     la_label(tsc_enabled);
     ra_free_temp(tsc_mode);
 
-    IR2_OPND ir2_eax = ra_alloc_gpr(eax_index);
-    IR2_OPND ir2_edx = ra_alloc_gpr(edx_index);
+    ir2_eax = ra_alloc_gpr(eax_index);
+    ir2_edx = ra_alloc_gpr(edx_index);
     la_rdtime_d(ir2_eax, zero_ir2_opnd);
     la_bstrpick_d(ir2_edx, ir2_eax, 63, 32);
     la_bstrpick_d(ir2_eax, ir2_eax, 31, 0);
@@ -1378,12 +1381,16 @@ bool translate_rdtscp(IR1_INST *pir1)
 {
     IR2_OPND tsc_mode = ra_alloc_itemp();
     IR2_OPND tsc_enabled = ra_alloc_label();
+    IR2_OPND eip_opnd;
+    IR2_OPND ir2_eax;
+    IR2_OPND ir2_ecx;
+    IR2_OPND ir2_edx;
 
     la_ld_d(tsc_mode, env_ir2_opnd, offsetof(CPUX86State, cr[4]));
     la_andi(tsc_mode, tsc_mode, CR4_TSD_MASK);
     la_beqz(tsc_mode, tsc_enabled);
 
-    IR2_OPND eip_opnd = ra_alloc_dbt_arg2();
+    eip_opnd = ra_alloc_dbt_arg2();
     li_d(eip_opnd, ir1_addr(pir1));
     la_store_addrx(eip_opnd, env_ir2_opnd, lsenv_offset_of_eip(lsenv));
     tr_save_registers_to_env(0xff, 0xff, option_save_xmm, options_to_save());
@@ -1394,9 +1401,9 @@ bool translate_rdtscp(IR1_INST *pir1)
     la_label(tsc_enabled);
     ra_free_temp(tsc_mode);
 
-    IR2_OPND ir2_eax = ra_alloc_gpr(eax_index);
-    IR2_OPND ir2_ecx = ra_alloc_gpr(ecx_index);
-    IR2_OPND ir2_edx = ra_alloc_gpr(edx_index);
+    ir2_eax = ra_alloc_gpr(eax_index);
+    ir2_ecx = ra_alloc_gpr(ecx_index);
+    ir2_edx = ra_alloc_gpr(edx_index);
     la_rdtime_d(ir2_eax, ir2_ecx);
     la_bstrpick_d(ir2_edx, ir2_eax, 63, 32);
     la_bstrpick_d(ir2_eax, ir2_eax, 31, 0);

--- a/tests/integration/meson.build
+++ b/tests/integration/meson.build
@@ -119,6 +119,17 @@ if host_machine.cpu_family() == 'loongarch64' and \
     timeout: 30,
   )
   test(
+    'test-prctl-x86-semantics',
+    find_program('test-prctl-x86-semantics.sh'),
+    args: [
+      emulators['latx-x86_64'],
+      files('prctl-x86-semantics.c'),
+    ],
+    protocol: 'exitcode',
+    suite: 'latx-integration',
+    timeout: 120,
+  )
+  test(
     'test-clone-namespaces',
     find_program('test-clone-namespaces.sh'),
     args: [

--- a/tests/integration/meson.build
+++ b/tests/integration/meson.build
@@ -130,6 +130,17 @@ if host_machine.cpu_family() == 'loongarch64' and \
     timeout: 120,
   )
   test(
+    'test-prctl-x86-privileged',
+    find_program('test-prctl-x86-privileged.sh'),
+    args: [
+      emulators['latx-x86_64'],
+      files('prctl-x86-semantics.c'),
+    ],
+    protocol: 'exitcode',
+    suite: 'latx-integration',
+    timeout: 120,
+  )
+  test(
     'test-clone-namespaces',
     find_program('test-clone-namespaces.sh'),
     args: [

--- a/tests/integration/meson.build
+++ b/tests/integration/meson.build
@@ -153,6 +153,19 @@ if host_machine.cpu_family() == 'loongarch64' and \
     timeout: 30,
   )
   test(
+    'test-prctl-x86-exec-race',
+    find_program('test-prctl-x86-exec-race.sh'),
+    args: [
+      emulators['latx-x86_64'],
+      files('prctl-x86-semantics.c'),
+      files('prctl-native-env-helper.c'),
+      files('prctl-exec-race-shim.c'),
+    ],
+    protocol: 'exitcode',
+    suite: 'latx-integration',
+    timeout: 45,
+  )
+  test(
     'test-clone-parent-settid',
     find_program('test-clone-parent-settid.sh'),
     args: [
@@ -245,6 +258,41 @@ endif
 
 if host_machine.cpu_family() == 'loongarch64' and \
    'i386-linux-user' in target_dirs
+  test(
+    'test-prctl-i386-abi',
+    find_program('test-prctl-i386-abi.sh'),
+    args: [
+      emulators['latx-i386'],
+      files('prctl-i386-abi.S'),
+    ],
+    protocol: 'exitcode',
+    suite: 'latx-integration',
+    timeout: 30,
+  )
+  test(
+    'test-prctl-i386-exec-race',
+    find_program('test-prctl-i386-exec-race.sh'),
+    args: [
+      emulators['latx-i386'],
+      files('prctl-i386-exec-race.S'),
+      files('prctl-native-env-helper.c'),
+      files('prctl-exec-race-shim.c'),
+    ],
+    protocol: 'exitcode',
+    suite: 'latx-integration',
+    timeout: 45,
+  )
+  test(
+    'test-prctl-i386-mremap',
+    find_program('test-prctl-i386-mremap.sh'),
+    args: [
+      emulators['latx-i386'],
+      files('prctl-i386-mremap.c'),
+    ],
+    protocol: 'exitcode',
+    suite: 'latx-integration',
+    timeout: 30,
+  )
   test(
     'test-seccomp-virtual-syscall-i386',
     find_program('test-seccomp-virtual-syscall.sh'),

--- a/tests/integration/meson.build
+++ b/tests/integration/meson.build
@@ -124,6 +124,7 @@ if host_machine.cpu_family() == 'loongarch64' and \
     args: [
       emulators['latx-x86_64'],
       files('prctl-x86-semantics.c'),
+      files('prctl-native-env-helper.c'),
     ],
     protocol: 'exitcode',
     suite: 'latx-integration',

--- a/tests/integration/meson.build
+++ b/tests/integration/meson.build
@@ -86,6 +86,39 @@ if host_machine.cpu_family() == 'loongarch64' and \
     timeout: 30,
   )
   test(
+    'test-syscall-user-dispatch',
+    find_program('test-syscall-user-dispatch.sh'),
+    args: [
+      emulators['latx-x86_64'],
+      files('syscall-user-dispatch.S'),
+    ],
+    protocol: 'exitcode',
+    suite: 'latx-integration',
+    timeout: 30,
+  )
+  test(
+    'test-prctl-x86-abi',
+    find_program('test-prctl-x86-abi.sh'),
+    args: [
+      emulators['latx-x86_64'],
+      files('prctl-x86-abi.S'),
+    ],
+    protocol: 'exitcode',
+    suite: 'latx-integration',
+    timeout: 30,
+  )
+  test(
+    'test-prctl-x86-inherit',
+    find_program('test-prctl-x86-inherit.sh'),
+    args: [
+      emulators['latx-x86_64'],
+      files('prctl-x86-inherit.S'),
+    ],
+    protocol: 'exitcode',
+    suite: 'latx-integration',
+    timeout: 30,
+  )
+  test(
     'test-clone-namespaces',
     find_program('test-clone-namespaces.sh'),
     args: [

--- a/tests/integration/prctl-exec-race-shim.c
+++ b/tests/integration/prctl-exec-race-shim.c
@@ -1,0 +1,53 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+static int blocked;
+
+static ssize_t intercept_pread(int fd, void *buffer, size_t count,
+                               off64_t offset)
+{
+    const char *target = getenv("LATX_EXEC_RACE_TARGET");
+    const char *ready = getenv("LATX_EXEC_RACE_READY");
+    const char *release = getenv("LATX_EXEC_RACE_RELEASE");
+    struct stat fd_stat, target_stat;
+    ssize_t ret;
+    int marker;
+    int i;
+
+    ret = syscall(SYS_pread64, fd, buffer, count, offset);
+    if (ret <= 0 || offset || !target || !ready || !release ||
+        fstat(fd, &fd_stat) || stat(target, &target_stat) ||
+        fd_stat.st_dev != target_stat.st_dev ||
+        fd_stat.st_ino != target_stat.st_ino ||
+        !__sync_bool_compare_and_swap(&blocked, 0, 1)) {
+        return ret;
+    }
+
+    marker = open(ready, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+    if (marker >= 0) {
+        close(marker);
+    }
+    for (i = 0; i < 10000; i++) {
+        if (access(release, F_OK) == 0) {
+            break;
+        }
+        usleep(1000);
+    }
+    return ret;
+}
+
+ssize_t pread(int fd, void *buffer, size_t count, off_t offset)
+{
+    return intercept_pread(fd, buffer, count, offset);
+}
+
+ssize_t pread64(int fd, void *buffer, size_t count, off64_t offset)
+{
+    return intercept_pread(fd, buffer, count, offset);
+}

--- a/tests/integration/prctl-i386-abi.S
+++ b/tests/integration/prctl-i386-abi.S
@@ -1,0 +1,447 @@
+.equ __NR_exit, 1
+.equ __NR_getpid, 20
+.equ __NR_mprotect, 125
+.equ __NR_prctl, 172
+.equ __NR_rt_sigreturn, 173
+.equ __NR_rt_sigaction, 174
+.equ __NR_mmap2, 192
+.equ __NR_tunnel_virtual, 600
+
+.equ EACCES, 13
+.equ EFAULT, 14
+.equ EINVAL, 22
+.equ EOPNOTSUPP, 95
+.equ SIGSYS, 31
+.equ SA_SIGINFO, 4
+.equ SA_RESTORER, 0x04000000
+.equ SYS_USER_DISPATCH, 2
+.equ AUDIT_ARCH_I386, 0x40000003
+
+.equ PROT_READ, 1
+.equ PROT_WRITE, 2
+.equ PROT_EXEC, 4
+.equ MAP_PRIVATE, 2
+.equ MAP_ANONYMOUS, 0x20
+
+.equ PR_GET_PDEATHSIG, 2
+.equ PR_GET_TSC, 25
+.equ PR_SET_TSC, 26
+.equ PR_TSC_ENABLE, 1
+.equ PR_TSC_SIGSEGV, 2
+.equ PR_SET_MM, 35
+.equ PR_SET_MM_MAP, 14
+.equ PR_SET_MM_MAP_SIZE, 15
+.equ PR_SET_SYSCALL_USER_DISPATCH, 59
+.equ PR_SYS_DISPATCH_OFF, 0
+.equ PR_SYS_DISPATCH_ON, 1
+.equ SYSCALL_DISPATCH_FILTER_ALLOW, 0
+.equ SYSCALL_DISPATCH_FILTER_BLOCK, 1
+.equ PR_SET_MDWE, 65
+.equ PR_GET_MDWE, 66
+.equ PR_MDWE_REFUSE_EXEC_GAIN, 1
+.equ PR_SET_MEMORY_MERGE, 67
+.equ PR_GET_MEMORY_MERGE, 68
+.equ PR_GET_AUXV, 0x41555856
+.equ PR_RSEQ_SLICE_EXTENSION, 79
+.equ PR_RSEQ_SLICE_EXTENSION_GET, 1
+.equ PR_RSEQ_SLICE_EXTENSION_SET, 2
+.equ PR_RSEQ_SLICE_EXT_ENABLE, 1
+.equ PR_GET_CFI, 80
+.equ PR_CFI_BRANCH_LANDING_PADS, 0
+
+/* A compat task on a native x86_64 kernel sees the full saved_auxv array. */
+.equ X86_AUXV_SIZE, 54 * 8
+.equ PRCTL_MM_MAP_SIZE, 104
+
+.section .text
+.global _start
+.type _start, @function
+_start:
+    /* Pointer-bearing prctl operations must use guest addresses. */
+    mov $__NR_prctl, %eax
+    mov $PR_GET_PDEATHSIG, %ebx
+    xor %ecx, %ecx
+    xor %edx, %edx
+    xor %esi, %esi
+    xor %edi, %edi
+    int $0x80
+    cmp $-EFAULT, %eax
+    jne fail_pointer
+
+    mov $__NR_prctl, %eax
+    mov $PR_GET_AUXV, %ebx
+    mov $auxv_buffer, %ecx
+    mov $X86_AUXV_SIZE, %edx
+    xor %esi, %esi
+    xor %edi, %edi
+    int $0x80
+    cmp $X86_AUXV_SIZE, %eax
+    jne fail_auxv
+
+    mov $auxv_buffer, %ecx
+    mov $54, %edx
+find_pagesz:
+    cmpl $6, (%ecx)
+    je check_pagesz
+    add $8, %ecx
+    dec %edx
+    jnz find_pagesz
+    jmp fail_auxv
+check_pagesz:
+    cmpl $4096, 4(%ecx)
+    jne fail_auxv
+
+    /* The UAPI PR_SET_MM map stays a 104-byte structure for compat tasks. */
+    mov $__NR_prctl, %eax
+    mov $PR_SET_MM, %ebx
+    mov $PR_SET_MM_MAP_SIZE, %ecx
+    mov $mm_map_size, %edx
+    xor %esi, %esi
+    xor %edi, %edi
+    int $0x80
+    test %eax, %eax
+    js fail_set_mm
+    cmpl $PRCTL_MM_MAP_SIZE, mm_map_size
+    jne fail_set_mm
+
+    /* A 64-bit UAPI address that cannot fit i386 must not be truncated. */
+    mov $__NR_prctl, %eax
+    mov $PR_SET_MM, %ebx
+    mov $PR_SET_MM_MAP, %ecx
+    mov $overflow_mm_map, %edx
+    mov $PRCTL_MM_MAP_SIZE, %esi
+    xor %edi, %edi
+    int $0x80
+    cmp $-EINVAL, %eax
+    jne fail_set_mm
+
+    /* SUD is x86 guest state and OFF accepts only zero trailing args. */
+    mov $__NR_prctl, %eax
+    mov $PR_SET_SYSCALL_USER_DISPATCH, %ebx
+    mov $PR_SYS_DISPATCH_OFF, %ecx
+    xor %edx, %edx
+    xor %esi, %esi
+    xor %edi, %edi
+    int $0x80
+    test %eax, %eax
+    js fail_sud
+
+    mov $__NR_rt_sigaction, %eax
+    mov $SIGSYS, %ebx
+    mov $sud_action, %ecx
+    xor %edx, %edx
+    mov $8, %esi
+    int $0x80
+    test %eax, %eax
+    js fail_sud
+
+    movb $SYSCALL_DISPATCH_FILTER_ALLOW, sud_selector
+    mov $__NR_prctl, %eax
+    mov $PR_SET_SYSCALL_USER_DISPATCH, %ebx
+    mov $PR_SYS_DISPATCH_ON, %ecx
+    xor %edx, %edx
+    xor %esi, %esi
+    mov $sud_selector, %edi
+    int $0x80
+    test %eax, %eax
+    js fail_sud
+
+    movl $__NR_getpid, sud_expected_syscall
+    movl $sud_getpid_after, sud_expected_address
+    movb $0, sud_seen
+    movb $0, sud_failed
+    movb $SYSCALL_DISPATCH_FILTER_BLOCK, sud_selector
+    mov $__NR_getpid, %eax
+    int $0x80
+sud_getpid_after:
+    cmp $__NR_getpid, %eax
+    jne fail_sud
+    cmpb $1, sud_seen
+    jne fail_sud
+    cmpb $0, sud_failed
+    jne fail_sud
+
+    /* Syscall 600 is special only for an authenticated loader callsite. */
+    movl $__NR_tunnel_virtual, sud_expected_syscall
+    movl $sud_tunnel_after, sud_expected_address
+    movb $0, sud_seen
+    movb $0, sud_failed
+    movb $SYSCALL_DISPATCH_FILTER_BLOCK, sud_selector
+    mov $__NR_tunnel_virtual, %eax
+    xor %ebx, %ebx
+    xor %ecx, %ecx
+    xor %edx, %edx
+    xor %esi, %esi
+    xor %edi, %edi
+    xor %ebp, %ebp
+    int $0x80
+sud_tunnel_after:
+    cmp $__NR_tunnel_virtual, %eax
+    jne fail_sud
+    cmpb $1, sud_seen
+    jne fail_sud
+    cmpb $0, sud_failed
+    jne fail_sud
+
+    mov $__NR_prctl, %eax
+    mov $PR_SET_SYSCALL_USER_DISPATCH, %ebx
+    mov $PR_SYS_DISPATCH_OFF, %ecx
+    xor %edx, %edx
+    xor %esi, %esi
+    xor %edi, %edi
+    int $0x80
+    test %eax, %eax
+    js fail_sud
+
+    /* TSC mode belongs to the virtual x86 CPU. */
+    mov $__NR_prctl, %eax
+    mov $PR_GET_TSC, %ebx
+    mov $tsc_mode, %ecx
+    xor %edx, %edx
+    xor %esi, %esi
+    xor %edi, %edi
+    int $0x80
+    test %eax, %eax
+    js fail_tsc
+    cmpl $PR_TSC_ENABLE, tsc_mode
+    jne fail_tsc
+
+    mov $__NR_prctl, %eax
+    mov $PR_SET_TSC, %ebx
+    mov $PR_TSC_SIGSEGV, %ecx
+    xor %edx, %edx
+    xor %esi, %esi
+    xor %edi, %edi
+    int $0x80
+    test %eax, %eax
+    js fail_tsc
+
+    mov $__NR_prctl, %eax
+    mov $PR_GET_TSC, %ebx
+    mov $tsc_mode, %ecx
+    xor %edx, %edx
+    xor %esi, %esi
+    xor %edi, %edi
+    int $0x80
+    test %eax, %eax
+    js fail_tsc
+    cmpl $PR_TSC_SIGSEGV, tsc_mode
+    jne fail_tsc
+
+    mov $__NR_prctl, %eax
+    mov $PR_SET_TSC, %ebx
+    mov $PR_TSC_ENABLE, %ecx
+    xor %edx, %edx
+    xor %esi, %esi
+    xor %edi, %edi
+    int $0x80
+
+    /* MDWE must cover both mmap2() and later mprotect() on i386. */
+    mov $__NR_mmap2, %eax
+    xor %ebx, %ebx
+    mov $4096, %ecx
+    mov $(PROT_READ | PROT_WRITE), %edx
+    mov $(MAP_PRIVATE | MAP_ANONYMOUS), %esi
+    mov $-1, %edi
+    xor %ebp, %ebp
+    int $0x80
+    test %eax, %eax
+    js fail_mdwe
+    mov %eax, %ebp
+
+    mov $__NR_prctl, %eax
+    mov $PR_GET_MDWE, %ebx
+    xor %ecx, %ecx
+    xor %edx, %edx
+    xor %esi, %esi
+    xor %edi, %edi
+    int $0x80
+    test %eax, %eax
+    jne fail_mdwe
+
+    mov $__NR_prctl, %eax
+    mov $PR_SET_MDWE, %ebx
+    mov $PR_MDWE_REFUSE_EXEC_GAIN, %ecx
+    xor %edx, %edx
+    xor %esi, %esi
+    xor %edi, %edi
+    int $0x80
+    test %eax, %eax
+    js fail_mdwe
+
+    mov $__NR_mprotect, %eax
+    mov %ebp, %ebx
+    mov $4096, %ecx
+    mov $(PROT_READ | PROT_EXEC), %edx
+    int $0x80
+    cmp $-EACCES, %eax
+    jne fail_mdwe
+
+    mov $__NR_mmap2, %eax
+    xor %ebx, %ebx
+    mov $4096, %ecx
+    mov $(PROT_WRITE | PROT_EXEC), %edx
+    mov $(MAP_PRIVATE | MAP_ANONYMOUS), %esi
+    mov $-1, %edi
+    xor %ebp, %ebp
+    int $0x80
+    cmp $-EACCES, %eax
+    jne fail_mdwe
+
+    /* Unsupported current x86 facilities retain Linux argument semantics. */
+    mov $__NR_prctl, %eax
+    mov $PR_RSEQ_SLICE_EXTENSION, %ebx
+    mov $PR_RSEQ_SLICE_EXTENSION_GET, %ecx
+    xor %edx, %edx
+    xor %esi, %esi
+    xor %edi, %edi
+    int $0x80
+    cmp $-EOPNOTSUPP, %eax
+    jne fail_current
+
+    mov $__NR_prctl, %eax
+    mov $PR_RSEQ_SLICE_EXTENSION, %ebx
+    mov $PR_RSEQ_SLICE_EXTENSION_SET, %ecx
+    mov $PR_RSEQ_SLICE_EXT_ENABLE, %edx
+    xor %esi, %esi
+    xor %edi, %edi
+    int $0x80
+    cmp $-EOPNOTSUPP, %eax
+    jne fail_current
+
+    mov $__NR_prctl, %eax
+    mov $PR_GET_CFI, %ebx
+    mov $PR_CFI_BRANCH_LANDING_PADS, %ecx
+    mov $cfi_state, %edx
+    xor %esi, %esi
+    xor %edi, %edi
+    int $0x80
+    cmp $-EINVAL, %eax
+    jne fail_current
+
+    /* Guest KSM controls must not alter the LoongArch translator mm. */
+    mov $__NR_prctl, %eax
+    mov $PR_GET_MEMORY_MERGE, %ebx
+    xor %ecx, %ecx
+    xor %edx, %edx
+    xor %esi, %esi
+    xor %edi, %edi
+    int $0x80
+    cmp $-EINVAL, %eax
+    jne fail_current
+
+    mov $__NR_prctl, %eax
+    mov $PR_SET_MEMORY_MERGE, %ebx
+    mov $1, %ecx
+    xor %edx, %edx
+    xor %esi, %esi
+    xor %edi, %edi
+    int $0x80
+    cmp $-EINVAL, %eax
+    jne fail_current
+
+    xor %ebx, %ebx
+    jmp exit_now
+
+fail_pointer:
+    mov $20, %ebx
+    jmp exit_now
+fail_auxv:
+    mov $21, %ebx
+    jmp exit_now
+fail_set_mm:
+    mov $22, %ebx
+    jmp exit_now
+fail_sud:
+    mov $23, %ebx
+    jmp exit_now
+fail_tsc:
+    mov $24, %ebx
+    jmp exit_now
+fail_mdwe:
+    mov $25, %ebx
+    jmp exit_now
+fail_current:
+    mov $26, %ebx
+
+exit_now:
+    mov $__NR_exit, %eax
+    int $0x80
+.size _start, .-_start
+
+.type sud_handler, @function
+sud_handler:
+    movb $SYSCALL_DISPATCH_FILTER_ALLOW, sud_selector
+    mov 8(%esp), %edx
+    cmpl $SIGSYS, 4(%esp)
+    jne sud_bad_siginfo
+    cmpl $0, 4(%edx)
+    jne sud_bad_siginfo
+    cmpl $SYS_USER_DISPATCH, 8(%edx)
+    jne sud_bad_siginfo
+    mov sud_expected_address, %eax
+    cmpl %eax, 12(%edx)
+    jne sud_bad_siginfo
+    mov sud_expected_syscall, %eax
+    cmpl %eax, 16(%edx)
+    jne sud_bad_siginfo
+    cmpl $AUDIT_ARCH_I386, 20(%edx)
+    jne sud_bad_siginfo
+    movb $1, sud_seen
+    ret
+sud_bad_siginfo:
+    movb $1, sud_failed
+    ret
+.size sud_handler, .-sud_handler
+
+.type sud_sigreturn, @function
+sud_sigreturn:
+    mov $__NR_rt_sigreturn, %eax
+    int $0x80
+    ud2
+.size sud_sigreturn, .-sud_sigreturn
+
+.section .data
+.align 8
+sud_action:
+    .long sud_handler
+    .long SA_SIGINFO | SA_RESTORER
+    .long sud_sigreturn
+    .quad 0
+sud_expected_address:
+    .long 0
+sud_expected_syscall:
+    .long 0
+sud_selector:
+    .byte 0
+sud_seen:
+    .byte 0
+sud_failed:
+    .byte 0
+.align 8
+overflow_mm_map:
+    .quad 0x0000000100100000
+    .quad 0x0000000000100001
+    .quad 0x0000000000200000
+    .quad 0x0000000000200000
+    .quad 0x0000000000300000
+    .quad 0x0000000000300000
+    .quad 0x0000000000400000
+    .quad 0x0000000000400000
+    .quad 0x0000000000400000
+    .quad 0x0000000000400000
+    .quad 0x0000000000400000
+    .quad 0
+    .long 0
+    .long -1
+
+.section .bss
+.align 8
+auxv_buffer:
+    .skip X86_AUXV_SIZE
+mm_map_size:
+    .skip 4
+tsc_mode:
+    .skip 4
+cfi_state:
+    .skip 4

--- a/tests/integration/prctl-i386-exec-race.S
+++ b/tests/integration/prctl-i386-exec-race.S
@@ -1,0 +1,102 @@
+.equ __NR_exit, 1
+.equ __NR_execve, 11
+.equ __NR_prctl, 172
+.equ __NR_execveat, 358
+
+.equ AT_FDCWD, -100
+.equ PR_SET_MDWE, 65
+.equ PR_GET_MDWE, 66
+.equ PR_MDWE_REFUSE_EXEC_GAIN, 1
+
+.section .text
+.global _start
+.type _start, @function
+_start:
+    cmpl $2, (%esp)
+    jne run_request
+    mov 8(%esp), %eax
+    cmpl $0x6f72702f, 0(%eax)   /* /pro */
+    jne fail
+    cmpl $0x65732f63, 4(%eax)   /* c/se */
+    jne fail
+    cmpl $0x662f666c, 8(%eax)   /* lf/f */
+    jne fail
+    cmpw $0x2f64, 12(%eax)      /* d/ */
+    je check_inherited_mdwe
+    jmp fail
+
+run_request:
+    cmpl $3, (%esp)
+    jne fail
+    mov 8(%esp), %eax
+    movzbl (%eax), %eax
+    mov %al, exec_mode
+    mov 12(%esp), %eax
+    mov %eax, target_path
+
+    mov $__NR_prctl, %eax
+    mov $PR_SET_MDWE, %ebx
+    mov $PR_MDWE_REFUSE_EXEC_GAIN, %ecx
+    xor %edx, %edx
+    xor %esi, %esi
+    xor %edi, %edi
+    int $0x80
+    test %eax, %eax
+    js fail
+
+    mov target_path, %eax
+    mov %eax, target_argv
+    cmpb $'u', exec_mode
+    je use_execveat
+
+    mov $__NR_execve, %eax
+    mov target_path, %ebx
+    mov $target_argv, %ecx
+    mov $target_envp, %edx
+    int $0x80
+    jmp fail
+
+use_execveat:
+    mov $__NR_execveat, %eax
+    mov $AT_FDCWD, %ebx
+    mov target_path, %ecx
+    mov $target_argv, %edx
+    mov $target_envp, %esi
+    xor %edi, %edi
+    int $0x80
+
+check_inherited_mdwe:
+    mov $__NR_prctl, %eax
+    mov $PR_GET_MDWE, %ebx
+    xor %ecx, %ecx
+    xor %edx, %edx
+    xor %esi, %esi
+    xor %edi, %edi
+    int $0x80
+    cmp $PR_MDWE_REFUSE_EXEC_GAIN, %eax
+    jne fail
+    xor %ebx, %ebx
+    jmp exit_now
+
+fail:
+    mov $135, %ebx
+exit_now:
+    mov $__NR_exit, %eax
+    int $0x80
+.size _start, .-_start
+
+.section .data
+keep_env:
+    .asciz "KEEP=1"
+target_envp:
+    .long keep_env
+    .long 0
+target_path:
+    .long 0
+target_argv:
+    .long 0
+    .long 0
+exec_mode:
+    .byte 0
+
+.section .note.GNU-stack,"",@progbits

--- a/tests/integration/prctl-i386-mremap.c
+++ b/tests/integration/prctl-i386-mremap.c
@@ -1,0 +1,209 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+typedef unsigned long guest_ulong_t;
+typedef long guest_slong_t;
+
+#define __NR_close          6
+#define __NR_munmap        91
+#define __NR_ftruncate     93
+#define __NR_mprotect     125
+#define __NR_msync        144
+#define __NR_mremap       163
+#define __NR_mmap2        192
+#define __NR_exit_group   252
+#define __NR_memfd_create 356
+
+#define EFAULT 14
+
+#define PROT_READ  1
+#define PROT_WRITE 2
+
+#define MAP_SHARED    1
+#define MAP_PRIVATE   2
+#define MAP_FIXED    16
+#define MAP_ANONYMOUS 32
+
+#define MREMAP_MAYMOVE 1
+#define MREMAP_FIXED   2
+#define MS_SYNC         4
+
+static inline guest_slong_t syscall1(guest_slong_t nr, guest_slong_t a1)
+{
+    guest_slong_t ret;
+
+    __asm__ volatile("int $0x80" : "=a"(ret) : "a"(nr), "b"(a1)
+                     : "memory");
+    return ret;
+}
+
+static inline guest_slong_t syscall2(guest_slong_t nr, guest_slong_t a1,
+                                     guest_slong_t a2)
+{
+    guest_slong_t ret;
+
+    __asm__ volatile("int $0x80" : "=a"(ret)
+                     : "a"(nr), "b"(a1), "c"(a2) : "memory");
+    return ret;
+}
+
+static inline guest_slong_t syscall3(guest_slong_t nr, guest_slong_t a1,
+                                     guest_slong_t a2, guest_slong_t a3)
+{
+    guest_slong_t ret;
+
+    __asm__ volatile("int $0x80" : "=a"(ret)
+                     : "a"(nr), "b"(a1), "c"(a2), "d"(a3) : "memory");
+    return ret;
+}
+
+static inline guest_slong_t syscall5(guest_slong_t nr, guest_slong_t a1,
+                                     guest_slong_t a2, guest_slong_t a3,
+                                     guest_slong_t a4, guest_slong_t a5)
+{
+    guest_slong_t ret;
+
+    __asm__ volatile("int $0x80" : "=a"(ret)
+                     : "a"(nr), "b"(a1), "c"(a2), "d"(a3), "S"(a4),
+                       "D"(a5) : "memory");
+    return ret;
+}
+
+static inline guest_slong_t syscall6(guest_slong_t nr, guest_slong_t a1,
+                                     guest_slong_t a2, guest_slong_t a3,
+                                     guest_slong_t a4, guest_slong_t a5,
+                                     guest_slong_t a6)
+{
+    register guest_slong_t ebp __asm__("ebp") = a6;
+    guest_slong_t ret;
+
+    __asm__ volatile("int $0x80" : "=a"(ret)
+                     : "a"(nr), "b"(a1), "c"(a2), "d"(a3), "S"(a4),
+                       "D"(a5), "r"(ebp) : "memory");
+    return ret;
+}
+
+static guest_slong_t do_mmap(guest_ulong_t addr, guest_ulong_t len,
+                             guest_slong_t prot, guest_slong_t flags,
+                             guest_slong_t fd)
+{
+    return syscall6(__NR_mmap2, addr, len, prot, flags, fd, 0);
+}
+
+static int test_shared_alias(void)
+{
+    guest_slong_t source;
+    guest_slong_t alias;
+
+    source = do_mmap(0, 16384, PROT_READ | PROT_WRITE,
+                     MAP_SHARED | MAP_ANONYMOUS, -1);
+    if (source < 0) {
+        return 30;
+    }
+    alias = syscall5(__NR_mremap, source, 0, 16384, MREMAP_MAYMOVE, 0);
+    if (alias < 0) {
+        return 30;
+    }
+    *(guest_ulong_t *)source = 0x10203040UL;
+    *(guest_ulong_t *)(alias + 12288) = 0x50607080UL;
+    if (*(guest_ulong_t *)alias != 0x10203040UL ||
+        *(guest_ulong_t *)(source + 12288) != 0x50607080UL ||
+        syscall3(__NR_mprotect, alias, 16384, PROT_READ) != 0 ||
+        syscall3(__NR_msync, alias, 16384, MS_SYNC) != 0 ||
+        syscall2(__NR_munmap, source, 16384) != 0 ||
+        *(guest_ulong_t *)alias != 0x10203040UL) {
+        return 30;
+    }
+    syscall2(__NR_munmap, alias, 16384);
+    return 0;
+}
+
+static int test_partial_failure(guest_ulong_t old_size,
+                                guest_ulong_t new_size)
+{
+    guest_slong_t source;
+    guest_slong_t target;
+
+    source = do_mmap(0, 16384, PROT_READ | PROT_WRITE,
+                     MAP_SHARED | MAP_ANONYMOUS, -1);
+    target = do_mmap(0, 16384, PROT_READ | PROT_WRITE,
+                     MAP_PRIVATE | MAP_ANONYMOUS, -1);
+    if (source < 0 || target < 0) {
+        return 31;
+    }
+    *(guest_ulong_t *)source = 0x11223344UL;
+    *(guest_ulong_t *)target = 0x55667788UL;
+    if (syscall5(__NR_mremap, source, old_size, new_size,
+                 MREMAP_MAYMOVE | MREMAP_FIXED, target) != -EFAULT ||
+        *(guest_ulong_t *)source != 0x11223344UL ||
+        *(guest_ulong_t *)target != 0x55667788UL) {
+        return 31;
+    }
+    syscall2(__NR_munmap, source, 16384);
+    syscall2(__NR_munmap, target, 16384);
+    return 0;
+}
+
+static int test_shadow_failure(void)
+{
+    static const char name[] = "lat-i386-shadow";
+    guest_slong_t map;
+    guest_slong_t fd;
+
+    map = do_mmap(0, 16384, PROT_READ | PROT_WRITE,
+                  MAP_PRIVATE | MAP_ANONYMOUS, -1);
+    fd = syscall2(__NR_memfd_create, (guest_slong_t)name, 0);
+    if (map < 0 || fd < 0 || syscall2(__NR_ftruncate, fd, 4096) != 0 ||
+        do_mmap(map + 4096, 4096, PROT_READ | PROT_WRITE,
+                MAP_SHARED | MAP_FIXED, fd) != map + 4096) {
+        return 32;
+    }
+    *(guest_ulong_t *)map = 0x89abcdefUL;
+    *(guest_ulong_t *)(map + 4096) = 0x76543210UL;
+    if (syscall5(__NR_mremap, map + 4096, 0, 4096,
+                 MREMAP_MAYMOVE, 0) != -EFAULT ||
+        *(guest_ulong_t *)map != 0x89abcdefUL ||
+        *(guest_ulong_t *)(map + 4096) != 0x76543210UL ||
+        syscall3(__NR_mprotect, map + 4096, 4096, PROT_READ) != 0 ||
+        syscall3(__NR_msync, map + 4096, 4096, MS_SYNC) != 0 ||
+        syscall2(__NR_munmap, map, 16384) != 0) {
+        return 32;
+    }
+    syscall1(__NR_close, fd);
+    return 0;
+}
+
+int test_main(guest_ulong_t *stack)
+{
+    guest_ulong_t argc = stack[0];
+    char **argv = (char **)&stack[1];
+    int ret;
+
+    ret = test_shared_alias();
+    if (ret || argc < 2 || !argv[1] || argv[1][0] != 'h') {
+        return ret;
+    }
+    ret = test_partial_failure(8193, 8193);
+    if (!ret) {
+        ret = test_partial_failure(8193, 12289);
+    }
+    if (!ret) {
+        ret = test_partial_failure(12289, 8193);
+    }
+    if (!ret) {
+        ret = test_shadow_failure();
+    }
+    return ret;
+}
+
+__asm__(".section .text\n"
+        ".global _start\n"
+        ".type _start,@function\n"
+        "_start:\n"
+        "mov %esp,%eax\n"
+        "push %eax\n"
+        "call test_main\n"
+        "mov %eax,%ebx\n"
+        "mov $252,%eax\n"
+        "int $0x80\n"
+        "ud2\n"
+        ".size _start,.-_start\n"
+        ".section .note.GNU-stack,\"\",@progbits\n");

--- a/tests/integration/prctl-native-env-helper.c
+++ b/tests/integration/prctl-native-env-helper.c
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+#include <stdlib.h>
+#include <string.h>
+
+int main(void)
+{
+    const char *keep = getenv("KEEP");
+
+    if (getenv("_LATX_GUEST_MDWE") || getenv("_LATX_GUEST_TSC")) {
+        return 1;
+    }
+    return !keep || strcmp(keep, "1") != 0;
+}

--- a/tests/integration/prctl-native-env-helper.c
+++ b/tests/integration/prctl-native-env-helper.c
@@ -1,13 +1,46 @@
 /* SPDX-License-Identifier: GPL-2.0-or-later */
+#include <fcntl.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
-int main(void)
+int main(int argc, char **argv)
 {
+#ifdef PRCTL_EXEC_RACE_FAIL
+    (void)argc;
+    (void)argv;
+    return 1;
+#else
+    static const char fd_prefix[] = "/proc/self/fd/";
+    static const char marker[] = "PR378_EXEC_RACE_ORIGINAL";
     const char *keep = getenv("KEEP");
 
+    if (argc > 1 && !strcmp(argv[1], "carrier")) {
+        char buffer[512];
+        int fd;
+        ssize_t len;
+
+        if (argc < 3 ||
+            strncmp(argv[2], fd_prefix, sizeof(fd_prefix) - 1)) {
+            return 1;
+        }
+        fd = open(argv[2], O_RDONLY);
+        if (fd < 0) {
+            return 1;
+        }
+        len = read(fd, buffer, sizeof(buffer) - 1);
+        close(fd);
+        if (len < 0) {
+            return 1;
+        }
+        buffer[len] = '\0';
+        if (!strstr(buffer, marker)) {
+            return 1;
+        }
+    }
     if (getenv("_LATX_GUEST_MDWE") || getenv("_LATX_GUEST_TSC")) {
         return 1;
     }
     return !keep || strcmp(keep, "1") != 0;
+#endif
 }

--- a/tests/integration/prctl-x86-abi.S
+++ b/tests/integration/prctl-x86-abi.S
@@ -40,8 +40,8 @@
 .equ PR_SPEC_STORE_BYPASS, 0
 .equ PR_SPEC_ENABLE, 2
 
-/* Linux 6.14 x86_64: 2 * (AT_VECTOR_SIZE_BASE + AT_VECTOR_SIZE_ARCH + 1). */
-.equ X86_64_AUXV_WORDS, 50
+/* Current Linux x86_64: 2 * (24 base + 2 arch + 1 terminator). */
+.equ X86_64_AUXV_WORDS, 54
 .equ X86_64_AUXV_SIZE, X86_64_AUXV_WORDS * 8
 .equ PRCTL_MM_MAP_SIZE, 104
 

--- a/tests/integration/prctl-x86-abi.S
+++ b/tests/integration/prctl-x86-abi.S
@@ -1,0 +1,448 @@
+.equ __NR_rt_sigaction, 13
+.equ __NR_mmap, 9
+.equ __NR_mprotect, 10
+.equ __NR_prctl, 157
+.equ __NR_exit, 60
+
+.equ EFAULT, 14
+.equ EINVAL, 22
+.equ EACCES, 13
+.equ EPERM, 1
+.equ ENXIO, 6
+.equ ENODEV, 19
+.equ SIGSEGV, 11
+.equ SA_SIGINFO, 4
+.equ SA_RESTORER, 0x04000000
+
+.equ PROT_READ, 1
+.equ PROT_WRITE, 2
+.equ PROT_EXEC, 4
+.equ MAP_PRIVATE, 2
+.equ MAP_ANONYMOUS, 0x20
+
+.equ PR_GET_PDEATHSIG, 2
+.equ PR_SET_MM, 35
+.equ PR_SET_MM_MAP, 14
+.equ PR_SET_MM_MAP_SIZE, 15
+.equ PR_GET_TSC, 25
+.equ PR_SET_TSC, 26
+.equ PR_TSC_ENABLE, 1
+.equ PR_TSC_SIGSEGV, 2
+.equ PR_SET_MDWE, 65
+.equ PR_GET_MDWE, 66
+.equ PR_MDWE_REFUSE_EXEC_GAIN, 1
+.equ PR_MDWE_NO_INHERIT, 2
+.equ PR_SET_VMA, 0x53564d41
+.equ PR_SET_VMA_ANON_NAME, 0
+.equ PR_GET_AUXV, 0x41555856
+.equ PR_GET_SPECULATION_CTRL, 52
+.equ PR_SET_SPECULATION_CTRL, 53
+.equ PR_SPEC_STORE_BYPASS, 0
+.equ PR_SPEC_ENABLE, 2
+
+/* Linux 6.14 x86_64: 2 * (AT_VECTOR_SIZE_BASE + AT_VECTOR_SIZE_ARCH + 1). */
+.equ X86_64_AUXV_WORDS, 50
+.equ X86_64_AUXV_SIZE, X86_64_AUXV_WORDS * 8
+.equ PRCTL_MM_MAP_SIZE, 104
+
+.section .text
+.global _start
+.type _start, @function
+_start:
+    /* PR_GET_PDEATHSIG must not silently accept a NULL output pointer. */
+    mov $__NR_prctl, %eax
+    mov $PR_GET_PDEATHSIG, %edi
+    xor %esi, %esi
+    xor %edx, %edx
+    xor %r10d, %r10d
+    xor %r8d, %r8d
+    syscall
+    cmp $-EFAULT, %rax
+    jne fail_pdeathsig
+
+    /* PR_GET_AUXV returns the fixed x86_64 saved_auxv size. */
+    mov $__NR_prctl, %eax
+    mov $PR_GET_AUXV, %edi
+    lea auxv_buffer(%rip), %rsi
+    mov $X86_64_AUXV_SIZE, %edx
+    xor %r10d, %r10d
+    xor %r8d, %r8d
+    syscall
+    cmp $X86_64_AUXV_SIZE, %rax
+    jne fail_auxv
+
+    lea auxv_buffer(%rip), %rdi
+    mov $X86_64_AUXV_WORDS, %ecx
+find_pagesz:
+    cmpq $6, (%rdi)
+    je check_pagesz
+    add $16, %rdi
+    sub $2, %ecx
+    jnz find_pagesz
+    jmp fail_auxv
+check_pagesz:
+    cmpq $4096, 8(%rdi)
+    jne fail_auxv
+
+    mov $__NR_prctl, %eax
+    mov $PR_GET_AUXV, %edi
+    mov $1, %esi
+    mov $1, %edx
+    xor %r10d, %r10d
+    xor %r8d, %r8d
+    syscall
+    cmp $-EFAULT, %rax
+    jne fail_auxv
+
+    mov $__NR_prctl, %eax
+    mov $PR_GET_AUXV, %edi
+    lea auxv_buffer(%rip), %rsi
+    mov $X86_64_AUXV_SIZE, %edx
+    mov $1, %r10d
+    xor %r8d, %r8d
+    syscall
+    cmp $-EINVAL, %rax
+    jne fail_auxv
+
+    /* PR_SET_MM map operations are guest ABI data, not host pointers. */
+    mov $__NR_prctl, %eax
+    mov $PR_SET_MM, %edi
+    mov $PR_SET_MM_MAP_SIZE, %esi
+    lea mm_map_size(%rip), %rdx
+    xor %r10d, %r10d
+    xor %r8d, %r8d
+    syscall
+    test %rax, %rax
+    js fail_set_mm
+    cmpl $PRCTL_MM_MAP_SIZE, mm_map_size(%rip)
+    jne fail_set_mm
+
+    mov $__NR_prctl, %eax
+    mov $PR_SET_MM, %edi
+    mov $PR_SET_MM_MAP_SIZE, %esi
+    lea mm_map_size(%rip), %rdx
+    xor %r10d, %r10d
+    mov $1, %r8d
+    syscall
+    cmp $-EINVAL, %rax
+    jne fail_set_mm
+
+    mov $__NR_mmap, %eax
+    xor %edi, %edi
+    mov $16384, %esi
+    mov $(PROT_READ | PROT_WRITE), %edx
+    mov $(MAP_PRIVATE | MAP_ANONYMOUS), %r10d
+    mov $-1, %r8d
+    xor %r9d, %r9d
+    syscall
+    test %rax, %rax
+    js fail_set_mm
+
+    lea mm_map(%rip), %rdi
+    mov %rax, 0(%rdi)
+    lea 1(%rax), %rcx
+    mov %rcx, 8(%rdi)
+    mov %rax, 16(%rdi)
+    mov %rax, 24(%rdi)
+    mov %rax, 32(%rdi)
+    mov %rax, 40(%rdi)
+    mov %rax, 48(%rdi)
+    mov %rax, 56(%rdi)
+    mov %rax, 64(%rdi)
+    mov %rax, 72(%rdi)
+    mov %rax, 80(%rdi)
+    lea replacement_auxv(%rip), %rcx
+    mov %rcx, 88(%rdi)
+    movl $16, 96(%rdi)
+    movl $-1, 100(%rdi)
+
+    mov $__NR_prctl, %eax
+    mov $PR_SET_MM, %edi
+    mov $PR_SET_MM_MAP, %esi
+    lea mm_map(%rip), %rdx
+    mov $PRCTL_MM_MAP_SIZE, %r10d
+    xor %r8d, %r8d
+    syscall
+    test %rax, %rax
+    js fail_set_mm
+
+    mov $__NR_prctl, %eax
+    mov $PR_GET_AUXV, %edi
+    lea auxv_buffer(%rip), %rsi
+    mov $16, %edx
+    xor %r10d, %r10d
+    xor %r8d, %r8d
+    syscall
+    cmp $X86_64_AUXV_SIZE, %rax
+    jne fail_set_mm
+    cmpq $123, auxv_buffer(%rip)
+    jne fail_set_mm
+    cmpq $456, auxv_buffer+8(%rip)
+    jne fail_set_mm
+
+    /* x86 speculation controls describe the virtual CPU, not LoongArch. */
+    mov $__NR_prctl, %eax
+    mov $PR_GET_SPECULATION_CTRL, %edi
+    mov $PR_SPEC_STORE_BYPASS, %esi
+    xor %edx, %edx
+    xor %r10d, %r10d
+    xor %r8d, %r8d
+    syscall
+    test %rax, %rax
+    jne fail_speculation
+
+    mov $__NR_prctl, %eax
+    mov $PR_GET_SPECULATION_CTRL, %edi
+    mov $99, %esi
+    xor %edx, %edx
+    xor %r10d, %r10d
+    xor %r8d, %r8d
+    syscall
+    cmp $-ENODEV, %rax
+    jne fail_speculation
+
+    mov $__NR_prctl, %eax
+    mov $PR_SET_SPECULATION_CTRL, %edi
+    mov $PR_SPEC_STORE_BYPASS, %esi
+    mov $PR_SPEC_ENABLE, %edx
+    xor %r10d, %r10d
+    xor %r8d, %r8d
+    syscall
+    cmp $-ENXIO, %rax
+    jne fail_speculation
+
+    /* TSC control is x86 guest state, not a host-LoongArch prctl. */
+    mov $__NR_prctl, %eax
+    mov $PR_GET_TSC, %edi
+    lea tsc_mode(%rip), %rsi
+    xor %edx, %edx
+    xor %r10d, %r10d
+    xor %r8d, %r8d
+    syscall
+    test %rax, %rax
+    js fail_tsc
+    cmpl $PR_TSC_ENABLE, tsc_mode(%rip)
+    jne fail_tsc
+
+    mov $__NR_prctl, %eax
+    mov $PR_SET_TSC, %edi
+    xor %esi, %esi
+    xor %edx, %edx
+    xor %r10d, %r10d
+    xor %r8d, %r8d
+    syscall
+    cmp $-EINVAL, %rax
+    jne fail_tsc
+
+    mov $__NR_prctl, %eax
+    mov $PR_SET_TSC, %edi
+    mov $PR_TSC_SIGSEGV, %esi
+    xor %edx, %edx
+    xor %r10d, %r10d
+    xor %r8d, %r8d
+    syscall
+    test %rax, %rax
+    js fail_tsc
+
+    mov $__NR_prctl, %eax
+    mov $PR_GET_TSC, %edi
+    lea tsc_mode(%rip), %rsi
+    xor %edx, %edx
+    xor %r10d, %r10d
+    xor %r8d, %r8d
+    syscall
+    test %rax, %rax
+    js fail_tsc
+    cmpl $PR_TSC_SIGSEGV, tsc_mode(%rip)
+    jne fail_tsc
+
+    /* Pointer and guest-address arguments must be translated for the host. */
+    mov $__NR_mmap, %eax
+    xor %edi, %edi
+    mov $16384, %esi
+    mov $(PROT_READ | PROT_WRITE), %edx
+    mov $(MAP_PRIVATE | MAP_ANONYMOUS), %r10d
+    mov $-1, %r8d
+    xor %r9d, %r9d
+    syscall
+    test %rax, %rax
+    js fail_vma
+    mov %rax, %r12
+
+    mov $__NR_prctl, %eax
+    mov $PR_SET_VMA, %edi
+    mov $PR_SET_VMA_ANON_NAME, %esi
+    mov %r12, %rdx
+    mov $16384, %r10d
+    lea anon_name(%rip), %r8
+    syscall
+    test %rax, %rax
+    je vma_done
+    /* CONFIG_ANON_VMA_NAME=n has the same EINVAL result on native x86. */
+    cmp $-EINVAL, %rax
+    jne fail_vma
+vma_done:
+
+    /* MDWE is per guest mm and must not constrain LAT's own JIT mappings. */
+    mov $__NR_prctl, %eax
+    mov $PR_GET_MDWE, %edi
+    xor %esi, %esi
+    xor %edx, %edx
+    xor %r10d, %r10d
+    xor %r8d, %r8d
+    syscall
+    test %rax, %rax
+    jne fail_mdwe
+
+    mov $__NR_prctl, %eax
+    mov $PR_SET_MDWE, %edi
+    mov $PR_MDWE_NO_INHERIT, %esi
+    xor %edx, %edx
+    xor %r10d, %r10d
+    xor %r8d, %r8d
+    syscall
+    cmp $-EINVAL, %rax
+    jne fail_mdwe
+
+    mov $__NR_prctl, %eax
+    mov $PR_SET_MDWE, %edi
+    mov $PR_MDWE_REFUSE_EXEC_GAIN, %esi
+    xor %edx, %edx
+    xor %r10d, %r10d
+    xor %r8d, %r8d
+    syscall
+    test %rax, %rax
+    js fail_mdwe
+
+    mov $__NR_prctl, %eax
+    mov $PR_GET_MDWE, %edi
+    xor %esi, %esi
+    xor %edx, %edx
+    xor %r10d, %r10d
+    xor %r8d, %r8d
+    syscall
+    cmp $PR_MDWE_REFUSE_EXEC_GAIN, %rax
+    jne fail_mdwe
+
+    mov $__NR_prctl, %eax
+    mov $PR_SET_MDWE, %edi
+    xor %esi, %esi
+    xor %edx, %edx
+    xor %r10d, %r10d
+    xor %r8d, %r8d
+    syscall
+    cmp $-EPERM, %rax
+    jne fail_mdwe
+
+    mov $__NR_mmap, %eax
+    xor %edi, %edi
+    mov $4096, %esi
+    mov $(PROT_WRITE | PROT_EXEC), %edx
+    mov $(MAP_PRIVATE | MAP_ANONYMOUS), %r10d
+    mov $-1, %r8d
+    xor %r9d, %r9d
+    syscall
+    cmp $-EACCES, %rax
+    jne fail_mdwe
+
+    mov $__NR_mmap, %eax
+    xor %edi, %edi
+    mov $4096, %esi
+    mov $(PROT_READ | PROT_WRITE), %edx
+    mov $(MAP_PRIVATE | MAP_ANONYMOUS), %r10d
+    mov $-1, %r8d
+    xor %r9d, %r9d
+    syscall
+    test %rax, %rax
+    js fail_mdwe
+    mov %rax, %r12
+
+    mov $__NR_mprotect, %eax
+    mov %r12, %rdi
+    mov $4096, %esi
+    mov $(PROT_READ | PROT_EXEC), %edx
+    syscall
+    cmp $-EACCES, %rax
+    jne fail_mdwe
+
+    /* Arrange for an actual RDTSC fault after all non-signal checks pass. */
+    mov $__NR_rt_sigaction, %eax
+    mov $SIGSEGV, %edi
+    lea action(%rip), %rsi
+    xor %edx, %edx
+    mov $8, %r10d
+    syscall
+    test %rax, %rax
+    js fail_tsc
+
+    rdtsc
+    mov $24, %edi
+    jmp exit_now
+
+fail_pdeathsig:
+    mov $20, %edi
+    jmp exit_now
+fail_auxv:
+    mov $21, %edi
+    jmp exit_now
+fail_tsc:
+    mov $22, %edi
+    jmp exit_now
+fail_mdwe:
+    mov $23, %edi
+    jmp exit_now
+fail_vma:
+    mov $26, %edi
+    jmp exit_now
+fail_set_mm:
+    mov $27, %edi
+    jmp exit_now
+fail_speculation:
+    mov $28, %edi
+    jmp exit_now
+.size _start, .-_start
+
+segv_handler:
+    cmp $SIGSEGV, %edi
+    jne fail_signal
+    xor %edi, %edi
+    jmp exit_now
+fail_signal:
+    mov $25, %edi
+
+exit_now:
+    mov $__NR_exit, %eax
+    syscall
+    ud2
+
+sigreturn:
+    mov $15, %eax
+    syscall
+    ud2
+
+.section .rodata
+.p2align 3
+action:
+    .quad segv_handler
+    .quad SA_SIGINFO | SA_RESTORER
+    .quad sigreturn
+    .quad 0
+anon_name:
+    .asciz "lat-prctl-test"
+.p2align 3
+replacement_auxv:
+    .quad 123, 456
+
+.section .bss
+.p2align 3
+auxv_buffer:
+    .skip X86_64_AUXV_SIZE
+tsc_mode:
+    .skip 4
+mm_map_size:
+    .skip 4
+.p2align 3
+mm_map:
+    .skip PRCTL_MM_MAP_SIZE
+
+.section .note.GNU-stack,"",@progbits

--- a/tests/integration/prctl-x86-inherit.S
+++ b/tests/integration/prctl-x86-inherit.S
@@ -128,7 +128,7 @@ inherit_stage:
     test %rax, %rax
     js fail_tsc
 
-    rdtsc
+    rdtscp
     mov $33, %edi
     jmp exit_now
 

--- a/tests/integration/prctl-x86-inherit.S
+++ b/tests/integration/prctl-x86-inherit.S
@@ -1,4 +1,6 @@
 .equ __NR_execve, 59
+.equ __NR_openat, 257
+.equ __NR_execveat, 322
 .equ __NR_rt_sigaction, 13
 .equ __NR_prctl, 157
 .equ __NR_exit, 60
@@ -16,6 +18,8 @@
 .equ PR_GET_MDWE, 66
 .equ PR_MDWE_REFUSE_EXEC_GAIN, 1
 .equ PR_MDWE_NO_INHERIT, 2
+.equ AT_FDCWD, -100
+.equ AT_EMPTY_PATH, 0x1000
 
 .section .text
 .global _start
@@ -124,12 +128,34 @@ fill_exec_argv:
     mov %rbx, 8(%rsi)
     mov %r14, 16(%rsi)
     mov %r15, 24(%rsi)
+    cmpb $'i', (%r14)
+    je exec_self_at_empty
     mov $__NR_execve, %eax
     mov %r15, %rdi
     mov %r9, %rdx
     syscall
+
+exec_failed:
     mov $32, %edi
     jmp exit_now
+
+exec_self_at_empty:
+    mov $__NR_openat, %eax
+    mov $AT_FDCWD, %edi
+    mov %r15, %rsi
+    xor %edx, %edx
+    xor %r10d, %r10d
+    syscall
+    test %rax, %rax
+    js exec_failed
+    mov %eax, %edi
+    lea empty_path(%rip), %rsi
+    lea exec_argv(%rip), %rdx
+    mov %r9, %r10
+    mov $AT_EMPTY_PATH, %r8d
+    mov $__NR_execveat, %eax
+    syscall
+    jmp exec_failed
 
 inherit_stage:
     mov $__NR_prctl, %eax
@@ -204,6 +230,8 @@ no_inherit_arg:
     .asciz "n"
 inherit_arg:
     .asciz "i"
+empty_path:
+    .asciz ""
 untrusted_env_arg:
     .asciz "u"
 fake_mdwe_env:

--- a/tests/integration/prctl-x86-inherit.S
+++ b/tests/integration/prctl-x86-inherit.S
@@ -1,0 +1,180 @@
+.equ __NR_execve, 59
+.equ __NR_rt_sigaction, 13
+.equ __NR_prctl, 157
+.equ __NR_exit, 60
+
+.equ EINVAL, 22
+.equ SIGSEGV, 11
+.equ SA_SIGINFO, 4
+.equ SA_RESTORER, 0x04000000
+
+.equ PR_GET_TSC, 25
+.equ PR_SET_TSC, 26
+.equ PR_TSC_SIGSEGV, 2
+.equ PR_SET_MDWE, 65
+.equ PR_GET_MDWE, 66
+.equ PR_MDWE_REFUSE_EXEC_GAIN, 1
+.equ PR_MDWE_NO_INHERIT, 2
+
+.section .text
+.global _start
+.type _start, @function
+_start:
+    mov (%rsp), %r12
+    lea 16(%rsp,%r12,8), %r13
+    mov 16(%rsp), %rax
+    cmpb $'n', (%rax)
+    je no_inherit_stage
+    cmpb $'i', (%rax)
+    je inherit_stage
+
+first_stage:
+    mov $__NR_prctl, %eax
+    mov $PR_SET_MDWE, %edi
+    mov $(PR_MDWE_REFUSE_EXEC_GAIN | PR_MDWE_NO_INHERIT), %esi
+    xor %edx, %edx
+    xor %r10d, %r10d
+    xor %r8d, %r8d
+    syscall
+    test %rax, %rax
+    js fail_mdwe
+
+    lea no_inherit_arg(%rip), %r14
+    jmp exec_self
+
+no_inherit_stage:
+    mov $__NR_prctl, %eax
+    mov $PR_GET_MDWE, %edi
+    xor %esi, %esi
+    xor %edx, %edx
+    xor %r10d, %r10d
+    xor %r8d, %r8d
+    syscall
+    test %rax, %rax
+    jne fail_mdwe
+
+    mov $__NR_prctl, %eax
+    mov $PR_SET_MDWE, %edi
+    mov $PR_MDWE_REFUSE_EXEC_GAIN, %esi
+    xor %edx, %edx
+    xor %r10d, %r10d
+    xor %r8d, %r8d
+    syscall
+    test %rax, %rax
+    js fail_mdwe
+
+    mov $__NR_prctl, %eax
+    mov $PR_SET_TSC, %edi
+    mov $PR_TSC_SIGSEGV, %esi
+    xor %edx, %edx
+    xor %r10d, %r10d
+    xor %r8d, %r8d
+    syscall
+    test %rax, %rax
+    js fail_tsc
+
+    lea inherit_arg(%rip), %r14
+
+exec_self:
+    mov 8(%rsp), %rbx
+    cmp $2, %r12
+    je first_exec
+    mov 24(%rsp), %r15
+    jmp fill_exec_argv
+first_exec:
+    mov 16(%rsp), %r15
+fill_exec_argv:
+    lea exec_argv(%rip), %rsi
+    mov %r15, 0(%rsi)
+    mov %rbx, 8(%rsi)
+    mov %r14, 16(%rsi)
+    mov %r15, 24(%rsi)
+    mov $__NR_execve, %eax
+    mov %r15, %rdi
+    mov %r13, %rdx
+    syscall
+    mov $32, %edi
+    jmp exit_now
+
+inherit_stage:
+    mov $__NR_prctl, %eax
+    mov $PR_GET_MDWE, %edi
+    xor %esi, %esi
+    xor %edx, %edx
+    xor %r10d, %r10d
+    xor %r8d, %r8d
+    syscall
+    cmp $PR_MDWE_REFUSE_EXEC_GAIN, %rax
+    jne fail_mdwe
+
+    mov $__NR_prctl, %eax
+    mov $PR_GET_TSC, %edi
+    lea tsc_mode(%rip), %rsi
+    xor %edx, %edx
+    xor %r10d, %r10d
+    xor %r8d, %r8d
+    syscall
+    test %rax, %rax
+    js fail_tsc
+    cmpl $PR_TSC_SIGSEGV, tsc_mode(%rip)
+    jne fail_tsc
+
+    mov $__NR_rt_sigaction, %eax
+    mov $SIGSEGV, %edi
+    lea action(%rip), %rsi
+    xor %edx, %edx
+    mov $8, %r10d
+    syscall
+    test %rax, %rax
+    js fail_tsc
+
+    rdtsc
+    mov $33, %edi
+    jmp exit_now
+
+fail_mdwe:
+    mov $34, %edi
+    jmp exit_now
+fail_tsc:
+    mov $35, %edi
+    jmp exit_now
+.size _start, .-_start
+
+segv_handler:
+    cmp $SIGSEGV, %edi
+    jne fail_signal
+    xor %edi, %edi
+    jmp exit_now
+fail_signal:
+    mov $36, %edi
+
+exit_now:
+    mov $__NR_exit, %eax
+    syscall
+    ud2
+
+sigreturn:
+    mov $15, %eax
+    syscall
+    ud2
+
+.section .rodata
+no_inherit_arg:
+    .asciz "n"
+inherit_arg:
+    .asciz "i"
+action:
+    .quad segv_handler
+    .quad SA_SIGINFO | SA_RESTORER
+    .quad sigreturn
+    .quad 0
+
+.section .bss
+.p2align 3
+exec_argv:
+    .skip 40
+.p2align 2
+tsc_mode:
+    .skip 4
+
+.section .note.GNU-stack,"",@progbits

--- a/tests/integration/prctl-x86-inherit.S
+++ b/tests/integration/prctl-x86-inherit.S
@@ -10,6 +10,7 @@
 
 .equ PR_GET_TSC, 25
 .equ PR_SET_TSC, 26
+.equ PR_TSC_ENABLE, 1
 .equ PR_TSC_SIGSEGV, 2
 .equ PR_SET_MDWE, 65
 .equ PR_GET_MDWE, 66
@@ -27,8 +28,40 @@ _start:
     je no_inherit_stage
     cmpb $'i', (%rax)
     je inherit_stage
+    cmpb $'u', (%rax)
+    je untrusted_env_stage
 
-first_stage:
+    lea fake_mdwe_env(%rip), %rax
+    mov %rax, fake_envp(%rip)
+    lea fake_tsc_env(%rip), %rax
+    mov %rax, fake_envp+8(%rip)
+    lea untrusted_env_arg(%rip), %r14
+    lea fake_envp(%rip), %r9
+    jmp exec_self
+
+untrusted_env_stage:
+    mov $__NR_prctl, %eax
+    mov $PR_GET_MDWE, %edi
+    xor %esi, %esi
+    xor %edx, %edx
+    xor %r10d, %r10d
+    xor %r8d, %r8d
+    syscall
+    test %rax, %rax
+    jne fail_untrusted_mdwe
+
+    mov $__NR_prctl, %eax
+    mov $PR_GET_TSC, %edi
+    lea tsc_mode(%rip), %rsi
+    xor %edx, %edx
+    xor %r10d, %r10d
+    xor %r8d, %r8d
+    syscall
+    test %rax, %rax
+    js fail_untrusted_tsc
+    cmpl $PR_TSC_ENABLE, tsc_mode(%rip)
+    jne fail_untrusted_tsc
+
     mov $__NR_prctl, %eax
     mov $PR_SET_MDWE, %edi
     mov $(PR_MDWE_REFUSE_EXEC_GAIN | PR_MDWE_NO_INHERIT), %esi
@@ -40,6 +73,7 @@ first_stage:
     js fail_mdwe
 
     lea no_inherit_arg(%rip), %r14
+    mov %r13, %r9
     jmp exec_self
 
 no_inherit_stage:
@@ -74,6 +108,7 @@ no_inherit_stage:
     js fail_tsc
 
     lea inherit_arg(%rip), %r14
+    mov %r13, %r9
 
 exec_self:
     mov 8(%rsp), %rbx
@@ -91,7 +126,7 @@ fill_exec_argv:
     mov %r15, 24(%rsi)
     mov $__NR_execve, %eax
     mov %r15, %rdi
-    mov %r13, %rdx
+    mov %r9, %rdx
     syscall
     mov $32, %edi
     jmp exit_now
@@ -138,6 +173,12 @@ fail_mdwe:
 fail_tsc:
     mov $35, %edi
     jmp exit_now
+fail_untrusted_mdwe:
+    mov $37, %edi
+    jmp exit_now
+fail_untrusted_tsc:
+    mov $38, %edi
+    jmp exit_now
 .size _start, .-_start
 
 segv_handler:
@@ -163,6 +204,12 @@ no_inherit_arg:
     .asciz "n"
 inherit_arg:
     .asciz "i"
+untrusted_env_arg:
+    .asciz "u"
+fake_mdwe_env:
+    .asciz "_LATX_GUEST_MDWE=1"
+fake_tsc_env:
+    .asciz "_LATX_GUEST_TSC=1"
 action:
     .quad segv_handler
     .quad SA_SIGINFO | SA_RESTORER
@@ -173,6 +220,9 @@ action:
 .p2align 3
 exec_argv:
     .skip 40
+.p2align 3
+fake_envp:
+    .skip 24
 .p2align 2
 tsc_mode:
     .skip 4

--- a/tests/integration/prctl-x86-semantics.c
+++ b/tests/integration/prctl-x86-semantics.c
@@ -1,0 +1,693 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * Freestanding x86_64 tests for prctl semantics that cross subsystem
+ * boundaries.  Each invocation runs one irreversible process-state case.
+ */
+
+typedef unsigned long ulong;
+typedef long slong;
+
+#define __NR_read               0
+#define __NR_close              3
+#define __NR_mmap               9
+#define __NR_mprotect          10
+#define __NR_munmap            11
+#define __NR_shmget            29
+#define __NR_shmat             30
+#define __NR_shmctl            31
+#define __NR_shmdt             67
+#define __NR_fork              57
+#define __NR_wait4             61
+#define __NR_personality      135
+#define __NR_prctl            157
+#define __NR_set_tid_address  218
+#define __NR_exit_group       231
+#define __NR_openat           257
+
+#define EACCES 13
+#define EBADF   9
+#define EFAULT 14
+#define EINVAL 22
+#define ENAMETOOLONG 36
+#define EPERM   1
+
+#define PROT_READ  1
+#define PROT_WRITE 2
+#define PROT_EXEC  4
+
+#define MAP_SHARED    1
+#define MAP_PRIVATE   2
+#define MAP_FIXED    16
+#define MAP_ANONYMOUS 32
+
+#define AT_FDCWD (-100)
+
+#define IPC_PRIVATE 0
+#define IPC_CREAT   01000
+#define IPC_RMID    0
+#define SHM_EXEC    0100000
+
+#define READ_IMPLIES_EXEC 0x0400000
+
+#define PR_SET_PDEATHSIG             1
+#define PR_GET_PDEATHSIG             2
+#define PR_GET_DUMPABLE              3
+#define PR_SET_DUMPABLE              4
+#define PR_GET_UNALIGN               5
+#define PR_SET_KEEPCAPS              8
+#define PR_GET_KEEPCAPS              7
+#define PR_SET_TIMING               14
+#define PR_GET_TIMING               13
+#define PR_SET_NAME                 15
+#define PR_GET_NAME                 16
+#define PR_CAPBSET_READ             23
+#define PR_GET_TSC                  25
+#define PR_SET_TSC                  26
+#define PR_TSC_SIGSEGV               2
+#define PR_SET_TIMERSLACK           29
+#define PR_GET_TIMERSLACK           30
+#define PR_TASK_PERF_EVENTS_DISABLE 31
+#define PR_TASK_PERF_EVENTS_ENABLE  32
+#define PR_MCE_KILL                 33
+#define PR_MCE_KILL_GET             34
+#define PR_MCE_KILL_CLEAR            0
+#define PR_MCE_KILL_SET              1
+#define PR_MCE_KILL_DEFAULT          2
+#define PR_MCE_KILL_EARLY            1
+#define PR_MCE_KILL_LATE             0
+#define PR_GET_TID_ADDRESS          40
+#define PR_SET_CHILD_SUBREAPER      36
+#define PR_GET_CHILD_SUBREAPER      37
+#define PR_SET_NO_NEW_PRIVS         38
+#define PR_GET_NO_NEW_PRIVS         39
+#define PR_SET_THP_DISABLE          41
+#define PR_GET_THP_DISABLE          42
+#define PR_SET_FP_MODE              45
+#define PR_SCHED_CORE               62
+#define PR_SCHED_CORE_GET            0
+#define PR_SCHED_CORE_SCOPE_THREAD   0
+#define PR_SET_MDWE                 65
+#define PR_GET_MDWE                 66
+#define PR_MDWE_REFUSE_EXEC_GAIN     1
+#define PR_MDWE_NO_INHERIT           2
+#define PR_SET_MEMORY_MERGE         67
+#define PR_GET_MEMORY_MERGE         68
+#define PR_SET_VMA          0x53564d41
+#define PR_SET_VMA_ANON_NAME         0
+
+#define CAP_CHOWN 0
+
+static inline slong syscall1(slong nr, slong a1)
+{
+    slong ret;
+
+    __asm__ volatile("syscall" : "=a"(ret) : "a"(nr), "D"(a1)
+                     : "rcx", "r11", "memory");
+    return ret;
+}
+
+static inline slong syscall2(slong nr, slong a1, slong a2)
+{
+    slong ret;
+
+    __asm__ volatile("syscall" : "=a"(ret)
+                     : "a"(nr), "D"(a1), "S"(a2)
+                     : "rcx", "r11", "memory");
+    return ret;
+}
+
+static inline slong syscall3(slong nr, slong a1, slong a2, slong a3)
+{
+    slong ret;
+
+    __asm__ volatile("syscall" : "=a"(ret)
+                     : "a"(nr), "D"(a1), "S"(a2), "d"(a3)
+                     : "rcx", "r11", "memory");
+    return ret;
+}
+
+static inline slong syscall4(slong nr, slong a1, slong a2, slong a3,
+                             slong a4)
+{
+    register slong r10 __asm__("r10") = a4;
+    slong ret;
+
+    __asm__ volatile("syscall" : "=a"(ret)
+                     : "a"(nr), "D"(a1), "S"(a2), "d"(a3), "r"(r10)
+                     : "rcx", "r11", "memory");
+    return ret;
+}
+
+static inline slong syscall5(slong nr, slong a1, slong a2, slong a3,
+                             slong a4, slong a5)
+{
+    register slong r10 __asm__("r10") = a4;
+    register slong r8 __asm__("r8") = a5;
+    slong ret;
+
+    __asm__ volatile("syscall" : "=a"(ret)
+                     : "a"(nr), "D"(a1), "S"(a2), "d"(a3), "r"(r10),
+                       "r"(r8)
+                     : "rcx", "r11", "memory");
+    return ret;
+}
+
+static inline slong syscall6(slong nr, slong a1, slong a2, slong a3,
+                             slong a4, slong a5, slong a6)
+{
+    register slong r10 __asm__("r10") = a4;
+    register slong r8 __asm__("r8") = a5;
+    register slong r9 __asm__("r9") = a6;
+    slong ret;
+
+    __asm__ volatile("syscall" : "=a"(ret)
+                     : "a"(nr), "D"(a1), "S"(a2), "d"(a3), "r"(r10),
+                       "r"(r8), "r"(r9)
+                     : "rcx", "r11", "memory");
+    return ret;
+}
+
+static slong do_prctl(slong option, slong arg2, slong arg3, slong arg4,
+                      slong arg5)
+{
+    return syscall5(__NR_prctl, option, arg2, arg3, arg4, arg5);
+}
+
+static slong do_mmap(void *addr, ulong len, slong prot, slong flags,
+                     slong fd, ulong offset)
+{
+    return syscall6(__NR_mmap, (slong)addr, len, prot, flags, fd, offset);
+}
+
+static int bytes_equal(const char *a, const char *b, ulong len)
+{
+    ulong i;
+
+    for (i = 0; i < len; i++) {
+        if (a[i] != b[i]) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+static int contains(const char *buf, ulong len, const char *needle,
+                    ulong needle_len)
+{
+    ulong i;
+
+    if (needle_len > len) {
+        return 0;
+    }
+    for (i = 0; i <= len - needle_len; i++) {
+        if (bytes_equal(buf + i, needle, needle_len)) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static int hex_value(char ch)
+{
+    if (ch >= '0' && ch <= '9') {
+        return ch - '0';
+    }
+    if (ch >= 'a' && ch <= 'f') {
+        return ch - 'a' + 10;
+    }
+    return -1;
+}
+
+static int named_range(const char *buf, ulong len, const char *marker,
+                       ulong marker_len, ulong *start, ulong *end)
+{
+    ulong marker_pos;
+    ulong line;
+    ulong pos;
+    int digit;
+
+    for (marker_pos = 0; marker_pos + marker_len <= len; marker_pos++) {
+        if (bytes_equal(buf + marker_pos, marker, marker_len)) {
+            break;
+        }
+    }
+    if (marker_pos + marker_len > len) {
+        return 0;
+    }
+    line = marker_pos;
+    while (line && buf[line - 1] != '\n') {
+        line--;
+    }
+    *start = 0;
+    for (pos = line; pos < marker_pos && buf[pos] != '-'; pos++) {
+        digit = hex_value(buf[pos]);
+        if (digit < 0) {
+            return 0;
+        }
+        *start = (*start << 4) | digit;
+    }
+    if (pos >= marker_pos || buf[pos++] != '-') {
+        return 0;
+    }
+    *end = 0;
+    for (; pos < marker_pos && buf[pos] != ' '; pos++) {
+        digit = hex_value(buf[pos]);
+        if (digit < 0) {
+            return 0;
+        }
+        *end = (*end << 4) | digit;
+    }
+    return pos < marker_pos && buf[pos] == ' ';
+}
+
+static slong read_maps(char *buffer, ulong size)
+{
+    static const char maps_path[] = "/proc/self/maps";
+    slong fd = syscall4(__NR_openat, AT_FDCWD, (slong)maps_path, 0, 0);
+    slong len;
+
+    if (fd < 0) {
+        return fd;
+    }
+    len = syscall3(__NR_read, fd, (slong)buffer, size);
+    syscall1(__NR_close, fd);
+    return len;
+}
+
+static int test_process_controls(void)
+{
+    static const char set_name[16] = "lat-prctl-proc";
+    char get_name[16] = { 0 };
+    int value = -1;
+    int old_dumpable;
+    int old_keepcaps;
+    int old_subreaper;
+    int old_thp;
+    int old_merge;
+    slong old_slack;
+    ulong tid_address = 0;
+    ulong clear_tid = 0;
+    ulong cookie = 0;
+    slong ret;
+
+    if (do_prctl(0x7fffffff, 0, 0, 0, 0) != -EINVAL) {
+        return 40;
+    }
+    if (do_prctl(PR_GET_PDEATHSIG, 0, 0, 0, 0) != -EFAULT ||
+        do_prctl(PR_SET_PDEATHSIG, 10, 0, 0, 0) != 0 ||
+        do_prctl(PR_GET_PDEATHSIG, (slong)&value, 0, 0, 0) != 0 ||
+        value != 10 || do_prctl(PR_SET_PDEATHSIG, 0, 0, 0, 0) != 0) {
+        return 41;
+    }
+    if (do_prctl(PR_SET_NAME, (slong)set_name, 0, 0, 0) != 0 ||
+        do_prctl(PR_GET_NAME, (slong)get_name, 0, 0, 0) != 0 ||
+        !bytes_equal(set_name, get_name, sizeof(set_name))) {
+        return 42;
+    }
+
+    old_dumpable = do_prctl(PR_GET_DUMPABLE, 0, 0, 0, 0);
+    if (old_dumpable < 0 || do_prctl(PR_SET_DUMPABLE, 0, 0, 0, 0) != 0 ||
+        do_prctl(PR_GET_DUMPABLE, 0, 0, 0, 0) != 0 ||
+        do_prctl(PR_SET_DUMPABLE, old_dumpable, 0, 0, 0) != 0) {
+        return 43;
+    }
+
+    old_keepcaps = do_prctl(PR_GET_KEEPCAPS, 0, 0, 0, 0);
+    if (old_keepcaps < 0 || do_prctl(PR_SET_KEEPCAPS, 1, 0, 0, 0) != 0 ||
+        do_prctl(PR_GET_KEEPCAPS, 0, 0, 0, 0) != 1 ||
+        do_prctl(PR_SET_KEEPCAPS, old_keepcaps, 0, 0, 0) != 0) {
+        return 44;
+    }
+
+    if (do_prctl(PR_GET_TIMING, 0, 0, 0, 0) != 0 ||
+        do_prctl(PR_SET_TIMING, 0, 0, 0, 0) != 0 ||
+        do_prctl(PR_SET_TIMING, 1, 0, 0, 0) != -EINVAL) {
+        return 45;
+    }
+
+    old_slack = do_prctl(PR_GET_TIMERSLACK, 0, 0, 0, 0);
+    if (old_slack <= 0 ||
+        do_prctl(PR_SET_TIMERSLACK, 1234567, 0, 0, 0) != 0 ||
+        do_prctl(PR_GET_TIMERSLACK, 0, 0, 0, 0) != 1234567 ||
+        do_prctl(PR_SET_TIMERSLACK, old_slack, 0, 0, 0) != 0) {
+        return 46;
+    }
+
+    ret = do_prctl(PR_MCE_KILL_GET, 0, 0, 0, 0);
+    if (ret < 0 || do_prctl(PR_MCE_KILL, PR_MCE_KILL_SET,
+                            PR_MCE_KILL_LATE, 0, 0) != 0 ||
+        do_prctl(PR_MCE_KILL_GET, 0, 0, 0, 0) != PR_MCE_KILL_LATE ||
+        do_prctl(PR_MCE_KILL, PR_MCE_KILL_CLEAR, 0, 0, 0) != 0 ||
+        do_prctl(PR_MCE_KILL_GET, 0, 0, 0, 0) != PR_MCE_KILL_DEFAULT) {
+        return 47;
+    }
+
+    old_subreaper = -1;
+    if (do_prctl(PR_GET_CHILD_SUBREAPER, (slong)&old_subreaper, 0, 0, 0) ||
+        old_subreaper < 0 ||
+        do_prctl(PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0) != 0) {
+        return 48;
+    }
+    value = -1;
+    if (do_prctl(PR_GET_CHILD_SUBREAPER, (slong)&value, 0, 0, 0) != 0 ||
+        value != 1 ||
+        do_prctl(PR_SET_CHILD_SUBREAPER, old_subreaper, 0, 0, 0) != 0) {
+        return 48;
+    }
+
+    if (syscall1(__NR_set_tid_address, (slong)&clear_tid) <= 0 ||
+        do_prctl(PR_GET_TID_ADDRESS, (slong)&tid_address, 0, 0, 0) != 0 ||
+        tid_address != (ulong)&clear_tid) {
+        return 49;
+    }
+
+    old_thp = do_prctl(PR_GET_THP_DISABLE, 0, 0, 0, 0);
+    if (old_thp < 0 || do_prctl(PR_SET_THP_DISABLE, 1, 0, 0, 0) != 0 ||
+        do_prctl(PR_GET_THP_DISABLE, 0, 0, 0, 0) != 1 ||
+        do_prctl(PR_SET_THP_DISABLE, old_thp, 0, 0, 0) != 0) {
+        return 50;
+    }
+
+    old_merge = do_prctl(PR_GET_MEMORY_MERGE, 0, 0, 0, 0);
+    if (old_merge != -EINVAL) {
+        int next_merge;
+
+        if (old_merge != 0 && old_merge != 1) {
+            return 51;
+        }
+        next_merge = !old_merge;
+        if (do_prctl(PR_SET_MEMORY_MERGE, next_merge, 0, 0, 0) != 0 ||
+            do_prctl(PR_GET_MEMORY_MERGE, 0, 0, 0, 0) != next_merge ||
+            do_prctl(PR_SET_MEMORY_MERGE, old_merge, 0, 0, 0) != 0) {
+            return 51;
+        }
+    }
+
+    ret = do_prctl(PR_SCHED_CORE, PR_SCHED_CORE_GET, 0,
+                   PR_SCHED_CORE_SCOPE_THREAD, (slong)&cookie);
+    if (ret != 0 && ret != -EINVAL) {
+        return 52;
+    }
+    ret = do_prctl(PR_CAPBSET_READ, CAP_CHOWN, 0, 0, 0);
+    if (ret != 0 && ret != 1) {
+        return 53;
+    }
+    if (do_prctl(PR_CAPBSET_READ, 999, 0, 0, 0) != -EINVAL ||
+        do_prctl(PR_TASK_PERF_EVENTS_DISABLE, 0, 0, 0, 0) != 0 ||
+        do_prctl(PR_TASK_PERF_EVENTS_ENABLE, 0, 0, 0, 0) != 0) {
+        return 53;
+    }
+
+    if (do_prctl(PR_GET_UNALIGN, (slong)&value, 0, 0, 0) != -EINVAL ||
+        do_prctl(PR_SET_FP_MODE, 0, 0, 0, 0) != -EINVAL) {
+        return 54;
+    }
+
+    if (do_prctl(PR_SET_NO_NEW_PRIVS, 1, 1, 0, 0) != -EINVAL ||
+        do_prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0 ||
+        do_prctl(PR_GET_NO_NEW_PRIVS, 0, 0, 0, 0) != 1) {
+        return 55;
+    }
+    return 0;
+}
+
+static int test_vma_name(void)
+{
+    static const char name[] = "lat-vma-inner";
+    static const char marker[] = "[anon:lat-vma-inner]";
+    static const char shared_name[] = "lat-vma-shared";
+    static const char shared_marker[] = "[anon_shmem:lat-vma-shared]";
+    static const char invalid_name[] = "lat[vma";
+    static const char exe_path[] = "/proc/self/exe";
+    char long_name[80];
+    char buffer[32768];
+    slong map;
+    slong shared_map;
+    slong file_map;
+    slong fd;
+    slong len;
+    ulong named_start;
+    ulong named_end;
+    ulong i;
+
+    map = do_mmap(0, 16384, PROT_READ | PROT_WRITE,
+                  MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (map < 0) {
+        return 60;
+    }
+    if (do_prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, map + 4096, 4096,
+                 (slong)name) != 0) {
+        return 61;
+    }
+    len = read_maps(buffer, sizeof(buffer));
+    if (len <= 0 ||
+        !named_range(buffer, len, marker, sizeof(marker) - 1,
+                     &named_start, &named_end) ||
+        named_start != (ulong)map + 4096 || named_end != (ulong)map + 8192) {
+        return 63;
+    }
+    if (do_prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, map + 4096, 4096, 0)) {
+        return 64;
+    }
+    len = read_maps(buffer, sizeof(buffer));
+    if (len <= 0 || contains(buffer, len, marker, sizeof(marker) - 1)) {
+        return 65;
+    }
+
+    for (i = 0; i < sizeof(long_name); i++) {
+        long_name[i] = 'a';
+    }
+    if (do_prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, map, 4096,
+                 (slong)invalid_name) != -EINVAL ||
+        do_prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, map, 4096,
+                 (slong)long_name) != -ENAMETOOLONG) {
+        return 66;
+    }
+
+    fd = syscall4(__NR_openat, AT_FDCWD, (slong)exe_path, 0, 0);
+    if (fd < 0) {
+        return 67;
+    }
+    file_map = do_mmap(0, 4096, PROT_READ, MAP_PRIVATE, fd, 0);
+    syscall1(__NR_close, fd);
+    if (file_map < 0 ||
+        do_prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, file_map, 4096,
+                 (slong)name) != -EBADF) {
+        return 67;
+    }
+    syscall2(__NR_munmap, file_map, 4096);
+
+    shared_map = do_mmap(0, 16384, PROT_READ | PROT_WRITE,
+                         MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+    if (shared_map < 0 ||
+        do_prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, shared_map + 4096,
+                 4096, (slong)shared_name) != 0) {
+        return 68;
+    }
+    len = read_maps(buffer, sizeof(buffer));
+    if (len <= 0 ||
+        !named_range(buffer, len, shared_marker,
+                     sizeof(shared_marker) - 1, &named_start, &named_end) ||
+        named_start != (ulong)shared_map + 4096 ||
+        named_end != (ulong)shared_map + 8192) {
+        return 68;
+    }
+    syscall2(__NR_munmap, shared_map, 16384);
+
+    if (do_prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, map + 4096, 4096,
+                 (slong)name) != 0 ||
+        syscall2(__NR_munmap, map + 4096, 4096) != 0 ||
+        do_mmap((void *)(map + 4096), 4096, PROT_READ | PROT_WRITE,
+                MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0) !=
+            map + 4096) {
+        return 69;
+    }
+    len = read_maps(buffer, sizeof(buffer));
+    if (len <= 0 || contains(buffer, len, marker, sizeof(marker) - 1)) {
+        return 69;
+    }
+    syscall2(__NR_munmap, map, 16384);
+    return 0;
+}
+
+static int enable_mdwe(void)
+{
+    return do_prctl(PR_SET_MDWE, PR_MDWE_REFUSE_EXEC_GAIN, 0, 0, 0) == 0 &&
+           do_prctl(PR_GET_MDWE, 0, 0, 0, 0) == PR_MDWE_REFUSE_EXEC_GAIN;
+}
+
+static int test_mdwe_basic(void)
+{
+    slong map;
+
+    if (!enable_mdwe()) {
+        return 70;
+    }
+    map = do_mmap(0, 4096, PROT_READ | PROT_EXEC,
+                  MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (map < 0 || syscall3(__NR_mprotect, map, 4096,
+                            PROT_READ | PROT_EXEC) != 0) {
+        return 71;
+    }
+    syscall2(__NR_munmap, map, 4096);
+
+    map = do_mmap(0, 4096, PROT_READ | PROT_WRITE,
+                  MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (map < 0 || syscall3(__NR_mprotect, map, 4096,
+                            PROT_READ | PROT_EXEC) != -EACCES) {
+        return 72;
+    }
+    syscall2(__NR_munmap, map, 4096);
+
+    if (do_mmap(0, 4096, PROT_WRITE | PROT_EXEC,
+                MAP_PRIVATE | MAP_ANONYMOUS, -1, 0) != -EACCES) {
+        return 73;
+    }
+
+    map = do_mmap(0, 4096, PROT_READ,
+                  MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (map < 0 || do_mmap((void *)map, 4096, PROT_READ | PROT_EXEC,
+                           MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED,
+                           -1, 0) != map) {
+        return 74;
+    }
+    syscall2(__NR_munmap, map, 4096);
+
+    if (do_prctl(PR_SET_MDWE, PR_MDWE_REFUSE_EXEC_GAIN, 0, 0, 0) != 0 ||
+        do_prctl(PR_SET_MDWE, 0, 0, 0, 0) != -EPERM) {
+        return 75;
+    }
+    return 0;
+}
+
+static int test_mdwe_personality(void)
+{
+    slong old_personality;
+    slong map;
+
+    old_personality = syscall1(__NR_personality, 0xffffffffUL);
+    if (old_personality < 0 ||
+        syscall1(__NR_personality, old_personality | READ_IMPLIES_EXEC) < 0) {
+        return 80;
+    }
+    if (!enable_mdwe()) {
+        return 81;
+    }
+    map = do_mmap(0, 4096, PROT_READ | PROT_WRITE,
+                  MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    syscall1(__NR_personality, old_personality);
+    if (map != -EACCES) {
+        return 82;
+    }
+    return 0;
+}
+
+static int test_mdwe_shmat(void)
+{
+    slong shmid;
+    slong map;
+
+    shmid = syscall3(__NR_shmget, IPC_PRIVATE, 4096, IPC_CREAT | 0700);
+    if (shmid < 0) {
+        return 90;
+    }
+    if (!enable_mdwe()) {
+        syscall3(__NR_shmctl, shmid, IPC_RMID, 0);
+        return 91;
+    }
+    map = syscall3(__NR_shmat, shmid, 0, SHM_EXEC);
+    syscall3(__NR_shmctl, shmid, IPC_RMID, 0);
+    if (map != -EACCES) {
+        if (map >= 0) {
+            syscall1(__NR_shmdt, map);
+        }
+        return 92;
+    }
+    return 0;
+}
+
+static int test_fork_state(int no_inherit)
+{
+    int mdwe = PR_MDWE_REFUSE_EXEC_GAIN |
+               (no_inherit ? PR_MDWE_NO_INHERIT : 0);
+    int expected_child_mdwe = no_inherit ? 0 : mdwe;
+    int tsc_mode = 0;
+    int status = -1;
+    slong pid;
+
+    if (do_prctl(PR_SET_MDWE, mdwe, 0, 0, 0) != 0 ||
+        do_prctl(PR_SET_TSC, PR_TSC_SIGSEGV, 0, 0, 0) != 0) {
+        return 110;
+    }
+    pid = syscall1(__NR_fork, 0);
+    if (pid < 0) {
+        return 111;
+    }
+    if (pid == 0) {
+        int result = 0;
+
+        if (do_prctl(PR_GET_MDWE, 0, 0, 0, 0) != expected_child_mdwe ||
+            do_prctl(PR_GET_TSC, (slong)&tsc_mode, 0, 0, 0) != 0 ||
+            tsc_mode != PR_TSC_SIGSEGV) {
+            result = 112;
+        }
+        syscall1(__NR_exit_group, result);
+    }
+    if (syscall4(__NR_wait4, pid, (slong)&status, 0, 0) != pid || status) {
+        return 113;
+    }
+    if (do_prctl(PR_GET_MDWE, 0, 0, 0, 0) != mdwe ||
+        do_prctl(PR_GET_TSC, (slong)&tsc_mode, 0, 0, 0) != 0 ||
+        tsc_mode != PR_TSC_SIGSEGV) {
+        return 114;
+    }
+    return 0;
+}
+
+int test_main(ulong *stack)
+{
+    ulong argc = stack[0];
+    char **argv = (char **)&stack[1];
+    char mode;
+
+    if (argc != 2 || !argv[1]) {
+        return 100;
+    }
+    mode = argv[1][0];
+    if (mode == 'p') {
+        return test_process_controls();
+    }
+    if (mode == 'v') {
+        return test_vma_name();
+    }
+    if (mode == 'm') {
+        return test_mdwe_basic();
+    }
+    if (mode == 'r') {
+        return test_mdwe_personality();
+    }
+    if (mode == 's') {
+        return test_mdwe_shmat();
+    }
+    if (mode == 'f') {
+        return test_fork_state(1);
+    }
+    if (mode == 'i') {
+        return test_fork_state(0);
+    }
+    return 101;
+}
+
+__asm__(".section .text\n"
+        ".global _start\n"
+        ".type _start,@function\n"
+        "_start:\n"
+        "mov %rsp,%rdi\n"
+        "andq $-16,%rsp\n"
+        "call test_main\n"
+        "mov %eax,%edi\n"
+        "mov $231,%eax\n"
+        "syscall\n"
+        "ud2\n"
+        ".size _start,.-_start\n"
+        ".section .note.GNU-stack,\"\",@progbits\n");

--- a/tests/integration/prctl-x86-semantics.c
+++ b/tests/integration/prctl-x86-semantics.c
@@ -10,6 +10,7 @@ typedef long slong;
 #define __NR_read               0
 #define __NR_write              1
 #define __NR_close              3
+#define __NR_execve            59
 #define __NR_mmap               9
 #define __NR_mprotect          10
 #define __NR_munmap            11
@@ -20,11 +21,15 @@ typedef long slong;
 #define __NR_shmdt             67
 #define __NR_fork              57
 #define __NR_wait4             61
+#define __NR_mremap            25
 #define __NR_personality      135
 #define __NR_prctl            157
 #define __NR_set_tid_address  218
 #define __NR_exit_group       231
 #define __NR_openat           257
+#define __NR_readlink          89
+#define __NR_rename            82
+#define __NR_unlink            87
 
 #define EACCES 13
 #define EBADF   9
@@ -41,6 +46,10 @@ typedef long slong;
 #define MAP_PRIVATE   2
 #define MAP_FIXED    16
 #define MAP_ANONYMOUS 32
+
+#define MREMAP_MAYMOVE   1
+#define MREMAP_FIXED     2
+#define MREMAP_DONTUNMAP 4
 
 #define AT_FDCWD (-100)
 
@@ -227,6 +236,16 @@ static int bytes_equal(const char *a, const char *b, ulong len)
     return 1;
 }
 
+static ulong string_length(const char *value)
+{
+    ulong len = 0;
+
+    while (value[len]) {
+        len++;
+    }
+    return len;
+}
+
 static int contains(const char *buf, ulong len, const char *needle,
                     ulong needle_len)
 {
@@ -300,6 +319,19 @@ static slong read_maps(char *buffer, ulong size)
 {
     static const char maps_path[] = "/proc/self/maps";
     slong fd = syscall4(__NR_openat, AT_FDCWD, (slong)maps_path, 0, 0);
+    slong len;
+
+    if (fd < 0) {
+        return fd;
+    }
+    len = syscall3(__NR_read, fd, (slong)buffer, size);
+    syscall1(__NR_close, fd);
+    return len;
+}
+
+static slong read_file(const char *path, char *buffer, ulong size)
+{
+    slong fd = syscall4(__NR_openat, AT_FDCWD, (slong)path, 0, 0);
     slong len;
 
     if (fd < 0) {
@@ -466,6 +498,9 @@ static int test_vma_name(void)
     slong file_map;
     slong shmid;
     slong second_shmid;
+    slong remap_source;
+    slong remap_target;
+    slong remap_copy;
     slong fd;
     slong len;
     ulong named_start;
@@ -600,6 +635,77 @@ static int test_vma_name(void)
         return 69;
     }
     syscall2(__NR_munmap, map, 16384);
+
+    remap_source = do_mmap(0, 16384, PROT_READ | PROT_WRITE,
+                           MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    remap_target = do_mmap(0, 16384, PROT_READ | PROT_WRITE,
+                           MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (remap_source < 0 || remap_target < 0 ||
+        do_prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, remap_source, 12288,
+                 (slong)name) != 0 ||
+        syscall2(__NR_munmap, remap_target, 16384) != 0 ||
+        syscall5(__NR_mremap, remap_source, 8193, 8193,
+                 MREMAP_MAYMOVE | MREMAP_FIXED, remap_target) !=
+            remap_target) {
+        return 69;
+    }
+    len = read_maps(buffer, sizeof(buffer));
+    if (len <= 0 ||
+        !named_range(buffer, len, marker, sizeof(marker) - 1,
+                     &named_start, &named_end) ||
+        named_start != (ulong)remap_target ||
+        named_end != (ulong)remap_target + 12288) {
+        return 69;
+    }
+    syscall2(__NR_munmap, remap_target, 12288);
+
+    shared_map = do_mmap(0, 16384, PROT_READ | PROT_WRITE,
+                         MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+    if (shared_map < 0 ||
+        do_prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, shared_map, 16384,
+                 (slong)shared_name) != 0) {
+        return 69;
+    }
+    remap_copy = syscall5(__NR_mremap, shared_map, 0, 16384,
+                          MREMAP_MAYMOVE, 0);
+    if (remap_copy < 0 ||
+        do_prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, shared_map, 16384, 0)) {
+        return 69;
+    }
+    len = read_maps(buffer, sizeof(buffer));
+    if (len <= 0 ||
+        !named_range(buffer, len, shared_marker,
+                     sizeof(shared_marker) - 1, &named_start, &named_end) ||
+        named_start != (ulong)remap_copy ||
+        named_end != (ulong)remap_copy + 16384) {
+        return 69;
+    }
+    syscall2(__NR_munmap, shared_map, 16384);
+    syscall2(__NR_munmap, remap_copy, 16384);
+
+    remap_source = do_mmap(0, 16384, PROT_READ | PROT_WRITE,
+                           MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (remap_source < 0 ||
+        do_prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, remap_source, 16384,
+                 (slong)name) != 0) {
+        return 69;
+    }
+    remap_copy = syscall5(__NR_mremap, remap_source, 16384, 16384,
+                          MREMAP_MAYMOVE | MREMAP_DONTUNMAP, 0);
+    if (remap_copy < 0 ||
+        do_prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, remap_source, 16384, 0)) {
+        return 69;
+    }
+    len = read_maps(buffer, sizeof(buffer));
+    if (len <= 0 ||
+        !named_range(buffer, len, marker, sizeof(marker) - 1,
+                     &named_start, &named_end) ||
+        named_start != (ulong)remap_copy ||
+        named_end != (ulong)remap_copy + 16384) {
+        return 69;
+    }
+    syscall2(__NR_munmap, remap_source, 16384);
+    syscall2(__NR_munmap, remap_copy, 16384);
     return 0;
 }
 
@@ -706,10 +812,13 @@ static int test_fork_state(int no_inherit)
     int expected_child_mdwe = no_inherit ? 0 : mdwe;
     int tsc_mode = 0;
     int status = -1;
+    ulong clear_tid = 0;
+    ulong tid_address = 1;
     slong pid;
 
     if (do_prctl(PR_SET_MDWE, mdwe, 0, 0, 0) != 0 ||
-        do_prctl(PR_SET_TSC, PR_TSC_SIGSEGV, 0, 0, 0) != 0) {
+        do_prctl(PR_SET_TSC, PR_TSC_SIGSEGV, 0, 0, 0) != 0 ||
+        syscall1(__NR_set_tid_address, (slong)&clear_tid) <= 0) {
         return 110;
     }
     pid = syscall1(__NR_fork, 0);
@@ -721,7 +830,9 @@ static int test_fork_state(int no_inherit)
 
         if (do_prctl(PR_GET_MDWE, 0, 0, 0, 0) != expected_child_mdwe ||
             do_prctl(PR_GET_TSC, (slong)&tsc_mode, 0, 0, 0) != 0 ||
-            tsc_mode != PR_TSC_SIGSEGV) {
+            tsc_mode != PR_TSC_SIGSEGV ||
+            do_prctl(PR_GET_TID_ADDRESS, (slong)&tid_address, 0, 0, 0) ||
+            tid_address != 0) {
             result = 112;
         }
         syscall1(__NR_exit_group, result);
@@ -731,26 +842,33 @@ static int test_fork_state(int no_inherit)
     }
     if (do_prctl(PR_GET_MDWE, 0, 0, 0, 0) != mdwe ||
         do_prctl(PR_GET_TSC, (slong)&tsc_mode, 0, 0, 0) != 0 ||
-        tsc_mode != PR_TSC_SIGSEGV) {
+        tsc_mode != PR_TSC_SIGSEGV ||
+        do_prctl(PR_GET_TID_ADDRESS, (slong)&tid_address, 0, 0, 0) ||
+        tid_address != (ulong)&clear_tid) {
         return 114;
     }
     return 0;
 }
 
-static int test_set_mm_privileged(void)
+static int test_set_mm_privileged(const char *self_path)
 {
     static const char cmdline[] = "lat-prctl-mm";
     static const char cmdline_path[] = "/proc/self/cmdline";
+    static const char environ[] = "E=1";
+    static const char environ_path[] = "/proc/self/environ";
+    static const char proctitle[] = "lat-prctl-title";
     static const char auxv_path[] = "/proc/self/auxv";
     static const char exe_path[] = "/proc/self/exe";
     ulong replacement_auxv[4] = { 123, 456, 0, 0 };
     ulong second_auxv[4] = { 789, 321, 0, 0 };
     ulong auxv_buffer[8] = { 0 };
     struct prctl_mm_map mm;
-    char buffer[64];
+    char buffer[512];
+    char renamed_path[256];
     slong map;
     slong fd;
     slong len;
+    ulong self_len;
     ulong i;
 
     map = do_mmap(0, 16384, PROT_READ | PROT_WRITE,
@@ -793,9 +911,31 @@ static int test_set_mm_privileged(void)
         syscall1(__NR_brk, 0) != map + 8192) {
         return 122;
     }
+    len = read_file(environ_path, buffer, sizeof(buffer));
+    if (len != sizeof(environ) ||
+        !bytes_equal(buffer, environ, sizeof(environ))) {
+        return 122;
+    }
+
+    for (i = 0; i < sizeof(proctitle); i++) {
+        ((char *)map)[512 + i] = proctitle[i];
+    }
+    mm.arg_start = map + 512;
+    mm.arg_end = map + 516;
+    mm.env_start = mm.arg_end;
+    mm.env_end = map + 512 + sizeof(proctitle);
+    mm.auxv_size = 0;
+    if (do_prctl(PR_SET_MM, PR_SET_MM_MAP, (slong)&mm, sizeof(mm), 0)) {
+        return 122;
+    }
+    len = read_file(cmdline_path, buffer, sizeof(buffer));
+    if (len != sizeof(proctitle) ||
+        !bytes_equal(buffer, proctitle, sizeof(proctitle))) {
+        return 122;
+    }
 
     if (do_prctl(PR_GET_AUXV, (slong)auxv_buffer,
-                 sizeof(replacement_auxv), 0, 0) < 0 ||
+                 sizeof(replacement_auxv), 0, 0) != 54 * sizeof(ulong) ||
         !bytes_equal((char *)auxv_buffer, (char *)replacement_auxv,
                      sizeof(replacement_auxv))) {
         return 123;
@@ -865,7 +1005,76 @@ static int test_set_mm_privileged(void)
         return 128;
     }
     syscall1(__NR_close, fd);
+
+    if (!self_path) {
+        return 129;
+    }
+    self_len = string_length(self_path);
+    fd = syscall4(__NR_openat, AT_FDCWD, (slong)self_path, 0, 0);
+    if (fd < 0) {
+        return 129;
+    }
+    mm.exe_fd = fd;
+    if (do_prctl(PR_SET_MM, PR_SET_MM_MAP, (slong)&mm, sizeof(mm), 0)) {
+        syscall1(__NR_close, fd);
+        return 129;
+    }
+    syscall1(__NR_close, fd);
+    len = syscall3(__NR_readlink, (slong)exe_path, (slong)buffer,
+                   sizeof(buffer));
+    if (len != self_len || !bytes_equal(buffer, self_path, self_len)) {
+        return 129;
+    }
+    for (i = 0; self_path[i] && i + 9 < sizeof(renamed_path); i++) {
+        renamed_path[i] = self_path[i];
+    }
+    if (self_path[i] || i + 9 >= sizeof(renamed_path)) {
+        return 129;
+    }
+    renamed_path[i++] = '.';
+    renamed_path[i++] = 'r';
+    renamed_path[i++] = 'e';
+    renamed_path[i++] = 'n';
+    renamed_path[i++] = 'a';
+    renamed_path[i++] = 'm';
+    renamed_path[i++] = 'e';
+    renamed_path[i++] = 'd';
+    renamed_path[i] = 0;
+    if (syscall2(__NR_rename, (slong)self_path, (slong)renamed_path) != 0) {
+        return 129;
+    }
+    len = syscall3(__NR_readlink, (slong)exe_path, (slong)buffer,
+                   sizeof(buffer));
+    if (len != i || !bytes_equal(buffer, renamed_path, i)) {
+        return 129;
+    }
+    if (syscall1(__NR_unlink, (slong)renamed_path) != 0) {
+        return 129;
+    }
+    len = syscall3(__NR_readlink, (slong)exe_path, (slong)buffer,
+                   sizeof(buffer));
+    if (len != i + 10 || !bytes_equal(buffer, renamed_path, i) ||
+        !bytes_equal(buffer + i, " (deleted)", 10)) {
+        return 129;
+    }
     return 0;
+}
+
+static int test_native_exec_env(const char *helper_path)
+{
+    static char mdwe_env[] = "_LATX_GUEST_MDWE=forged";
+    static char tsc_env[] = "_LATX_GUEST_TSC=forged";
+    static char keep_env[] = "KEEP=1";
+    char *argv[] = { (char *)helper_path, 0 };
+    char *envp[] = { mdwe_env, tsc_env, keep_env, 0 };
+
+    if (!helper_path ||
+        do_prctl(PR_SET_MDWE, PR_MDWE_REFUSE_EXEC_GAIN, 0, 0, 0) ||
+        do_prctl(PR_SET_TSC, PR_TSC_SIGSEGV, 0, 0, 0)) {
+        return 130;
+    }
+    syscall3(__NR_execve, (slong)helper_path, (slong)argv, (slong)envp);
+    return 131;
 }
 
 int test_main(ulong *stack)
@@ -874,7 +1083,7 @@ int test_main(ulong *stack)
     char **argv = (char **)&stack[1];
     char mode;
 
-    if (argc != 2 || !argv[1]) {
+    if (argc < 2 || argc > 3 || !argv[1]) {
         return 100;
     }
     mode = argv[1][0];
@@ -900,7 +1109,10 @@ int test_main(ulong *stack)
         return test_fork_state(0);
     }
     if (mode == 'x') {
-        return test_set_mm_privileged();
+        return test_set_mm_privileged(argc == 3 ? argv[2] : 0);
+    }
+    if (mode == 'e') {
+        return test_native_exec_env(argc == 3 ? argv[2] : 0);
     }
     return 101;
 }

--- a/tests/integration/prctl-x86-semantics.c
+++ b/tests/integration/prctl-x86-semantics.c
@@ -27,6 +27,7 @@ typedef long slong;
 #define __NR_set_tid_address  218
 #define __NR_exit_group       231
 #define __NR_openat           257
+#define __NR_readlinkat       267
 #define __NR_execveat         322
 #define __NR_readlink          89
 #define __NR_rename            82
@@ -36,6 +37,7 @@ typedef long slong;
 #define EBADF   9
 #define EFAULT 14
 #define EINVAL 22
+#define ENOMEM 12
 #define ENAMETOOLONG 36
 #define EPERM   1
 
@@ -54,6 +56,7 @@ typedef long slong;
 
 #define AT_FDCWD (-100)
 #define AT_EMPTY_PATH 0x1000
+#define O_DIRECTORY 00200000
 
 #define IPC_PRIVATE 0
 #define IPC_CREAT   01000
@@ -346,6 +349,7 @@ static slong read_file(const char *path, char *buffer, ulong size)
 
 static int test_process_controls(void)
 {
+    static const char exe_path[] = "/proc/self/exe";
     static const char set_name[16] = "lat-prctl-proc";
     char get_name[16] = { 0 };
     int value = -1;
@@ -477,6 +481,12 @@ static int test_process_controls(void)
         do_prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0 ||
         do_prctl(PR_GET_NO_NEW_PRIVS, 0, 0, 0, 0) != 1) {
         return 55;
+    }
+    if (syscall3(__NR_readlink, (slong)exe_path, -1, 0) != -EINVAL ||
+        syscall3(__NR_readlink, (slong)exe_path, -1, -1) != -EINVAL ||
+        syscall4(__NR_readlinkat, AT_FDCWD, (slong)exe_path, -1, 0) !=
+            -EINVAL) {
+        return 56;
     }
     return 0;
 }
@@ -661,6 +671,63 @@ static int test_vma_name(void)
     }
     syscall2(__NR_munmap, remap_target, 12288);
 
+    remap_source = do_mmap(0, 12288, PROT_READ | PROT_WRITE,
+                           MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    remap_target = do_mmap(0, 12288, PROT_READ | PROT_WRITE,
+                           MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (remap_source < 0 || remap_target < 0) {
+        return 69;
+    }
+    *(ulong *)remap_source = 0x123456789abcdef0UL;
+    if (syscall3(__NR_mprotect, remap_source, 12288, 0) != 0 ||
+        syscall2(__NR_munmap, remap_target, 12288) != 0 ||
+        syscall5(__NR_mremap, remap_source, 8193, 8193,
+                 MREMAP_MAYMOVE | MREMAP_FIXED, remap_target) !=
+            remap_target ||
+        syscall3(__NR_mprotect, remap_target, 12288, PROT_READ) != 0 ||
+        *(ulong *)remap_target != 0x123456789abcdef0UL ||
+        syscall3(__NR_mprotect, remap_source, 4096, PROT_READ) != -ENOMEM) {
+        return 69;
+    }
+    syscall2(__NR_munmap, remap_target, 12288);
+
+    remap_source = do_mmap(0, 12288, PROT_READ | PROT_WRITE,
+                           MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    remap_target = do_mmap(0, 16384, PROT_READ | PROT_WRITE,
+                           MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (remap_source < 0 || remap_target < 0) {
+        return 69;
+    }
+    *(ulong *)remap_source = 0x1122334455667788UL;
+    *(ulong *)(remap_target + 12288) = 0x8877665544332211UL;
+    if (syscall5(__NR_mremap, remap_source, 8193, 8193,
+                 MREMAP_MAYMOVE | MREMAP_FIXED, remap_target) !=
+            remap_target ||
+        *(ulong *)remap_target != 0x1122334455667788UL ||
+        *(ulong *)(remap_target + 12288) != 0x8877665544332211UL) {
+        return 69;
+    }
+    syscall2(__NR_munmap, remap_target, 16384);
+
+    remap_source = do_mmap(0, 12288, PROT_READ | PROT_WRITE,
+                           MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    remap_target = do_mmap(0, 16384, PROT_READ | PROT_WRITE,
+                           MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (remap_source < 0 || remap_target < 0 ||
+        syscall3(__NR_mprotect, remap_source + 4096, 4096, PROT_READ) != 0) {
+        return 69;
+    }
+    *(ulong *)remap_target = 0xaabbccddeeff0011UL;
+    *(ulong *)(remap_target + 12288) = 0x1100ffeeddccbbaaUL;
+    if (syscall5(__NR_mremap, remap_source, 8193, 8193,
+                 MREMAP_MAYMOVE | MREMAP_FIXED, remap_target) != -EFAULT ||
+        *(ulong *)remap_target != 0xaabbccddeeff0011UL ||
+        *(ulong *)(remap_target + 12288) != 0x1100ffeeddccbbaaUL) {
+        return 69;
+    }
+    syscall2(__NR_munmap, remap_source, 12288);
+    syscall2(__NR_munmap, remap_target, 16384);
+
     shared_map = do_mmap(0, 16384, PROT_READ | PROT_WRITE,
                          MAP_SHARED | MAP_ANONYMOUS, -1, 0);
     if (shared_map < 0 ||
@@ -811,7 +878,7 @@ static int test_fork_state(int no_inherit)
 {
     int mdwe = PR_MDWE_REFUSE_EXEC_GAIN |
                (no_inherit ? PR_MDWE_NO_INHERIT : 0);
-    int expected_child_mdwe = no_inherit ? 0 : mdwe;
+    int expected_child_mdwe = mdwe;
     int tsc_mode = 0;
     int status = -1;
     ulong clear_tid = 0;
@@ -1091,6 +1158,37 @@ static int test_native_exec_env(const char *helper_path, int at_empty_path)
     return 131;
 }
 
+static int test_script_exec(const char *dir_path)
+{
+    static char script_name[] = "state-script";
+    static char stage_name[] = "k";
+    char *argv[] = { script_name, stage_name, 0 };
+    slong dirfd;
+
+    if (!dir_path ||
+        do_prctl(PR_SET_MDWE, PR_MDWE_REFUSE_EXEC_GAIN, 0, 0, 0) ||
+        do_prctl(PR_SET_TSC, PR_TSC_SIGSEGV, 0, 0, 0)) {
+        return 132;
+    }
+    dirfd = syscall4(__NR_openat, AT_FDCWD, (slong)dir_path,
+                     O_DIRECTORY, 0);
+    if (dirfd < 0) {
+        return 132;
+    }
+    syscall5(__NR_execveat, dirfd, (slong)script_name, (slong)argv, 0, 0);
+    return 132;
+}
+
+static int test_script_inherit(void)
+{
+    int tsc_mode = 0;
+
+    return do_prctl(PR_GET_MDWE, 0, 0, 0, 0) ==
+               PR_MDWE_REFUSE_EXEC_GAIN &&
+           do_prctl(PR_GET_TSC, (slong)&tsc_mode, 0, 0, 0) == 0 &&
+           tsc_mode == PR_TSC_SIGSEGV ? 0 : 133;
+}
+
 int test_main(ulong *stack)
 {
     ulong argc = stack[0];
@@ -1099,6 +1197,9 @@ int test_main(ulong *stack)
 
     if (argc < 2 || argc > 3 || !argv[1]) {
         return 100;
+    }
+    if (argc == 3 && argv[2] && argv[2][0] == 'k') {
+        return test_script_inherit();
     }
     mode = argv[1][0];
     if (mode == 'p') {
@@ -1130,6 +1231,12 @@ int test_main(ulong *stack)
     }
     if (mode == 'a') {
         return test_native_exec_env(argc == 3 ? argv[2] : 0, 1);
+    }
+    if (mode == 'd') {
+        return test_script_exec(argc == 3 ? argv[2] : 0);
+    }
+    if (mode == 'k') {
+        return test_script_inherit();
     }
     return 101;
 }

--- a/tests/integration/prctl-x86-semantics.c
+++ b/tests/integration/prctl-x86-semantics.c
@@ -453,13 +453,19 @@ static int test_vma_name(void)
     static const char marker[] = "[anon:lat-vma-inner]";
     static const char shared_name[] = "lat-vma-shared";
     static const char shared_marker[] = "[anon_shmem:lat-vma-shared]";
+    static const char sysv_name[] = "lat-vma-sysv";
+    static const char sysv_marker[] = "[anon_shmem:lat-vma-sysv]";
     static const char invalid_name[] = "lat[vma";
     static const char exe_path[] = "/proc/self/exe";
     char long_name[80];
     char buffer[32768];
     slong map;
     slong shared_map;
+    slong sysv_map;
+    slong sysv_remap;
     slong file_map;
+    slong shmid;
+    slong second_shmid;
     slong fd;
     slong len;
     ulong named_start;
@@ -535,6 +541,51 @@ static int test_vma_name(void)
         return 68;
     }
     syscall2(__NR_munmap, shared_map, 16384);
+
+    shmid = syscall3(__NR_shmget, IPC_PRIVATE, 4096, IPC_CREAT | 0600);
+    if (shmid < 0) {
+        return 69;
+    }
+    sysv_map = syscall3(__NR_shmat, shmid, 0, 0);
+    if (sysv_map < 0 ||
+        do_prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, sysv_map, 4096,
+                 (slong)sysv_name) != 0) {
+        syscall3(__NR_shmctl, shmid, IPC_RMID, 0);
+        return 69;
+    }
+    len = read_maps(buffer, sizeof(buffer));
+    if (len <= 0 ||
+        !named_range(buffer, len, sysv_marker, sizeof(sysv_marker) - 1,
+                     &named_start, &named_end) ||
+        named_start != (ulong)sysv_map || named_end != (ulong)sysv_map + 4096) {
+        syscall1(__NR_shmdt, sysv_map);
+        syscall3(__NR_shmctl, shmid, IPC_RMID, 0);
+        return 69;
+    }
+    if (syscall1(__NR_shmdt, sysv_map) != 0 ||
+        syscall3(__NR_shmctl, shmid, IPC_RMID, 0) != 0) {
+        return 69;
+    }
+
+    second_shmid = syscall3(__NR_shmget, IPC_PRIVATE, 4096,
+                            IPC_CREAT | 0600);
+    if (second_shmid < 0) {
+        return 69;
+    }
+    sysv_remap = syscall3(__NR_shmat, second_shmid, sysv_map, 0);
+    if (sysv_remap != sysv_map) {
+        syscall3(__NR_shmctl, second_shmid, IPC_RMID, 0);
+        return 69;
+    }
+    len = read_maps(buffer, sizeof(buffer));
+    if (len <= 0 || contains(buffer, len, sysv_marker,
+                             sizeof(sysv_marker) - 1)) {
+        syscall1(__NR_shmdt, sysv_remap);
+        syscall3(__NR_shmctl, second_shmid, IPC_RMID, 0);
+        return 69;
+    }
+    syscall1(__NR_shmdt, sysv_remap);
+    syscall3(__NR_shmctl, second_shmid, IPC_RMID, 0);
 
     if (do_prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, map + 4096, 4096,
                  (slong)name) != 0 ||
@@ -694,7 +745,7 @@ static int test_set_mm_privileged(void)
     static const char exe_path[] = "/proc/self/exe";
     ulong replacement_auxv[4] = { 123, 456, 0, 0 };
     ulong second_auxv[4] = { 789, 321, 0, 0 };
-    ulong auxv_buffer[4] = { 0 };
+    ulong auxv_buffer[8] = { 0 };
     struct prctl_mm_map mm;
     char buffer[64];
     slong map;
@@ -744,7 +795,7 @@ static int test_set_mm_privileged(void)
     }
 
     if (do_prctl(PR_GET_AUXV, (slong)auxv_buffer,
-                 sizeof(auxv_buffer), 0, 0) < 0 ||
+                 sizeof(replacement_auxv), 0, 0) < 0 ||
         !bytes_equal((char *)auxv_buffer, (char *)replacement_auxv,
                      sizeof(replacement_auxv))) {
         return 123;
@@ -756,23 +807,26 @@ static int test_set_mm_privileged(void)
     len = syscall3(__NR_read, fd, (slong)auxv_buffer,
                    sizeof(auxv_buffer));
     syscall1(__NR_close, fd);
-    if (len != sizeof(auxv_buffer) ||
+    if (len != sizeof(replacement_auxv) ||
         !bytes_equal((char *)auxv_buffer, (char *)replacement_auxv,
                      sizeof(replacement_auxv))) {
         return 123;
     }
 
-    if (do_prctl(PR_SET_MM, PR_SET_MM_START_CODE, map, 0, 0) ||
-        do_prctl(PR_SET_MM, PR_SET_MM_END_CODE, map + 64, 0, 0) ||
-        do_prctl(PR_SET_MM, PR_SET_MM_START_DATA, map + 128, 0, 0) ||
-        do_prctl(PR_SET_MM, PR_SET_MM_END_DATA, map + 256, 0, 0) ||
-        do_prctl(PR_SET_MM, PR_SET_MM_START_BRK, map + 4096, 0, 0) ||
-        do_prctl(PR_SET_MM, PR_SET_MM_BRK, map + 8192, 0, 0) ||
-        do_prctl(PR_SET_MM, PR_SET_MM_START_STACK, map + 12288, 0, 0) ||
-        do_prctl(PR_SET_MM, PR_SET_MM_ARG_START, map, 0, 0) ||
-        do_prctl(PR_SET_MM, PR_SET_MM_ARG_END, map + 4, 0, 0) ||
-        do_prctl(PR_SET_MM, PR_SET_MM_ENV_START, map + 128, 0, 0) ||
-        do_prctl(PR_SET_MM, PR_SET_MM_ENV_END, map + 132, 0, 0)) {
+    if (do_prctl(PR_SET_MM, PR_SET_MM_START_CODE, map, 0, 0) != -EPERM ||
+        do_prctl(PR_SET_MM, PR_SET_MM_END_CODE, map + 64, 0, 0) != -EPERM ||
+        do_prctl(PR_SET_MM, PR_SET_MM_START_DATA, map + 128, 0, 0) != -EPERM ||
+        do_prctl(PR_SET_MM, PR_SET_MM_END_DATA, map + 256, 0, 0) != -EPERM ||
+        do_prctl(PR_SET_MM, PR_SET_MM_START_BRK, map + 4096, 0, 0) != -EPERM ||
+        do_prctl(PR_SET_MM, PR_SET_MM_BRK, map + 8192, 0, 0) != -EPERM ||
+        do_prctl(PR_SET_MM, PR_SET_MM_START_STACK, map + 12288,
+                 0, 0) != -EPERM ||
+        do_prctl(PR_SET_MM, PR_SET_MM_ARG_START, map, 0, 0) != -EPERM ||
+        do_prctl(PR_SET_MM, PR_SET_MM_ARG_END, map + 4, 0, 0) != -EPERM ||
+        do_prctl(PR_SET_MM, PR_SET_MM_ENV_START, map + 128,
+                 0, 0) != -EPERM ||
+        do_prctl(PR_SET_MM, PR_SET_MM_ENV_END, map + 132,
+                 0, 0) != -EPERM) {
         return 124;
     }
     fd = syscall4(__NR_openat, AT_FDCWD, (slong)cmdline_path, 0, 0);
@@ -781,26 +835,28 @@ static int test_set_mm_privileged(void)
     }
     len = syscall3(__NR_read, fd, (slong)buffer, sizeof(buffer));
     syscall1(__NR_close, fd);
-    if (len != 4 || !bytes_equal(buffer, cmdline, 4)) {
+    if (len != sizeof(cmdline) ||
+        !bytes_equal(buffer, cmdline, sizeof(cmdline))) {
         return 125;
     }
 
     if (do_prctl(PR_SET_MM, PR_SET_MM_AUXV, (slong)second_auxv,
-                 sizeof(second_auxv), 0) ||
+                 sizeof(second_auxv), 0) != -EPERM ||
         do_prctl(PR_GET_AUXV, (slong)auxv_buffer,
-                 sizeof(auxv_buffer), 0, 0) < 0 ||
-        !bytes_equal((char *)auxv_buffer, (char *)second_auxv,
-                     sizeof(second_auxv))) {
+                 sizeof(replacement_auxv), 0, 0) < 0 ||
+        !bytes_equal((char *)auxv_buffer, (char *)replacement_auxv,
+                     sizeof(replacement_auxv))) {
         return 126;
     }
     if (do_prctl(PR_SET_MM, PR_SET_MM_START_STACK,
-                 map + 0x100000, 0, 0) != -EFAULT ||
-        do_prctl(PR_SET_MM, 99, map, 0, 0) != -EINVAL) {
+                 map + 0x100000, 0, 0) != -EPERM ||
+        do_prctl(PR_SET_MM, 99, map, 0, 0) != -EPERM) {
         return 127;
     }
 
     fd = syscall4(__NR_openat, AT_FDCWD, (slong)exe_path, 0, 0);
-    if (fd < 0 || do_prctl(PR_SET_MM, PR_SET_MM_EXE_FILE, fd, 0, 0)) {
+    if (fd < 0 ||
+        do_prctl(PR_SET_MM, PR_SET_MM_EXE_FILE, fd, 0, 0) != -EPERM) {
         return 128;
     }
     syscall1(__NR_close, fd);

--- a/tests/integration/prctl-x86-semantics.c
+++ b/tests/integration/prctl-x86-semantics.c
@@ -25,6 +25,8 @@ typedef long slong;
 #define __NR_personality      135
 #define __NR_prctl            157
 #define __NR_set_tid_address  218
+#define __NR_timer_create     222
+#define __NR_timer_delete     226
 #define __NR_exit_group       231
 #define __NR_openat           257
 #define __NR_readlinkat       267
@@ -35,10 +37,12 @@ typedef long slong;
 
 #define EACCES 13
 #define EBADF   9
+#define EBUSY  16
 #define EFAULT 14
 #define EINVAL 22
 #define ENOMEM 12
 #define ENAMETOOLONG 36
+#define EOPNOTSUPP 95
 #define EPERM   1
 
 #define PROT_READ  1
@@ -69,7 +73,6 @@ typedef long slong;
 #define PR_GET_PDEATHSIG             2
 #define PR_GET_DUMPABLE              3
 #define PR_SET_DUMPABLE              4
-#define PR_GET_UNALIGN               5
 #define PR_SET_KEEPCAPS              8
 #define PR_GET_KEEPCAPS              7
 #define PR_SET_TIMING               14
@@ -114,7 +117,7 @@ typedef long slong;
 #define PR_GET_NO_NEW_PRIVS         39
 #define PR_SET_THP_DISABLE          41
 #define PR_GET_THP_DISABLE          42
-#define PR_SET_FP_MODE              45
+#define PR_THP_DISABLE_EXCEPT_ADVISED 2
 #define PR_SCHED_CORE               62
 #define PR_SCHED_CORE_GET            0
 #define PR_SCHED_CORE_SCOPE_THREAD   0
@@ -124,6 +127,15 @@ typedef long slong;
 #define PR_MDWE_NO_INHERIT           2
 #define PR_SET_MEMORY_MERGE         67
 #define PR_GET_MEMORY_MERGE         68
+#define PR_TIMER_CREATE_RESTORE_IDS 77
+#define PR_TIMER_CREATE_RESTORE_IDS_OFF 0
+#define PR_TIMER_CREATE_RESTORE_IDS_ON  1
+#define PR_TIMER_CREATE_RESTORE_IDS_GET 2
+#define PR_FUTEX_HASH               78
+#define PR_FUTEX_HASH_SET_SLOTS      1
+#define PR_FUTEX_HASH_GET_SLOTS      2
+#define PR_RSEQ_SLICE_EXTENSION     79
+#define PR_RSEQ_SLICE_EXTENSION_GET  1
 #define PR_SET_VMA          0x53564d41
 #define PR_SET_VMA_ANON_NAME         0
 #define PR_GET_AUXV         0x41555856
@@ -357,6 +369,7 @@ static int test_process_controls(void)
     int old_keepcaps;
     int old_subreaper;
     int old_thp;
+    int timer_id;
     int old_merge;
     slong old_slack;
     ulong tid_address = 0;
@@ -438,7 +451,18 @@ static int test_process_controls(void)
     old_thp = do_prctl(PR_GET_THP_DISABLE, 0, 0, 0, 0);
     if (old_thp < 0 || do_prctl(PR_SET_THP_DISABLE, 1, 0, 0, 0) != 0 ||
         do_prctl(PR_GET_THP_DISABLE, 0, 0, 0, 0) != 1 ||
-        do_prctl(PR_SET_THP_DISABLE, old_thp, 0, 0, 0) != 0) {
+        do_prctl(PR_SET_THP_DISABLE, !!old_thp, old_thp & ~1, 0, 0) != 0) {
+        return 50;
+    }
+    ret = do_prctl(PR_SET_THP_DISABLE, 1,
+                   PR_THP_DISABLE_EXCEPT_ADVISED, 0, 0);
+    if (ret == 0) {
+        if (do_prctl(PR_GET_THP_DISABLE, 0, 0, 0, 0) != 3 ||
+            do_prctl(PR_SET_THP_DISABLE, !!old_thp, old_thp & ~1,
+                     0, 0) != 0) {
+            return 50;
+        }
+    } else if (ret != -EINVAL) {
         return 50;
     }
 
@@ -472,21 +496,79 @@ static int test_process_controls(void)
         return 53;
     }
 
-    if (do_prctl(PR_GET_UNALIGN, (slong)&value, 0, 0, 0) != -EINVAL ||
-        do_prctl(PR_SET_FP_MODE, 0, 0, 0, 0) != -EINVAL) {
-        return 54;
-    }
-
     if (do_prctl(PR_SET_NO_NEW_PRIVS, 1, 1, 0, 0) != -EINVAL ||
         do_prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0 ||
         do_prctl(PR_GET_NO_NEW_PRIVS, 0, 0, 0, 0) != 1) {
         return 55;
     }
+
+    timer_id = 123;
+    if (do_prctl(PR_TIMER_CREATE_RESTORE_IDS,
+                 PR_TIMER_CREATE_RESTORE_IDS_GET, 0, 0, 0) != 0 ||
+        do_prctl(PR_TIMER_CREATE_RESTORE_IDS,
+                 PR_TIMER_CREATE_RESTORE_IDS_ON, 0, 0, 0) != 0 ||
+        do_prctl(PR_TIMER_CREATE_RESTORE_IDS,
+                 PR_TIMER_CREATE_RESTORE_IDS_GET, 0, 0, 0) != 1 ||
+        syscall3(__NR_timer_create, 1, 0, (slong)&timer_id) != 0 ||
+        timer_id != 123) {
+        return 56;
+    }
+    timer_id = 123;
+    if (syscall3(__NR_timer_create, 1, 0, (slong)&timer_id) != -EBUSY ||
+        syscall1(__NR_timer_delete, 123) != 0) {
+        return 56;
+    }
+    timer_id = -1;
+    if (syscall3(__NR_timer_create, 1, 0, (slong)&timer_id) != -EINVAL ||
+        do_prctl(PR_TIMER_CREATE_RESTORE_IDS,
+                 PR_TIMER_CREATE_RESTORE_IDS_OFF, 0, 0, 0) != 0) {
+        return 56;
+    }
+    timer_id = -1;
+    if (syscall3(__NR_timer_create, 1, 0, (slong)&timer_id) != 0 ||
+        timer_id < 0 || syscall1(__NR_timer_delete, timer_id) != 0 ||
+        do_prctl(PR_TIMER_CREATE_RESTORE_IDS, 99, 0, 0, 0) != -EINVAL ||
+        do_prctl(PR_TIMER_CREATE_RESTORE_IDS,
+                 PR_TIMER_CREATE_RESTORE_IDS_GET, 1, 0, 0) != -EINVAL) {
+        return 56;
+    }
+
+    if (do_prctl(PR_FUTEX_HASH, PR_FUTEX_HASH_GET_SLOTS,
+                 123, 456, 789) != 0 ||
+        do_prctl(PR_FUTEX_HASH, PR_FUTEX_HASH_SET_SLOTS,
+                 1, 0, 0) != -EINVAL ||
+        do_prctl(PR_FUTEX_HASH, PR_FUTEX_HASH_SET_SLOTS,
+                 3, 0, 0) != -EINVAL ||
+        do_prctl(PR_FUTEX_HASH, PR_FUTEX_HASH_SET_SLOTS,
+                 16, 1, 0) != -EINVAL ||
+        do_prctl(PR_FUTEX_HASH, PR_FUTEX_HASH_SET_SLOTS,
+                 16, 0, 0) != 0 ||
+        do_prctl(PR_FUTEX_HASH, PR_FUTEX_HASH_GET_SLOTS,
+                 0, 0, 0) != 16 ||
+        do_prctl(PR_FUTEX_HASH, PR_FUTEX_HASH_SET_SLOTS,
+                 32, 0, 0) != 0 ||
+        do_prctl(PR_FUTEX_HASH, PR_FUTEX_HASH_GET_SLOTS,
+                 0, 0, 0) != 32 ||
+        do_prctl(PR_FUTEX_HASH, PR_FUTEX_HASH_SET_SLOTS,
+                 0, 0, 0) != 0 ||
+        do_prctl(PR_FUTEX_HASH, PR_FUTEX_HASH_SET_SLOTS,
+                 16, 0, 0) != -EBUSY) {
+        return 57;
+    }
+
+    value = 0x12345678;
+    if (do_prctl(PR_RSEQ_SLICE_EXTENSION,
+                 PR_RSEQ_SLICE_EXTENSION_GET, 0, 0, 0) != -EOPNOTSUPP ||
+        do_prctl(PR_RSEQ_SLICE_EXTENSION,
+                 PR_RSEQ_SLICE_EXTENSION_GET, 0, 1, 0) != -EINVAL) {
+        return 58;
+    }
+
     if (syscall3(__NR_readlink, (slong)exe_path, -1, 0) != -EINVAL ||
         syscall3(__NR_readlink, (slong)exe_path, -1, -1) != -EINVAL ||
         syscall4(__NR_readlinkat, AT_FDCWD, (slong)exe_path, -1, 0) !=
             -EINVAL) {
-        return 56;
+        return 59;
     }
     return 0;
 }
@@ -917,6 +999,10 @@ static int test_fork_state(int no_inherit)
 
     if (do_prctl(PR_SET_MDWE, mdwe, 0, 0, 0) != 0 ||
         do_prctl(PR_SET_TSC, PR_TSC_SIGSEGV, 0, 0, 0) != 0 ||
+        do_prctl(PR_TIMER_CREATE_RESTORE_IDS,
+                 PR_TIMER_CREATE_RESTORE_IDS_ON, 0, 0, 0) != 0 ||
+        do_prctl(PR_FUTEX_HASH, PR_FUTEX_HASH_SET_SLOTS,
+                 32, 0, 0) != 0 ||
         syscall1(__NR_set_tid_address, (slong)&clear_tid) <= 0) {
         return 110;
     }
@@ -930,6 +1016,10 @@ static int test_fork_state(int no_inherit)
         if (do_prctl(PR_GET_MDWE, 0, 0, 0, 0) != expected_child_mdwe ||
             do_prctl(PR_GET_TSC, (slong)&tsc_mode, 0, 0, 0) != 0 ||
             tsc_mode != PR_TSC_SIGSEGV ||
+            do_prctl(PR_TIMER_CREATE_RESTORE_IDS,
+                     PR_TIMER_CREATE_RESTORE_IDS_GET, 0, 0, 0) != 0 ||
+            do_prctl(PR_FUTEX_HASH, PR_FUTEX_HASH_GET_SLOTS,
+                     0, 0, 0) != 0 ||
             do_prctl(PR_GET_TID_ADDRESS, (slong)&tid_address, 0, 0, 0) ||
             tid_address != 0) {
             result = 112;
@@ -942,6 +1032,10 @@ static int test_fork_state(int no_inherit)
     if (do_prctl(PR_GET_MDWE, 0, 0, 0, 0) != mdwe ||
         do_prctl(PR_GET_TSC, (slong)&tsc_mode, 0, 0, 0) != 0 ||
         tsc_mode != PR_TSC_SIGSEGV ||
+        do_prctl(PR_TIMER_CREATE_RESTORE_IDS,
+                 PR_TIMER_CREATE_RESTORE_IDS_GET, 0, 0, 0) != 1 ||
+        do_prctl(PR_FUTEX_HASH, PR_FUTEX_HASH_GET_SLOTS,
+                 0, 0, 0) != 32 ||
         do_prctl(PR_GET_TID_ADDRESS, (slong)&tid_address, 0, 0, 0) ||
         tid_address != (ulong)&clear_tid) {
         return 114;

--- a/tests/integration/prctl-x86-semantics.c
+++ b/tests/integration/prctl-x86-semantics.c
@@ -13,6 +13,7 @@ typedef long slong;
 #define __NR_mmap               9
 #define __NR_mprotect          10
 #define __NR_munmap            11
+#define __NR_brk               12
 #define __NR_shmget            29
 #define __NR_shmat             30
 #define __NR_shmctl            31
@@ -71,6 +72,22 @@ typedef long slong;
 #define PR_TASK_PERF_EVENTS_ENABLE  32
 #define PR_MCE_KILL                 33
 #define PR_MCE_KILL_GET             34
+#define PR_SET_MM                   35
+#define PR_SET_MM_START_CODE         1
+#define PR_SET_MM_END_CODE           2
+#define PR_SET_MM_START_DATA         3
+#define PR_SET_MM_END_DATA           4
+#define PR_SET_MM_START_STACK        5
+#define PR_SET_MM_START_BRK          6
+#define PR_SET_MM_BRK                7
+#define PR_SET_MM_ARG_START          8
+#define PR_SET_MM_ARG_END            9
+#define PR_SET_MM_ENV_START         10
+#define PR_SET_MM_ENV_END           11
+#define PR_SET_MM_AUXV              12
+#define PR_SET_MM_EXE_FILE          13
+#define PR_SET_MM_MAP               14
+#define PR_SET_MM_MAP_SIZE          15
 #define PR_MCE_KILL_CLEAR            0
 #define PR_MCE_KILL_SET              1
 #define PR_MCE_KILL_DEFAULT          2
@@ -95,8 +112,26 @@ typedef long slong;
 #define PR_GET_MEMORY_MERGE         68
 #define PR_SET_VMA          0x53564d41
 #define PR_SET_VMA_ANON_NAME         0
+#define PR_GET_AUXV         0x41555856
 
 #define CAP_CHOWN 0
+
+struct prctl_mm_map {
+    ulong start_code;
+    ulong end_code;
+    ulong start_data;
+    ulong end_data;
+    ulong start_brk;
+    ulong brk;
+    ulong start_stack;
+    ulong arg_start;
+    ulong arg_end;
+    ulong env_start;
+    ulong env_end;
+    ulong auxv;
+    unsigned int auxv_size;
+    unsigned int exe_fd;
+};
 
 static inline slong syscall1(slong nr, slong a1)
 {
@@ -651,6 +686,132 @@ static int test_fork_state(int no_inherit)
     return 0;
 }
 
+static int test_set_mm_privileged(void)
+{
+    static const char cmdline[] = "lat-prctl-mm";
+    static const char cmdline_path[] = "/proc/self/cmdline";
+    static const char auxv_path[] = "/proc/self/auxv";
+    static const char exe_path[] = "/proc/self/exe";
+    ulong replacement_auxv[4] = { 123, 456, 0, 0 };
+    ulong second_auxv[4] = { 789, 321, 0, 0 };
+    ulong auxv_buffer[4] = { 0 };
+    struct prctl_mm_map mm;
+    char buffer[64];
+    slong map;
+    slong fd;
+    slong len;
+    ulong i;
+
+    map = do_mmap(0, 16384, PROT_READ | PROT_WRITE,
+                  MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (map < 0) {
+        return 120;
+    }
+    for (i = 0; i < sizeof(cmdline); i++) {
+        ((char *)map)[i] = cmdline[i];
+    }
+    for (i = 0; i < 4; i++) {
+        ((char *)map)[128 + i] = "E=1\0"[i];
+    }
+    mm.start_code = map;
+    mm.end_code = map + 64;
+    mm.start_data = map + 128;
+    mm.end_data = map + 256;
+    mm.start_brk = map + 4096;
+    mm.brk = map + 8192;
+    mm.start_stack = map + 12288;
+    mm.arg_start = map;
+    mm.arg_end = map + sizeof(cmdline);
+    mm.env_start = map + 128;
+    mm.env_end = map + 132;
+    mm.auxv = (ulong)replacement_auxv;
+    mm.auxv_size = sizeof(replacement_auxv);
+    mm.exe_fd = ~0U;
+
+    if (do_prctl(PR_SET_MM, PR_SET_MM_MAP, (slong)&mm, sizeof(mm), 0)) {
+        return 121;
+    }
+    fd = syscall4(__NR_openat, AT_FDCWD, (slong)cmdline_path, 0, 0);
+    if (fd < 0) {
+        return 122;
+    }
+    len = syscall3(__NR_read, fd, (slong)buffer, sizeof(buffer));
+    syscall1(__NR_close, fd);
+    if (len != sizeof(cmdline) ||
+        !bytes_equal(buffer, cmdline, sizeof(cmdline)) ||
+        syscall1(__NR_brk, 0) != map + 8192) {
+        return 122;
+    }
+
+    if (do_prctl(PR_GET_AUXV, (slong)auxv_buffer,
+                 sizeof(auxv_buffer), 0, 0) < 0 ||
+        !bytes_equal((char *)auxv_buffer, (char *)replacement_auxv,
+                     sizeof(replacement_auxv))) {
+        return 123;
+    }
+    fd = syscall4(__NR_openat, AT_FDCWD, (slong)auxv_path, 0, 0);
+    if (fd < 0) {
+        return 123;
+    }
+    len = syscall3(__NR_read, fd, (slong)auxv_buffer,
+                   sizeof(auxv_buffer));
+    syscall1(__NR_close, fd);
+    if (len != sizeof(auxv_buffer) ||
+        !bytes_equal((char *)auxv_buffer, (char *)replacement_auxv,
+                     sizeof(replacement_auxv))) {
+        return 123;
+    }
+
+    if (do_prctl(PR_SET_MM, PR_SET_MM_START_CODE, map, 0, 0) ||
+        do_prctl(PR_SET_MM, PR_SET_MM_END_CODE, map + 64, 0, 0) ||
+        do_prctl(PR_SET_MM, PR_SET_MM_START_DATA, map + 128, 0, 0) ||
+        do_prctl(PR_SET_MM, PR_SET_MM_END_DATA, map + 256, 0, 0) ||
+        do_prctl(PR_SET_MM, PR_SET_MM_START_BRK, map + 4096, 0, 0) ||
+        do_prctl(PR_SET_MM, PR_SET_MM_BRK, map + 8192, 0, 0) ||
+        do_prctl(PR_SET_MM, PR_SET_MM_START_STACK, map + 12288, 0, 0) ||
+        do_prctl(PR_SET_MM, PR_SET_MM_ARG_START, map, 0, 0) ||
+        do_prctl(PR_SET_MM, PR_SET_MM_ARG_END, map + 4, 0, 0) ||
+        do_prctl(PR_SET_MM, PR_SET_MM_ENV_START, map + 128, 0, 0) ||
+        do_prctl(PR_SET_MM, PR_SET_MM_ENV_END, map + 132, 0, 0)) {
+        return 124;
+    }
+    fd = syscall4(__NR_openat, AT_FDCWD, (slong)cmdline_path, 0, 0);
+    if (fd < 0) {
+        return 125;
+    }
+    len = syscall3(__NR_read, fd, (slong)buffer, sizeof(buffer));
+    syscall1(__NR_close, fd);
+    if (len != 4 || !bytes_equal(buffer, cmdline, 4)) {
+        return 125;
+    }
+
+    if (do_prctl(PR_SET_MM, PR_SET_MM_AUXV, (slong)second_auxv,
+                 sizeof(second_auxv), 0) ||
+        do_prctl(PR_GET_AUXV, (slong)auxv_buffer,
+                 sizeof(auxv_buffer), 0, 0) < 0 ||
+        !bytes_equal((char *)auxv_buffer, (char *)second_auxv,
+                     sizeof(second_auxv))) {
+        return 126;
+    }
+    if (do_prctl(PR_SET_MM, PR_SET_MM_START_STACK,
+                 map + 0x100000, 0, 0) != -EFAULT ||
+        do_prctl(PR_SET_MM, 99, map, 0, 0) != -EINVAL) {
+        return 127;
+    }
+
+    fd = syscall4(__NR_openat, AT_FDCWD, (slong)exe_path, 0, 0);
+    if (fd < 0 || do_prctl(PR_SET_MM, PR_SET_MM_EXE_FILE, fd, 0, 0)) {
+        return 128;
+    }
+    syscall1(__NR_close, fd);
+    fd = syscall4(__NR_openat, AT_FDCWD, (slong)exe_path, 0, 0);
+    if (fd < 0) {
+        return 128;
+    }
+    syscall1(__NR_close, fd);
+    return 0;
+}
+
 int test_main(ulong *stack)
 {
     ulong argc = stack[0];
@@ -681,6 +842,9 @@ int test_main(ulong *stack)
     }
     if (mode == 'i') {
         return test_fork_state(0);
+    }
+    if (mode == 'x') {
+        return test_set_mm_privileged();
     }
     return 101;
 }

--- a/tests/integration/prctl-x86-semantics.c
+++ b/tests/integration/prctl-x86-semantics.c
@@ -27,6 +27,7 @@ typedef long slong;
 #define __NR_set_tid_address  218
 #define __NR_exit_group       231
 #define __NR_openat           257
+#define __NR_execveat         322
 #define __NR_readlink          89
 #define __NR_rename            82
 #define __NR_unlink            87
@@ -52,6 +53,7 @@ typedef long slong;
 #define MREMAP_DONTUNMAP 4
 
 #define AT_FDCWD (-100)
+#define AT_EMPTY_PATH 0x1000
 
 #define IPC_PRIVATE 0
 #define IPC_CREAT   01000
@@ -975,8 +977,8 @@ static int test_set_mm_privileged(const char *self_path)
     }
     len = syscall3(__NR_read, fd, (slong)buffer, sizeof(buffer));
     syscall1(__NR_close, fd);
-    if (len != sizeof(cmdline) ||
-        !bytes_equal(buffer, cmdline, sizeof(cmdline))) {
+    if (len != sizeof(proctitle) ||
+        !bytes_equal(buffer, proctitle, sizeof(proctitle))) {
         return 125;
     }
 
@@ -1060,8 +1062,9 @@ static int test_set_mm_privileged(const char *self_path)
     return 0;
 }
 
-static int test_native_exec_env(const char *helper_path)
+static int test_native_exec_env(const char *helper_path, int at_empty_path)
 {
+    static char empty_path[] = "";
     static char mdwe_env[] = "_LATX_GUEST_MDWE=forged";
     static char tsc_env[] = "_LATX_GUEST_TSC=forged";
     static char keep_env[] = "KEEP=1";
@@ -1073,7 +1076,18 @@ static int test_native_exec_env(const char *helper_path)
         do_prctl(PR_SET_TSC, PR_TSC_SIGSEGV, 0, 0, 0)) {
         return 130;
     }
-    syscall3(__NR_execve, (slong)helper_path, (slong)argv, (slong)envp);
+    if (at_empty_path) {
+        slong fd = syscall4(__NR_openat, AT_FDCWD, (slong)helper_path, 0, 0);
+
+        if (fd < 0) {
+            return 131;
+        }
+        syscall5(__NR_execveat, fd, (slong)empty_path, (slong)argv,
+                 (slong)envp, AT_EMPTY_PATH);
+    } else {
+        syscall3(__NR_execve, (slong)helper_path, (slong)argv,
+                 (slong)envp);
+    }
     return 131;
 }
 
@@ -1112,7 +1126,10 @@ int test_main(ulong *stack)
         return test_set_mm_privileged(argc == 3 ? argv[2] : 0);
     }
     if (mode == 'e') {
-        return test_native_exec_env(argc == 3 ? argv[2] : 0);
+        return test_native_exec_env(argc == 3 ? argv[2] : 0, 0);
+    }
+    if (mode == 'a') {
+        return test_native_exec_env(argc == 3 ? argv[2] : 0, 1);
     }
     return 101;
 }

--- a/tests/integration/prctl-x86-semantics.c
+++ b/tests/integration/prctl-x86-semantics.c
@@ -752,6 +752,36 @@ static int test_vma_name(void)
     syscall2(__NR_munmap, shared_map, 16384);
     syscall2(__NR_munmap, remap_copy, 16384);
 
+    /* A partial-host-page fallback must not privatize a shared mapping. */
+    shared_map = do_mmap(0, 16384, PROT_READ | PROT_WRITE,
+                         MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+    remap_copy = syscall5(__NR_mremap, shared_map, 0, 16384,
+                          MREMAP_MAYMOVE, 0);
+    remap_target = do_mmap(0, 16384, PROT_READ | PROT_WRITE,
+                           MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (shared_map < 0 || remap_copy < 0 || remap_target < 0 ||
+        syscall2(__NR_munmap, remap_target, 16384) != 0) {
+        return 69;
+    }
+    *(ulong *)remap_copy = 0x1020304050607080UL;
+    remap_target = syscall5(__NR_mremap, shared_map, 8193, 8193,
+                            MREMAP_MAYMOVE | MREMAP_FIXED, remap_target);
+    if (remap_target >= 0) {
+        *(ulong *)remap_copy = 0x8070605040302010UL;
+        if (*(ulong *)remap_target != 0x8070605040302010UL) {
+            return 69;
+        }
+        *(ulong *)remap_target = 0x1234432112344321UL;
+        if (*(ulong *)remap_copy != 0x1234432112344321UL) {
+            return 69;
+        }
+        syscall2(__NR_munmap, remap_target, 12288);
+    } else if (remap_target != -EINVAL && remap_target != -EFAULT) {
+        return 69;
+    }
+    syscall2(__NR_munmap, shared_map, 16384);
+    syscall2(__NR_munmap, remap_copy, 16384);
+
     remap_source = do_mmap(0, 16384, PROT_READ | PROT_WRITE,
                            MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
     if (remap_source < 0 ||

--- a/tests/integration/prctl-x86-semantics.c
+++ b/tests/integration/prctl-x86-semantics.c
@@ -8,6 +8,7 @@ typedef unsigned long ulong;
 typedef long slong;
 
 #define __NR_read               0
+#define __NR_write              1
 #define __NR_close              3
 #define __NR_mmap               9
 #define __NR_mprotect          10
@@ -444,6 +445,9 @@ static int test_vma_name(void)
         !named_range(buffer, len, marker, sizeof(marker) - 1,
                      &named_start, &named_end) ||
         named_start != (ulong)map + 4096 || named_end != (ulong)map + 8192) {
+        if (len > 0) {
+            syscall3(__NR_write, 2, (slong)buffer, len);
+        }
         return 63;
     }
     if (do_prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, map + 4096, 4096, 0)) {
@@ -490,6 +494,9 @@ static int test_vma_name(void)
                      sizeof(shared_marker) - 1, &named_start, &named_end) ||
         named_start != (ulong)shared_map + 4096 ||
         named_end != (ulong)shared_map + 8192) {
+        if (len > 0) {
+            syscall3(__NR_write, 2, (slong)buffer, len);
+        }
         return 68;
     }
     syscall2(__NR_munmap, shared_map, 16384);

--- a/tests/integration/prctl-x86-semantics.c
+++ b/tests/integration/prctl-x86-semantics.c
@@ -4,8 +4,8 @@
  * boundaries.  Each invocation runs one irreversible process-state case.
  */
 
-typedef unsigned long ulong;
-typedef long slong;
+typedef unsigned long guest_ulong_t;
+typedef long guest_slong_t;
 
 #define __NR_read               0
 #define __NR_write              1
@@ -19,9 +19,11 @@ typedef long slong;
 #define __NR_shmat             30
 #define __NR_shmctl            31
 #define __NR_shmdt             67
+#define __NR_ftruncate         77
 #define __NR_fork              57
 #define __NR_wait4             61
 #define __NR_mremap            25
+#define __NR_msync             26
 #define __NR_personality      135
 #define __NR_prctl            157
 #define __NR_set_tid_address  218
@@ -29,6 +31,7 @@ typedef long slong;
 #define __NR_timer_delete     226
 #define __NR_exit_group       231
 #define __NR_openat           257
+#define __NR_memfd_create     319
 #define __NR_readlinkat       267
 #define __NR_execveat         322
 #define __NR_readlink          89
@@ -57,6 +60,7 @@ typedef long slong;
 #define MREMAP_MAYMOVE   1
 #define MREMAP_FIXED     2
 #define MREMAP_DONTUNMAP 4
+#define MS_SYNC           4
 
 #define AT_FDCWD (-100)
 #define AT_EMPTY_PATH 0x1000
@@ -136,41 +140,48 @@ typedef long slong;
 #define PR_FUTEX_HASH_GET_SLOTS      2
 #define PR_RSEQ_SLICE_EXTENSION     79
 #define PR_RSEQ_SLICE_EXTENSION_GET  1
+#define PR_RSEQ_SLICE_EXTENSION_SET  2
+#define PR_RSEQ_SLICE_EXT_ENABLE      1
+#define PR_GET_CFI                   80
+#define PR_SET_CFI                   81
+#define PR_CFI_BRANCH_LANDING_PADS    0
+#define PR_CFI_ENABLE                 1
 #define PR_SET_VMA          0x53564d41
 #define PR_SET_VMA_ANON_NAME         0
 #define PR_GET_AUXV         0x41555856
 
 #define CAP_CHOWN 0
 
-struct prctl_mm_map {
-    ulong start_code;
-    ulong end_code;
-    ulong start_data;
-    ulong end_data;
-    ulong start_brk;
-    ulong brk;
-    ulong start_stack;
-    ulong arg_start;
-    ulong arg_end;
-    ulong env_start;
-    ulong env_end;
-    ulong auxv;
+typedef struct PrctlMmMap {
+    guest_ulong_t start_code;
+    guest_ulong_t end_code;
+    guest_ulong_t start_data;
+    guest_ulong_t end_data;
+    guest_ulong_t start_brk;
+    guest_ulong_t brk;
+    guest_ulong_t start_stack;
+    guest_ulong_t arg_start;
+    guest_ulong_t arg_end;
+    guest_ulong_t env_start;
+    guest_ulong_t env_end;
+    guest_ulong_t auxv;
     unsigned int auxv_size;
     unsigned int exe_fd;
-};
+} PrctlMmMap;
 
-static inline slong syscall1(slong nr, slong a1)
+static inline guest_slong_t syscall1(guest_slong_t nr, guest_slong_t a1)
 {
-    slong ret;
+    guest_slong_t ret;
 
     __asm__ volatile("syscall" : "=a"(ret) : "a"(nr), "D"(a1)
                      : "rcx", "r11", "memory");
     return ret;
 }
 
-static inline slong syscall2(slong nr, slong a1, slong a2)
+static inline guest_slong_t syscall2(guest_slong_t nr, guest_slong_t a1,
+                                     guest_slong_t a2)
 {
-    slong ret;
+    guest_slong_t ret;
 
     __asm__ volatile("syscall" : "=a"(ret)
                      : "a"(nr), "D"(a1), "S"(a2)
@@ -178,9 +189,10 @@ static inline slong syscall2(slong nr, slong a1, slong a2)
     return ret;
 }
 
-static inline slong syscall3(slong nr, slong a1, slong a2, slong a3)
+static inline guest_slong_t syscall3(guest_slong_t nr, guest_slong_t a1,
+                                     guest_slong_t a2, guest_slong_t a3)
 {
-    slong ret;
+    guest_slong_t ret;
 
     __asm__ volatile("syscall" : "=a"(ret)
                      : "a"(nr), "D"(a1), "S"(a2), "d"(a3)
@@ -188,11 +200,12 @@ static inline slong syscall3(slong nr, slong a1, slong a2, slong a3)
     return ret;
 }
 
-static inline slong syscall4(slong nr, slong a1, slong a2, slong a3,
-                             slong a4)
+static inline guest_slong_t syscall4(guest_slong_t nr, guest_slong_t a1,
+                                     guest_slong_t a2, guest_slong_t a3,
+                                     guest_slong_t a4)
 {
-    register slong r10 __asm__("r10") = a4;
-    slong ret;
+    register guest_slong_t r10 __asm__("r10") = a4;
+    guest_slong_t ret;
 
     __asm__ volatile("syscall" : "=a"(ret)
                      : "a"(nr), "D"(a1), "S"(a2), "d"(a3), "r"(r10)
@@ -200,12 +213,13 @@ static inline slong syscall4(slong nr, slong a1, slong a2, slong a3,
     return ret;
 }
 
-static inline slong syscall5(slong nr, slong a1, slong a2, slong a3,
-                             slong a4, slong a5)
+static inline guest_slong_t syscall5(guest_slong_t nr, guest_slong_t a1,
+                                     guest_slong_t a2, guest_slong_t a3,
+                                     guest_slong_t a4, guest_slong_t a5)
 {
-    register slong r10 __asm__("r10") = a4;
-    register slong r8 __asm__("r8") = a5;
-    slong ret;
+    register guest_slong_t r10 __asm__("r10") = a4;
+    register guest_slong_t r8 __asm__("r8") = a5;
+    guest_slong_t ret;
 
     __asm__ volatile("syscall" : "=a"(ret)
                      : "a"(nr), "D"(a1), "S"(a2), "d"(a3), "r"(r10),
@@ -214,13 +228,15 @@ static inline slong syscall5(slong nr, slong a1, slong a2, slong a3,
     return ret;
 }
 
-static inline slong syscall6(slong nr, slong a1, slong a2, slong a3,
-                             slong a4, slong a5, slong a6)
+static inline guest_slong_t syscall6(guest_slong_t nr, guest_slong_t a1,
+                                     guest_slong_t a2, guest_slong_t a3,
+                                     guest_slong_t a4, guest_slong_t a5,
+                                     guest_slong_t a6)
 {
-    register slong r10 __asm__("r10") = a4;
-    register slong r8 __asm__("r8") = a5;
-    register slong r9 __asm__("r9") = a6;
-    slong ret;
+    register guest_slong_t r10 __asm__("r10") = a4;
+    register guest_slong_t r8 __asm__("r8") = a5;
+    register guest_slong_t r9 __asm__("r9") = a6;
+    guest_slong_t ret;
 
     __asm__ volatile("syscall" : "=a"(ret)
                      : "a"(nr), "D"(a1), "S"(a2), "d"(a3), "r"(r10),
@@ -229,21 +245,24 @@ static inline slong syscall6(slong nr, slong a1, slong a2, slong a3,
     return ret;
 }
 
-static slong do_prctl(slong option, slong arg2, slong arg3, slong arg4,
-                      slong arg5)
+static guest_slong_t do_prctl(guest_slong_t option, guest_slong_t arg2,
+                              guest_slong_t arg3, guest_slong_t arg4,
+                              guest_slong_t arg5)
 {
     return syscall5(__NR_prctl, option, arg2, arg3, arg4, arg5);
 }
 
-static slong do_mmap(void *addr, ulong len, slong prot, slong flags,
-                     slong fd, ulong offset)
+static guest_slong_t do_mmap(void *addr, guest_ulong_t len,
+                             guest_slong_t prot, guest_slong_t flags,
+                             guest_slong_t fd, guest_ulong_t offset)
 {
-    return syscall6(__NR_mmap, (slong)addr, len, prot, flags, fd, offset);
+    return syscall6(__NR_mmap, (guest_slong_t)addr, len, prot, flags, fd,
+                    offset);
 }
 
-static int bytes_equal(const char *a, const char *b, ulong len)
+static int bytes_equal(const char *a, const char *b, guest_ulong_t len)
 {
-    ulong i;
+    guest_ulong_t i;
 
     for (i = 0; i < len; i++) {
         if (a[i] != b[i]) {
@@ -253,9 +272,9 @@ static int bytes_equal(const char *a, const char *b, ulong len)
     return 1;
 }
 
-static ulong string_length(const char *value)
+static guest_ulong_t string_length(const char *value)
 {
-    ulong len = 0;
+    guest_ulong_t len = 0;
 
     while (value[len]) {
         len++;
@@ -263,10 +282,10 @@ static ulong string_length(const char *value)
     return len;
 }
 
-static int contains(const char *buf, ulong len, const char *needle,
-                    ulong needle_len)
+static int contains(const char *buf, guest_ulong_t len, const char *needle,
+                    guest_ulong_t needle_len)
 {
-    ulong i;
+    guest_ulong_t i;
 
     if (needle_len > len) {
         return 0;
@@ -290,12 +309,13 @@ static int hex_value(char ch)
     return -1;
 }
 
-static int named_range(const char *buf, ulong len, const char *marker,
-                       ulong marker_len, ulong *start, ulong *end)
+static int named_range(const char *buf, guest_ulong_t len, const char *marker,
+                       guest_ulong_t marker_len, guest_ulong_t *start,
+                       guest_ulong_t *end)
 {
-    ulong marker_pos;
-    ulong line;
-    ulong pos;
+    guest_ulong_t marker_pos;
+    guest_ulong_t line;
+    guest_ulong_t pos;
     int digit;
 
     for (marker_pos = 0; marker_pos + marker_len <= len; marker_pos++) {
@@ -332,31 +352,107 @@ static int named_range(const char *buf, ulong len, const char *marker,
     return pos < marker_pos && buf[pos] == ' ';
 }
 
-static slong read_maps(char *buffer, ulong size)
+static guest_slong_t read_maps(char *buffer, guest_ulong_t size)
 {
     static const char maps_path[] = "/proc/self/maps";
-    slong fd = syscall4(__NR_openat, AT_FDCWD, (slong)maps_path, 0, 0);
-    slong len;
+    guest_slong_t fd = syscall4(__NR_openat, AT_FDCWD,
+                                (guest_slong_t)maps_path, 0, 0);
+    guest_slong_t len;
 
     if (fd < 0) {
         return fd;
     }
-    len = syscall3(__NR_read, fd, (slong)buffer, size);
+    len = syscall3(__NR_read, fd, (guest_slong_t)buffer, size);
     syscall1(__NR_close, fd);
     return len;
 }
 
-static slong read_file(const char *path, char *buffer, ulong size)
+static guest_slong_t read_file(const char *path, char *buffer,
+                               guest_ulong_t size)
 {
-    slong fd = syscall4(__NR_openat, AT_FDCWD, (slong)path, 0, 0);
-    slong len;
+    guest_slong_t fd = syscall4(__NR_openat, AT_FDCWD,
+                                (guest_slong_t)path, 0, 0);
+    guest_slong_t len;
 
     if (fd < 0) {
         return fd;
     }
-    len = syscall3(__NR_read, fd, (slong)buffer, size);
+    len = syscall3(__NR_read, fd, (guest_slong_t)buffer, size);
     syscall1(__NR_close, fd);
     return len;
+}
+
+static int test_shared_mremap_4k_case(guest_ulong_t old_request,
+                                      guest_ulong_t new_request)
+{
+    guest_ulong_t old_size = (old_request + 4095) & -4096UL;
+    guest_ulong_t new_size = (new_request + 4095) & -4096UL;
+    guest_ulong_t common_size = old_size < new_size ? old_size : new_size;
+    guest_slong_t source;
+    guest_slong_t old_alias;
+    guest_slong_t target;
+    guest_slong_t new_alias;
+    guest_ulong_t offset;
+
+    source = do_mmap(0, old_size, PROT_READ | PROT_WRITE,
+                     MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+    if (source < 0) {
+        return 1;
+    }
+    old_alias = syscall5(__NR_mremap, source, 0, old_size,
+                         MREMAP_MAYMOVE, 0);
+    target = do_mmap(0, 16384, PROT_READ | PROT_WRITE,
+                     MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (old_alias < 0 || target < 0) {
+        return 1;
+    }
+    for (offset = 0; offset < old_size; offset += 4096) {
+        *(guest_ulong_t *)(source + offset) =
+            0x1020304050607000UL + offset;
+    }
+    if (new_size < 16384) {
+        *(guest_ulong_t *)(target + new_size) = 0xaabbccddeeff0011UL;
+    }
+    if (syscall5(__NR_mremap, source, old_request, new_request,
+                 MREMAP_MAYMOVE | MREMAP_FIXED, target) != target ||
+        syscall3(__NR_mprotect, source, old_size, PROT_READ) != -ENOMEM) {
+        return 1;
+    }
+    for (offset = 0; offset < common_size; offset += 4096) {
+        guest_ulong_t expected = 0x1020304050607000UL + offset;
+
+        if (*(guest_ulong_t *)(target + offset) != expected ||
+            *(guest_ulong_t *)(old_alias + offset) != expected) {
+            return 1;
+        }
+    }
+    if (new_size > old_size &&
+        *(guest_ulong_t *)(target + old_size) != 0) {
+        return 1;
+    }
+    if (new_size < 16384 &&
+        *(guest_ulong_t *)(target + new_size) != 0xaabbccddeeff0011UL) {
+        return 1;
+    }
+    *(guest_ulong_t *)target = 0x8877665544332211UL;
+    if (*(guest_ulong_t *)old_alias != 0x8877665544332211UL) {
+        return 1;
+    }
+    new_alias = syscall5(__NR_mremap, target, 0, new_size,
+                         MREMAP_MAYMOVE, 0);
+    if (new_alias < 0) {
+        return 1;
+    }
+    *(guest_ulong_t *)(new_alias + new_size - 4096) =
+        0xfedcba9876543210UL;
+    if (*(guest_ulong_t *)(target + new_size - 4096) !=
+            0xfedcba9876543210UL) {
+        return 1;
+    }
+    syscall2(__NR_munmap, old_alias, old_size);
+    syscall2(__NR_munmap, new_alias, new_size);
+    syscall2(__NR_munmap, target, 16384);
+    return 0;
 }
 
 static int test_process_controls(void)
@@ -370,24 +466,23 @@ static int test_process_controls(void)
     int old_subreaper;
     int old_thp;
     int timer_id;
-    int old_merge;
-    slong old_slack;
-    ulong tid_address = 0;
-    ulong clear_tid = 0;
-    ulong cookie = 0;
-    slong ret;
+    guest_slong_t old_slack;
+    guest_ulong_t tid_address = 0;
+    guest_ulong_t clear_tid = 0;
+    guest_ulong_t cookie = 0;
+    guest_slong_t ret;
 
     if (do_prctl(0x7fffffff, 0, 0, 0, 0) != -EINVAL) {
         return 40;
     }
     if (do_prctl(PR_GET_PDEATHSIG, 0, 0, 0, 0) != -EFAULT ||
         do_prctl(PR_SET_PDEATHSIG, 10, 0, 0, 0) != 0 ||
-        do_prctl(PR_GET_PDEATHSIG, (slong)&value, 0, 0, 0) != 0 ||
+        do_prctl(PR_GET_PDEATHSIG, (guest_slong_t)&value, 0, 0, 0) != 0 ||
         value != 10 || do_prctl(PR_SET_PDEATHSIG, 0, 0, 0, 0) != 0) {
         return 41;
     }
-    if (do_prctl(PR_SET_NAME, (slong)set_name, 0, 0, 0) != 0 ||
-        do_prctl(PR_GET_NAME, (slong)get_name, 0, 0, 0) != 0 ||
+    if (do_prctl(PR_SET_NAME, (guest_slong_t)set_name, 0, 0, 0) != 0 ||
+        do_prctl(PR_GET_NAME, (guest_slong_t)get_name, 0, 0, 0) != 0 ||
         !bytes_equal(set_name, get_name, sizeof(set_name))) {
         return 42;
     }
@@ -430,21 +525,23 @@ static int test_process_controls(void)
     }
 
     old_subreaper = -1;
-    if (do_prctl(PR_GET_CHILD_SUBREAPER, (slong)&old_subreaper, 0, 0, 0) ||
+    if (do_prctl(PR_GET_CHILD_SUBREAPER,
+                 (guest_slong_t)&old_subreaper, 0, 0, 0) ||
         old_subreaper < 0 ||
         do_prctl(PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0) != 0) {
         return 48;
     }
     value = -1;
-    if (do_prctl(PR_GET_CHILD_SUBREAPER, (slong)&value, 0, 0, 0) != 0 ||
+    if (do_prctl(PR_GET_CHILD_SUBREAPER, (guest_slong_t)&value, 0, 0, 0) != 0 ||
         value != 1 ||
         do_prctl(PR_SET_CHILD_SUBREAPER, old_subreaper, 0, 0, 0) != 0) {
         return 48;
     }
 
-    if (syscall1(__NR_set_tid_address, (slong)&clear_tid) <= 0 ||
-        do_prctl(PR_GET_TID_ADDRESS, (slong)&tid_address, 0, 0, 0) != 0 ||
-        tid_address != (ulong)&clear_tid) {
+    if (syscall1(__NR_set_tid_address, (guest_slong_t)&clear_tid) <= 0 ||
+        do_prctl(PR_GET_TID_ADDRESS,
+                 (guest_slong_t)&tid_address, 0, 0, 0) != 0 ||
+        tid_address != (guest_ulong_t)&clear_tid) {
         return 49;
     }
 
@@ -466,23 +563,13 @@ static int test_process_controls(void)
         return 50;
     }
 
-    old_merge = do_prctl(PR_GET_MEMORY_MERGE, 0, 0, 0, 0);
-    if (old_merge != -EINVAL) {
-        int next_merge;
-
-        if (old_merge != 0 && old_merge != 1) {
-            return 51;
-        }
-        next_merge = !old_merge;
-        if (do_prctl(PR_SET_MEMORY_MERGE, next_merge, 0, 0, 0) != 0 ||
-            do_prctl(PR_GET_MEMORY_MERGE, 0, 0, 0, 0) != next_merge ||
-            do_prctl(PR_SET_MEMORY_MERGE, old_merge, 0, 0, 0) != 0) {
-            return 51;
-        }
+    if (do_prctl(PR_GET_MEMORY_MERGE, 0, 0, 0, 0) != -EINVAL ||
+        do_prctl(PR_SET_MEMORY_MERGE, 1, 0, 0, 0) != -EINVAL) {
+        return 51;
     }
 
     ret = do_prctl(PR_SCHED_CORE, PR_SCHED_CORE_GET, 0,
-                   PR_SCHED_CORE_SCOPE_THREAD, (slong)&cookie);
+                   PR_SCHED_CORE_SCOPE_THREAD, (guest_slong_t)&cookie);
     if (ret != 0 && ret != -EINVAL) {
         return 52;
     }
@@ -509,23 +596,24 @@ static int test_process_controls(void)
                  PR_TIMER_CREATE_RESTORE_IDS_ON, 0, 0, 0) != 0 ||
         do_prctl(PR_TIMER_CREATE_RESTORE_IDS,
                  PR_TIMER_CREATE_RESTORE_IDS_GET, 0, 0, 0) != 1 ||
-        syscall3(__NR_timer_create, 1, 0, (slong)&timer_id) != 0 ||
+        syscall3(__NR_timer_create, 1, 0, (guest_slong_t)&timer_id) != 0 ||
         timer_id != 123) {
         return 56;
     }
     timer_id = 123;
-    if (syscall3(__NR_timer_create, 1, 0, (slong)&timer_id) != -EBUSY ||
+    if (syscall3(__NR_timer_create, 1, 0, (guest_slong_t)&timer_id) != -EBUSY ||
         syscall1(__NR_timer_delete, 123) != 0) {
         return 56;
     }
     timer_id = -1;
-    if (syscall3(__NR_timer_create, 1, 0, (slong)&timer_id) != -EINVAL ||
+    if (syscall3(__NR_timer_create, 1, 0,
+                 (guest_slong_t)&timer_id) != -EINVAL ||
         do_prctl(PR_TIMER_CREATE_RESTORE_IDS,
                  PR_TIMER_CREATE_RESTORE_IDS_OFF, 0, 0, 0) != 0) {
         return 56;
     }
     timer_id = -1;
-    if (syscall3(__NR_timer_create, 1, 0, (slong)&timer_id) != 0 ||
+    if (syscall3(__NR_timer_create, 1, 0, (guest_slong_t)&timer_id) != 0 ||
         timer_id < 0 || syscall1(__NR_timer_delete, timer_id) != 0 ||
         do_prctl(PR_TIMER_CREATE_RESTORE_IDS, 99, 0, 0, 0) != -EINVAL ||
         do_prctl(PR_TIMER_CREATE_RESTORE_IDS,
@@ -560,20 +648,27 @@ static int test_process_controls(void)
     if (do_prctl(PR_RSEQ_SLICE_EXTENSION,
                  PR_RSEQ_SLICE_EXTENSION_GET, 0, 0, 0) != -EOPNOTSUPP ||
         do_prctl(PR_RSEQ_SLICE_EXTENSION,
-                 PR_RSEQ_SLICE_EXTENSION_GET, 0, 1, 0) != -EINVAL) {
+                 PR_RSEQ_SLICE_EXTENSION_GET, 0, 1, 0) != -EINVAL ||
+        do_prctl(PR_RSEQ_SLICE_EXTENSION,
+                 PR_RSEQ_SLICE_EXTENSION_SET,
+                 PR_RSEQ_SLICE_EXT_ENABLE, 0, 0) != -EOPNOTSUPP ||
+        do_prctl(PR_GET_CFI, PR_CFI_BRANCH_LANDING_PADS,
+                 (guest_slong_t)&value, 0, 0) != -EINVAL ||
+        do_prctl(PR_SET_CFI, PR_CFI_BRANCH_LANDING_PADS,
+                 PR_CFI_ENABLE, 0, 0) != -EINVAL) {
         return 58;
     }
 
-    if (syscall3(__NR_readlink, (slong)exe_path, -1, 0) != -EINVAL ||
-        syscall3(__NR_readlink, (slong)exe_path, -1, -1) != -EINVAL ||
-        syscall4(__NR_readlinkat, AT_FDCWD, (slong)exe_path, -1, 0) !=
+    if (syscall3(__NR_readlink, (guest_slong_t)exe_path, -1, 0) != -EINVAL ||
+        syscall3(__NR_readlink, (guest_slong_t)exe_path, -1, -1) != -EINVAL ||
+        syscall4(__NR_readlinkat, AT_FDCWD, (guest_slong_t)exe_path, -1, 0) !=
             -EINVAL) {
         return 59;
     }
     return 0;
 }
 
-static int test_vma_name(void)
+static int test_vma_name(int large_host_page)
 {
     static const char name[] = "lat-vma-inner";
     static const char marker[] = "[anon:lat-vma-inner]";
@@ -583,23 +678,24 @@ static int test_vma_name(void)
     static const char sysv_marker[] = "[anon_shmem:lat-vma-sysv]";
     static const char invalid_name[] = "lat[vma";
     static const char exe_path[] = "/proc/self/exe";
+    static const char memfd_name[] = "lat-mremap-shadow";
     char long_name[80];
     char buffer[32768];
-    slong map;
-    slong shared_map;
-    slong sysv_map;
-    slong sysv_remap;
-    slong file_map;
-    slong shmid;
-    slong second_shmid;
-    slong remap_source;
-    slong remap_target;
-    slong remap_copy;
-    slong fd;
-    slong len;
-    ulong named_start;
-    ulong named_end;
-    ulong i;
+    guest_slong_t map;
+    guest_slong_t shared_map;
+    guest_slong_t sysv_map;
+    guest_slong_t sysv_remap;
+    guest_slong_t file_map;
+    guest_slong_t shmid;
+    guest_slong_t second_shmid;
+    guest_slong_t remap_source;
+    guest_slong_t remap_target;
+    guest_slong_t remap_copy;
+    guest_slong_t fd;
+    guest_slong_t len;
+    guest_ulong_t named_start;
+    guest_ulong_t named_end;
+    guest_ulong_t i;
 
     map = do_mmap(0, 16384, PROT_READ | PROT_WRITE,
                   MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
@@ -607,16 +703,17 @@ static int test_vma_name(void)
         return 60;
     }
     if (do_prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, map + 4096, 4096,
-                 (slong)name) != 0) {
+                 (guest_slong_t)name) != 0) {
         return 61;
     }
     len = read_maps(buffer, sizeof(buffer));
     if (len <= 0 ||
         !named_range(buffer, len, marker, sizeof(marker) - 1,
                      &named_start, &named_end) ||
-        named_start != (ulong)map + 4096 || named_end != (ulong)map + 8192) {
+        named_start != (guest_ulong_t)map + 4096 ||
+        named_end != (guest_ulong_t)map + 8192) {
         if (len > 0) {
-            syscall3(__NR_write, 2, (slong)buffer, len);
+            syscall3(__NR_write, 2, (guest_slong_t)buffer, len);
         }
         return 63;
     }
@@ -632,13 +729,13 @@ static int test_vma_name(void)
         long_name[i] = 'a';
     }
     if (do_prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, map, 4096,
-                 (slong)invalid_name) != -EINVAL ||
+                 (guest_slong_t)invalid_name) != -EINVAL ||
         do_prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, map, 4096,
-                 (slong)long_name) != -ENAMETOOLONG) {
+                 (guest_slong_t)long_name) != -ENAMETOOLONG) {
         return 66;
     }
 
-    fd = syscall4(__NR_openat, AT_FDCWD, (slong)exe_path, 0, 0);
+    fd = syscall4(__NR_openat, AT_FDCWD, (guest_slong_t)exe_path, 0, 0);
     if (fd < 0) {
         return 67;
     }
@@ -646,7 +743,7 @@ static int test_vma_name(void)
     syscall1(__NR_close, fd);
     if (file_map < 0 ||
         do_prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, file_map, 4096,
-                 (slong)name) != -EBADF) {
+                 (guest_slong_t)name) != -EBADF) {
         return 67;
     }
     syscall2(__NR_munmap, file_map, 4096);
@@ -655,17 +752,17 @@ static int test_vma_name(void)
                          MAP_SHARED | MAP_ANONYMOUS, -1, 0);
     if (shared_map < 0 ||
         do_prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, shared_map + 4096,
-                 4096, (slong)shared_name) != 0) {
+                 4096, (guest_slong_t)shared_name) != 0) {
         return 68;
     }
     len = read_maps(buffer, sizeof(buffer));
     if (len <= 0 ||
         !named_range(buffer, len, shared_marker,
                      sizeof(shared_marker) - 1, &named_start, &named_end) ||
-        named_start != (ulong)shared_map + 4096 ||
-        named_end != (ulong)shared_map + 8192) {
+        named_start != (guest_ulong_t)shared_map + 4096 ||
+        named_end != (guest_ulong_t)shared_map + 8192) {
         if (len > 0) {
-            syscall3(__NR_write, 2, (slong)buffer, len);
+            syscall3(__NR_write, 2, (guest_slong_t)buffer, len);
         }
         return 68;
     }
@@ -678,7 +775,7 @@ static int test_vma_name(void)
     sysv_map = syscall3(__NR_shmat, shmid, 0, 0);
     if (sysv_map < 0 ||
         do_prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, sysv_map, 4096,
-                 (slong)sysv_name) != 0) {
+                 (guest_slong_t)sysv_name) != 0) {
         syscall3(__NR_shmctl, shmid, IPC_RMID, 0);
         return 69;
     }
@@ -686,7 +783,8 @@ static int test_vma_name(void)
     if (len <= 0 ||
         !named_range(buffer, len, sysv_marker, sizeof(sysv_marker) - 1,
                      &named_start, &named_end) ||
-        named_start != (ulong)sysv_map || named_end != (ulong)sysv_map + 4096) {
+        named_start != (guest_ulong_t)sysv_map ||
+        named_end != (guest_ulong_t)sysv_map + 4096) {
         syscall1(__NR_shmdt, sysv_map);
         syscall3(__NR_shmctl, shmid, IPC_RMID, 0);
         return 69;
@@ -717,7 +815,7 @@ static int test_vma_name(void)
     syscall3(__NR_shmctl, second_shmid, IPC_RMID, 0);
 
     if (do_prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, map + 4096, 4096,
-                 (slong)name) != 0 ||
+                 (guest_slong_t)name) != 0 ||
         syscall2(__NR_munmap, map + 4096, 4096) != 0 ||
         do_mmap((void *)(map + 4096), 4096, PROT_READ | PROT_WRITE,
                 MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0) !=
@@ -736,7 +834,7 @@ static int test_vma_name(void)
                            MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
     if (remap_source < 0 || remap_target < 0 ||
         do_prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, remap_source, 12288,
-                 (slong)name) != 0 ||
+                 (guest_slong_t)name) != 0 ||
         syscall2(__NR_munmap, remap_target, 16384) != 0 ||
         syscall5(__NR_mremap, remap_source, 8193, 8193,
                  MREMAP_MAYMOVE | MREMAP_FIXED, remap_target) !=
@@ -747,8 +845,8 @@ static int test_vma_name(void)
     if (len <= 0 ||
         !named_range(buffer, len, marker, sizeof(marker) - 1,
                      &named_start, &named_end) ||
-        named_start != (ulong)remap_target ||
-        named_end != (ulong)remap_target + 12288) {
+        named_start != (guest_ulong_t)remap_target ||
+        named_end != (guest_ulong_t)remap_target + 12288) {
         return 69;
     }
     syscall2(__NR_munmap, remap_target, 12288);
@@ -760,14 +858,14 @@ static int test_vma_name(void)
     if (remap_source < 0 || remap_target < 0) {
         return 69;
     }
-    *(ulong *)remap_source = 0x123456789abcdef0UL;
+    *(guest_ulong_t *)remap_source = 0x123456789abcdef0UL;
     if (syscall3(__NR_mprotect, remap_source, 12288, 0) != 0 ||
         syscall2(__NR_munmap, remap_target, 12288) != 0 ||
         syscall5(__NR_mremap, remap_source, 8193, 8193,
                  MREMAP_MAYMOVE | MREMAP_FIXED, remap_target) !=
             remap_target ||
         syscall3(__NR_mprotect, remap_target, 12288, PROT_READ) != 0 ||
-        *(ulong *)remap_target != 0x123456789abcdef0UL ||
+        *(guest_ulong_t *)remap_target != 0x123456789abcdef0UL ||
         syscall3(__NR_mprotect, remap_source, 4096, PROT_READ) != -ENOMEM) {
         return 69;
     }
@@ -780,13 +878,13 @@ static int test_vma_name(void)
     if (remap_source < 0 || remap_target < 0) {
         return 69;
     }
-    *(ulong *)remap_source = 0x1122334455667788UL;
-    *(ulong *)(remap_target + 12288) = 0x8877665544332211UL;
+    *(guest_ulong_t *)remap_source = 0x1122334455667788UL;
+    *(guest_ulong_t *)(remap_target + 12288) = 0x8877665544332211UL;
     if (syscall5(__NR_mremap, remap_source, 8193, 8193,
                  MREMAP_MAYMOVE | MREMAP_FIXED, remap_target) !=
             remap_target ||
-        *(ulong *)remap_target != 0x1122334455667788UL ||
-        *(ulong *)(remap_target + 12288) != 0x8877665544332211UL) {
+        *(guest_ulong_t *)remap_target != 0x1122334455667788UL ||
+        *(guest_ulong_t *)(remap_target + 12288) != 0x8877665544332211UL) {
         return 69;
     }
     syscall2(__NR_munmap, remap_target, 16384);
@@ -799,12 +897,12 @@ static int test_vma_name(void)
         syscall3(__NR_mprotect, remap_source + 4096, 4096, PROT_READ) != 0) {
         return 69;
     }
-    *(ulong *)remap_target = 0xaabbccddeeff0011UL;
-    *(ulong *)(remap_target + 12288) = 0x1100ffeeddccbbaaUL;
+    *(guest_ulong_t *)remap_target = 0xaabbccddeeff0011UL;
+    *(guest_ulong_t *)(remap_target + 12288) = 0x1100ffeeddccbbaaUL;
     if (syscall5(__NR_mremap, remap_source, 8193, 8193,
                  MREMAP_MAYMOVE | MREMAP_FIXED, remap_target) != -EFAULT ||
-        *(ulong *)remap_target != 0xaabbccddeeff0011UL ||
-        *(ulong *)(remap_target + 12288) != 0x1100ffeeddccbbaaUL) {
+        *(guest_ulong_t *)remap_target != 0xaabbccddeeff0011UL ||
+        *(guest_ulong_t *)(remap_target + 12288) != 0x1100ffeeddccbbaaUL) {
         return 69;
     }
     syscall2(__NR_munmap, remap_source, 12288);
@@ -814,7 +912,7 @@ static int test_vma_name(void)
                          MAP_SHARED | MAP_ANONYMOUS, -1, 0);
     if (shared_map < 0 ||
         do_prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, shared_map, 16384,
-                 (slong)shared_name) != 0) {
+                 (guest_slong_t)shared_name) != 0) {
         return 69;
     }
     remap_copy = syscall5(__NR_mremap, shared_map, 0, 16384,
@@ -823,18 +921,32 @@ static int test_vma_name(void)
         do_prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, shared_map, 16384, 0)) {
         return 69;
     }
+    *(guest_ulong_t *)shared_map = 0x123456789abcdef0UL;
+    if (*(guest_ulong_t *)remap_copy != 0x123456789abcdef0UL) {
+        return 69;
+    }
+    *(guest_ulong_t *)(remap_copy + 12288) = 0xfedcba9876543210UL;
+    if (*(guest_ulong_t *)(shared_map + 12288) != 0xfedcba9876543210UL ||
+        syscall3(__NR_mprotect, remap_copy, 16384, PROT_READ) != 0 ||
+        syscall3(__NR_msync, remap_copy, 16384, MS_SYNC) != 0) {
+        return 69;
+    }
     len = read_maps(buffer, sizeof(buffer));
     if (len <= 0 ||
         !named_range(buffer, len, shared_marker,
                      sizeof(shared_marker) - 1, &named_start, &named_end) ||
-        named_start != (ulong)remap_copy ||
-        named_end != (ulong)remap_copy + 16384) {
+        named_start != (guest_ulong_t)remap_copy ||
+        named_end != (guest_ulong_t)remap_copy + 16384) {
         return 69;
     }
     syscall2(__NR_munmap, shared_map, 16384);
+    if (*(guest_ulong_t *)remap_copy != 0x123456789abcdef0UL ||
+        *(guest_ulong_t *)(remap_copy + 12288) != 0xfedcba9876543210UL) {
+        return 69;
+    }
     syscall2(__NR_munmap, remap_copy, 16384);
 
-    /* A partial-host-page fallback must not privatize a shared mapping. */
+    /* Partial shared moves cannot be expressed safely on a 16K host page. */
     shared_map = do_mmap(0, 16384, PROT_READ | PROT_WRITE,
                          MAP_SHARED | MAP_ANONYMOUS, -1, 0);
     remap_copy = syscall5(__NR_mremap, shared_map, 0, 16384,
@@ -842,33 +954,120 @@ static int test_vma_name(void)
     remap_target = do_mmap(0, 16384, PROT_READ | PROT_WRITE,
                            MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
     if (shared_map < 0 || remap_copy < 0 || remap_target < 0 ||
-        syscall2(__NR_munmap, remap_target, 16384) != 0) {
+        do_prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, shared_map, 16384,
+                 (guest_slong_t)shared_name) != 0) {
         return 69;
     }
-    *(ulong *)remap_copy = 0x1020304050607080UL;
-    remap_target = syscall5(__NR_mremap, shared_map, 8193, 8193,
-                            MREMAP_MAYMOVE | MREMAP_FIXED, remap_target);
-    if (remap_target >= 0) {
-        *(ulong *)remap_copy = 0x8070605040302010UL;
-        if (*(ulong *)remap_target != 0x8070605040302010UL) {
-            return 69;
-        }
-        *(ulong *)remap_target = 0x1234432112344321UL;
-        if (*(ulong *)remap_copy != 0x1234432112344321UL) {
-            return 69;
-        }
-        syscall2(__NR_munmap, remap_target, 12288);
-    } else if (remap_target != -EINVAL && remap_target != -EFAULT) {
+    *(guest_ulong_t *)remap_copy = 0x1020304050607080UL;
+    *(guest_ulong_t *)(remap_copy + 4096) = 0x1122334455667788UL;
+    *(guest_ulong_t *)(remap_copy + 8192) = 0x8877665544332211UL;
+    *(guest_ulong_t *)(remap_copy + 12288) = 0x0102030405060708UL;
+    *(guest_ulong_t *)(remap_target + 12288) = 0x8070605040302010UL;
+    *(guest_ulong_t *)remap_target = 0xaabbccddeeff0011UL;
+    if (syscall5(__NR_mremap, shared_map, 8193, 8193,
+                 MREMAP_MAYMOVE | MREMAP_FIXED, remap_target + 1) != -EINVAL ||
+        (large_host_page &&
+         (syscall5(__NR_mremap, shared_map, 8193, 8193,
+                   MREMAP_MAYMOVE | MREMAP_FIXED, remap_target) != -EFAULT ||
+          syscall5(__NR_mremap, shared_map, 8193, 12289,
+                   MREMAP_MAYMOVE | MREMAP_FIXED, remap_target) != -EFAULT ||
+          syscall5(__NR_mremap, shared_map, 12289, 8193,
+                   MREMAP_MAYMOVE | MREMAP_FIXED, remap_target) != -EFAULT)) ||
+        *(guest_ulong_t *)remap_copy != 0x1020304050607080UL ||
+        *(guest_ulong_t *)(remap_copy + 4096) != 0x1122334455667788UL ||
+        *(guest_ulong_t *)(remap_copy + 8192) != 0x8877665544332211UL ||
+        *(guest_ulong_t *)(remap_copy + 12288) != 0x0102030405060708UL ||
+        *(guest_ulong_t *)remap_target != 0xaabbccddeeff0011UL ||
+        *(guest_ulong_t *)(remap_target + 12288) !=
+            0x8070605040302010UL) {
         return 69;
     }
+    *(guest_ulong_t *)remap_copy = 0x8070605040302010UL;
+    len = read_maps(buffer, sizeof(buffer));
+    if (*(guest_ulong_t *)shared_map != 0x8070605040302010UL ||
+        syscall3(__NR_mprotect, shared_map, 16384, PROT_READ) != 0 ||
+        syscall3(__NR_msync, shared_map, 16384, MS_SYNC) != 0 ||
+        syscall3(__NR_mprotect, shared_map, 16384,
+                 PROT_READ | PROT_WRITE) != 0 ||
+        len <= 0 ||
+        !named_range(buffer, len, shared_marker,
+                     sizeof(shared_marker) - 1, &named_start, &named_end) ||
+        named_start != (guest_ulong_t)shared_map ||
+        named_end != (guest_ulong_t)shared_map + 16384) {
+        return 69;
+    }
+    syscall2(__NR_munmap, remap_target, 16384);
     syscall2(__NR_munmap, shared_map, 16384);
     syscall2(__NR_munmap, remap_copy, 16384);
+
+    if (!large_host_page &&
+        (test_shared_mremap_4k_case(8193, 8193) ||
+         test_shared_mremap_4k_case(8193, 12289) ||
+         test_shared_mremap_4k_case(12289, 8193))) {
+        return 69;
+    }
+
+    if (large_host_page) {
+        shared_map = do_mmap(0, 16384, PROT_READ | PROT_WRITE,
+                             MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+        remap_target = do_mmap(0, 16384, PROT_READ | PROT_WRITE,
+                               MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        if (shared_map < 0 || remap_target < 0 ||
+            syscall3(__NR_mprotect, shared_map + 4096, 4096,
+                     PROT_READ) != 0) {
+            return 69;
+        }
+        *(guest_ulong_t *)shared_map = 0xaabbccddeeff0011UL;
+        *(guest_ulong_t *)remap_target = 0x1100ffeeddccbbaaUL;
+        if (syscall5(__NR_mremap, shared_map, 0, 16384,
+                     MREMAP_MAYMOVE | MREMAP_FIXED, remap_target) !=
+                -EFAULT ||
+            *(guest_ulong_t *)shared_map != 0xaabbccddeeff0011UL ||
+            *(guest_ulong_t *)remap_target != 0x1100ffeeddccbbaaUL) {
+            return 69;
+        }
+        syscall2(__NR_munmap, shared_map, 16384);
+        syscall2(__NR_munmap, remap_target, 16384);
+    }
+
+    /* A shared file fragment uses a shadow page on a 16K host. */
+    map = do_mmap(0, 16384, PROT_READ | PROT_WRITE,
+                  MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    fd = syscall2(__NR_memfd_create, (guest_slong_t)memfd_name, 0);
+    if (map < 0 || fd < 0 || syscall2(__NR_ftruncate, fd, 4096) != 0 ||
+        do_mmap((void *)(map + 4096), 4096, PROT_READ | PROT_WRITE,
+                MAP_SHARED | MAP_FIXED, fd, 0) != map + 4096) {
+        return 69;
+    }
+    *(guest_ulong_t *)map = 0x0123456789abcdefUL;
+    *(guest_ulong_t *)(map + 4096) = 0xfedcba9876543210UL;
+    remap_copy = syscall5(__NR_mremap, map + 4096, 0, 4096,
+                          MREMAP_MAYMOVE, 0);
+    if ((large_host_page && remap_copy != -EFAULT) ||
+        (!large_host_page && remap_copy < 0) ||
+        *(guest_ulong_t *)map != 0x0123456789abcdefUL ||
+        *(guest_ulong_t *)(map + 4096) != 0xfedcba9876543210UL ||
+        syscall3(__NR_mprotect, map + 4096, 4096, PROT_READ) != 0 ||
+        syscall3(__NR_msync, map + 4096, 4096, MS_SYNC) != 0 ||
+        syscall3(__NR_mprotect, map + 4096, 4096,
+                 PROT_READ | PROT_WRITE) != 0) {
+        return 69;
+    }
+    if (remap_copy >= 0) {
+        *(guest_ulong_t *)remap_copy = 0x1122334455667788UL;
+        if (*(guest_ulong_t *)(map + 4096) != 0x1122334455667788UL) {
+            return 69;
+        }
+        syscall2(__NR_munmap, remap_copy, 4096);
+    }
+    syscall2(__NR_munmap, map, 16384);
+    syscall1(__NR_close, fd);
 
     remap_source = do_mmap(0, 16384, PROT_READ | PROT_WRITE,
                            MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
     if (remap_source < 0 ||
         do_prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, remap_source, 16384,
-                 (slong)name) != 0) {
+                 (guest_slong_t)name) != 0) {
         return 69;
     }
     remap_copy = syscall5(__NR_mremap, remap_source, 16384, 16384,
@@ -881,8 +1080,8 @@ static int test_vma_name(void)
     if (len <= 0 ||
         !named_range(buffer, len, marker, sizeof(marker) - 1,
                      &named_start, &named_end) ||
-        named_start != (ulong)remap_copy ||
-        named_end != (ulong)remap_copy + 16384) {
+        named_start != (guest_ulong_t)remap_copy ||
+        named_end != (guest_ulong_t)remap_copy + 16384) {
         return 69;
     }
     syscall2(__NR_munmap, remap_source, 16384);
@@ -898,7 +1097,7 @@ static int enable_mdwe(void)
 
 static int test_mdwe_basic(void)
 {
-    slong map;
+    guest_slong_t map;
 
     if (!enable_mdwe()) {
         return 70;
@@ -942,8 +1141,8 @@ static int test_mdwe_basic(void)
 
 static int test_mdwe_personality(void)
 {
-    slong old_personality;
-    slong map;
+    guest_slong_t old_personality;
+    guest_slong_t map;
 
     old_personality = syscall1(__NR_personality, 0xffffffffUL);
     if (old_personality < 0 ||
@@ -964,8 +1163,8 @@ static int test_mdwe_personality(void)
 
 static int test_mdwe_shmat(void)
 {
-    slong shmid;
-    slong map;
+    guest_slong_t shmid;
+    guest_slong_t map;
 
     shmid = syscall3(__NR_shmget, IPC_PRIVATE, 4096, IPC_CREAT | 0700);
     if (shmid < 0) {
@@ -990,12 +1189,12 @@ static int test_fork_state(int no_inherit)
 {
     int mdwe = PR_MDWE_REFUSE_EXEC_GAIN |
                (no_inherit ? PR_MDWE_NO_INHERIT : 0);
-    int expected_child_mdwe = mdwe;
+    int expected_child_mdwe = no_inherit ? 0 : mdwe;
     int tsc_mode = 0;
     int status = -1;
-    ulong clear_tid = 0;
-    ulong tid_address = 1;
-    slong pid;
+    guest_ulong_t clear_tid = 0;
+    guest_ulong_t tid_address = 1;
+    guest_slong_t pid;
 
     if (do_prctl(PR_SET_MDWE, mdwe, 0, 0, 0) != 0 ||
         do_prctl(PR_SET_TSC, PR_TSC_SIGSEGV, 0, 0, 0) != 0 ||
@@ -1003,7 +1202,7 @@ static int test_fork_state(int no_inherit)
                  PR_TIMER_CREATE_RESTORE_IDS_ON, 0, 0, 0) != 0 ||
         do_prctl(PR_FUTEX_HASH, PR_FUTEX_HASH_SET_SLOTS,
                  32, 0, 0) != 0 ||
-        syscall1(__NR_set_tid_address, (slong)&clear_tid) <= 0) {
+        syscall1(__NR_set_tid_address, (guest_slong_t)&clear_tid) <= 0) {
         return 110;
     }
     pid = syscall1(__NR_fork, 0);
@@ -1014,30 +1213,33 @@ static int test_fork_state(int no_inherit)
         int result = 0;
 
         if (do_prctl(PR_GET_MDWE, 0, 0, 0, 0) != expected_child_mdwe ||
-            do_prctl(PR_GET_TSC, (slong)&tsc_mode, 0, 0, 0) != 0 ||
+            do_prctl(PR_GET_TSC, (guest_slong_t)&tsc_mode, 0, 0, 0) != 0 ||
             tsc_mode != PR_TSC_SIGSEGV ||
             do_prctl(PR_TIMER_CREATE_RESTORE_IDS,
                      PR_TIMER_CREATE_RESTORE_IDS_GET, 0, 0, 0) != 0 ||
             do_prctl(PR_FUTEX_HASH, PR_FUTEX_HASH_GET_SLOTS,
                      0, 0, 0) != 0 ||
-            do_prctl(PR_GET_TID_ADDRESS, (slong)&tid_address, 0, 0, 0) ||
+            do_prctl(PR_GET_TID_ADDRESS,
+                     (guest_slong_t)&tid_address, 0, 0, 0) ||
             tid_address != 0) {
             result = 112;
         }
         syscall1(__NR_exit_group, result);
     }
-    if (syscall4(__NR_wait4, pid, (slong)&status, 0, 0) != pid || status) {
+    if (syscall4(__NR_wait4, pid, (guest_slong_t)&status, 0, 0) != pid ||
+        status) {
         return 113;
     }
     if (do_prctl(PR_GET_MDWE, 0, 0, 0, 0) != mdwe ||
-        do_prctl(PR_GET_TSC, (slong)&tsc_mode, 0, 0, 0) != 0 ||
+        do_prctl(PR_GET_TSC, (guest_slong_t)&tsc_mode, 0, 0, 0) != 0 ||
         tsc_mode != PR_TSC_SIGSEGV ||
         do_prctl(PR_TIMER_CREATE_RESTORE_IDS,
                  PR_TIMER_CREATE_RESTORE_IDS_GET, 0, 0, 0) != 1 ||
         do_prctl(PR_FUTEX_HASH, PR_FUTEX_HASH_GET_SLOTS,
                  0, 0, 0) != 32 ||
-        do_prctl(PR_GET_TID_ADDRESS, (slong)&tid_address, 0, 0, 0) ||
-        tid_address != (ulong)&clear_tid) {
+        do_prctl(PR_GET_TID_ADDRESS,
+                 (guest_slong_t)&tid_address, 0, 0, 0) ||
+        tid_address != (guest_ulong_t)&clear_tid) {
         return 114;
     }
     return 0;
@@ -1052,17 +1254,17 @@ static int test_set_mm_privileged(const char *self_path)
     static const char proctitle[] = "lat-prctl-title";
     static const char auxv_path[] = "/proc/self/auxv";
     static const char exe_path[] = "/proc/self/exe";
-    ulong replacement_auxv[4] = { 123, 456, 0, 0 };
-    ulong second_auxv[4] = { 789, 321, 0, 0 };
-    ulong auxv_buffer[8] = { 0 };
-    struct prctl_mm_map mm;
+    guest_ulong_t replacement_auxv[4] = { 123, 456, 0, 0 };
+    guest_ulong_t second_auxv[4] = { 789, 321, 0, 0 };
+    guest_ulong_t auxv_buffer[8] = { 0 };
+    PrctlMmMap mm;
     char buffer[512];
     char renamed_path[256];
-    slong map;
-    slong fd;
-    slong len;
-    ulong self_len;
-    ulong i;
+    guest_slong_t map;
+    guest_slong_t fd;
+    guest_slong_t len;
+    guest_ulong_t self_len;
+    guest_ulong_t i;
 
     map = do_mmap(0, 16384, PROT_READ | PROT_WRITE,
                   MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
@@ -1086,18 +1288,18 @@ static int test_set_mm_privileged(const char *self_path)
     mm.arg_end = map + sizeof(cmdline);
     mm.env_start = map + 128;
     mm.env_end = map + 132;
-    mm.auxv = (ulong)replacement_auxv;
+    mm.auxv = (guest_ulong_t)replacement_auxv;
     mm.auxv_size = sizeof(replacement_auxv);
     mm.exe_fd = ~0U;
 
-    if (do_prctl(PR_SET_MM, PR_SET_MM_MAP, (slong)&mm, sizeof(mm), 0)) {
+    if (do_prctl(PR_SET_MM, PR_SET_MM_MAP, (guest_slong_t)&mm, sizeof(mm), 0)) {
         return 121;
     }
-    fd = syscall4(__NR_openat, AT_FDCWD, (slong)cmdline_path, 0, 0);
+    fd = syscall4(__NR_openat, AT_FDCWD, (guest_slong_t)cmdline_path, 0, 0);
     if (fd < 0) {
         return 122;
     }
-    len = syscall3(__NR_read, fd, (slong)buffer, sizeof(buffer));
+    len = syscall3(__NR_read, fd, (guest_slong_t)buffer, sizeof(buffer));
     syscall1(__NR_close, fd);
     if (len != sizeof(cmdline) ||
         !bytes_equal(buffer, cmdline, sizeof(cmdline)) ||
@@ -1118,7 +1320,7 @@ static int test_set_mm_privileged(const char *self_path)
     mm.env_start = mm.arg_end;
     mm.env_end = map + 512 + sizeof(proctitle);
     mm.auxv_size = 0;
-    if (do_prctl(PR_SET_MM, PR_SET_MM_MAP, (slong)&mm, sizeof(mm), 0)) {
+    if (do_prctl(PR_SET_MM, PR_SET_MM_MAP, (guest_slong_t)&mm, sizeof(mm), 0)) {
         return 122;
     }
     len = read_file(cmdline_path, buffer, sizeof(buffer));
@@ -1127,17 +1329,18 @@ static int test_set_mm_privileged(const char *self_path)
         return 122;
     }
 
-    if (do_prctl(PR_GET_AUXV, (slong)auxv_buffer,
-                 sizeof(replacement_auxv), 0, 0) != 54 * sizeof(ulong) ||
+    if (do_prctl(PR_GET_AUXV, (guest_slong_t)auxv_buffer,
+                 sizeof(replacement_auxv), 0, 0) !=
+            54 * sizeof(guest_ulong_t) ||
         !bytes_equal((char *)auxv_buffer, (char *)replacement_auxv,
                      sizeof(replacement_auxv))) {
         return 123;
     }
-    fd = syscall4(__NR_openat, AT_FDCWD, (slong)auxv_path, 0, 0);
+    fd = syscall4(__NR_openat, AT_FDCWD, (guest_slong_t)auxv_path, 0, 0);
     if (fd < 0) {
         return 123;
     }
-    len = syscall3(__NR_read, fd, (slong)auxv_buffer,
+    len = syscall3(__NR_read, fd, (guest_slong_t)auxv_buffer,
                    sizeof(auxv_buffer));
     syscall1(__NR_close, fd);
     if (len != sizeof(replacement_auxv) ||
@@ -1162,20 +1365,20 @@ static int test_set_mm_privileged(const char *self_path)
                  0, 0) != -EPERM) {
         return 124;
     }
-    fd = syscall4(__NR_openat, AT_FDCWD, (slong)cmdline_path, 0, 0);
+    fd = syscall4(__NR_openat, AT_FDCWD, (guest_slong_t)cmdline_path, 0, 0);
     if (fd < 0) {
         return 125;
     }
-    len = syscall3(__NR_read, fd, (slong)buffer, sizeof(buffer));
+    len = syscall3(__NR_read, fd, (guest_slong_t)buffer, sizeof(buffer));
     syscall1(__NR_close, fd);
     if (len != sizeof(proctitle) ||
         !bytes_equal(buffer, proctitle, sizeof(proctitle))) {
         return 125;
     }
 
-    if (do_prctl(PR_SET_MM, PR_SET_MM_AUXV, (slong)second_auxv,
+    if (do_prctl(PR_SET_MM, PR_SET_MM_AUXV, (guest_slong_t)second_auxv,
                  sizeof(second_auxv), 0) != -EPERM ||
-        do_prctl(PR_GET_AUXV, (slong)auxv_buffer,
+        do_prctl(PR_GET_AUXV, (guest_slong_t)auxv_buffer,
                  sizeof(replacement_auxv), 0, 0) < 0 ||
         !bytes_equal((char *)auxv_buffer, (char *)replacement_auxv,
                      sizeof(replacement_auxv))) {
@@ -1187,13 +1390,13 @@ static int test_set_mm_privileged(const char *self_path)
         return 127;
     }
 
-    fd = syscall4(__NR_openat, AT_FDCWD, (slong)exe_path, 0, 0);
+    fd = syscall4(__NR_openat, AT_FDCWD, (guest_slong_t)exe_path, 0, 0);
     if (fd < 0 ||
         do_prctl(PR_SET_MM, PR_SET_MM_EXE_FILE, fd, 0, 0) != -EPERM) {
         return 128;
     }
     syscall1(__NR_close, fd);
-    fd = syscall4(__NR_openat, AT_FDCWD, (slong)exe_path, 0, 0);
+    fd = syscall4(__NR_openat, AT_FDCWD, (guest_slong_t)exe_path, 0, 0);
     if (fd < 0) {
         return 128;
     }
@@ -1203,19 +1406,20 @@ static int test_set_mm_privileged(const char *self_path)
         return 129;
     }
     self_len = string_length(self_path);
-    fd = syscall4(__NR_openat, AT_FDCWD, (slong)self_path, 0, 0);
+    fd = syscall4(__NR_openat, AT_FDCWD, (guest_slong_t)self_path, 0, 0);
     if (fd < 0) {
         return 129;
     }
     mm.exe_fd = fd;
-    if (do_prctl(PR_SET_MM, PR_SET_MM_MAP, (slong)&mm, sizeof(mm), 0)) {
+    if (do_prctl(PR_SET_MM, PR_SET_MM_MAP, (guest_slong_t)&mm, sizeof(mm), 0)) {
         syscall1(__NR_close, fd);
         return 129;
     }
     syscall1(__NR_close, fd);
-    len = syscall3(__NR_readlink, (slong)exe_path, (slong)buffer,
-                   sizeof(buffer));
-    if (len != self_len || !bytes_equal(buffer, self_path, self_len)) {
+    len = syscall3(__NR_readlink, (guest_slong_t)exe_path,
+                   (guest_slong_t)buffer, sizeof(buffer));
+    if (len != (guest_slong_t)self_len ||
+        !bytes_equal(buffer, self_path, self_len)) {
         return 129;
     }
     for (i = 0; self_path[i] && i + 9 < sizeof(renamed_path); i++) {
@@ -1233,20 +1437,22 @@ static int test_set_mm_privileged(const char *self_path)
     renamed_path[i++] = 'e';
     renamed_path[i++] = 'd';
     renamed_path[i] = 0;
-    if (syscall2(__NR_rename, (slong)self_path, (slong)renamed_path) != 0) {
+    if (syscall2(__NR_rename, (guest_slong_t)self_path,
+                 (guest_slong_t)renamed_path) != 0) {
         return 129;
     }
-    len = syscall3(__NR_readlink, (slong)exe_path, (slong)buffer,
-                   sizeof(buffer));
-    if (len != i || !bytes_equal(buffer, renamed_path, i)) {
+    len = syscall3(__NR_readlink, (guest_slong_t)exe_path,
+                   (guest_slong_t)buffer, sizeof(buffer));
+    if (len != (guest_slong_t)i || !bytes_equal(buffer, renamed_path, i)) {
         return 129;
     }
-    if (syscall1(__NR_unlink, (slong)renamed_path) != 0) {
+    if (syscall1(__NR_unlink, (guest_slong_t)renamed_path) != 0) {
         return 129;
     }
-    len = syscall3(__NR_readlink, (slong)exe_path, (slong)buffer,
-                   sizeof(buffer));
-    if (len != i + 10 || !bytes_equal(buffer, renamed_path, i) ||
+    len = syscall3(__NR_readlink, (guest_slong_t)exe_path,
+                   (guest_slong_t)buffer, sizeof(buffer));
+    if (len != (guest_slong_t)(i + 10) ||
+        !bytes_equal(buffer, renamed_path, i) ||
         !bytes_equal(buffer + i, " (deleted)", 10)) {
         return 129;
     }
@@ -1268,16 +1474,17 @@ static int test_native_exec_env(const char *helper_path, int at_empty_path)
         return 130;
     }
     if (at_empty_path) {
-        slong fd = syscall4(__NR_openat, AT_FDCWD, (slong)helper_path, 0, 0);
+        guest_slong_t fd = syscall4(__NR_openat, AT_FDCWD,
+                                    (guest_slong_t)helper_path, 0, 0);
 
         if (fd < 0) {
             return 131;
         }
-        syscall5(__NR_execveat, fd, (slong)empty_path, (slong)argv,
-                 (slong)envp, AT_EMPTY_PATH);
+        syscall5(__NR_execveat, fd, (guest_slong_t)empty_path,
+                 (guest_slong_t)argv, (guest_slong_t)envp, AT_EMPTY_PATH);
     } else {
-        syscall3(__NR_execve, (slong)helper_path, (slong)argv,
-                 (slong)envp);
+        syscall3(__NR_execve, (guest_slong_t)helper_path, (guest_slong_t)argv,
+                 (guest_slong_t)envp);
     }
     return 131;
 }
@@ -1287,19 +1494,20 @@ static int test_script_exec(const char *dir_path)
     static char script_name[] = "state-script";
     static char stage_name[] = "k";
     char *argv[] = { script_name, stage_name, 0 };
-    slong dirfd;
+    guest_slong_t dirfd;
 
     if (!dir_path ||
         do_prctl(PR_SET_MDWE, PR_MDWE_REFUSE_EXEC_GAIN, 0, 0, 0) ||
         do_prctl(PR_SET_TSC, PR_TSC_SIGSEGV, 0, 0, 0)) {
         return 132;
     }
-    dirfd = syscall4(__NR_openat, AT_FDCWD, (slong)dir_path,
+    dirfd = syscall4(__NR_openat, AT_FDCWD, (guest_slong_t)dir_path,
                      O_DIRECTORY, 0);
     if (dirfd < 0) {
         return 132;
     }
-    syscall5(__NR_execveat, dirfd, (slong)script_name, (slong)argv, 0, 0);
+    syscall5(__NR_execveat, dirfd, (guest_slong_t)script_name,
+             (guest_slong_t)argv, 0, 0);
     return 132;
 }
 
@@ -1309,13 +1517,40 @@ static int test_script_inherit(void)
 
     return do_prctl(PR_GET_MDWE, 0, 0, 0, 0) ==
                PR_MDWE_REFUSE_EXEC_GAIN &&
-           do_prctl(PR_GET_TSC, (slong)&tsc_mode, 0, 0, 0) == 0 &&
+           do_prctl(PR_GET_TSC, (guest_slong_t)&tsc_mode, 0, 0, 0) == 0 &&
            tsc_mode == PR_TSC_SIGSEGV ? 0 : 133;
 }
 
-int test_main(ulong *stack)
+static int test_mdwe_inherit(void)
 {
-    ulong argc = stack[0];
+    return do_prctl(PR_GET_MDWE, 0, 0, 0, 0) ==
+           PR_MDWE_REFUSE_EXEC_GAIN ? 0 : 134;
+}
+
+static int test_exec_race(const char *target_path, int use_execveat)
+{
+    static char mode[] = "l";
+    static char keep_env[] = "KEEP=1";
+    char *argv[] = { (char *)target_path, mode, 0 };
+    char *envp[] = { keep_env, 0 };
+
+    if (!target_path ||
+        do_prctl(PR_SET_MDWE, PR_MDWE_REFUSE_EXEC_GAIN, 0, 0, 0)) {
+        return 135;
+    }
+    if (use_execveat) {
+        syscall5(__NR_execveat, AT_FDCWD, (guest_slong_t)target_path,
+                 (guest_slong_t)argv, (guest_slong_t)envp, 0);
+    } else {
+        syscall3(__NR_execve, (guest_slong_t)target_path,
+                 (guest_slong_t)argv, (guest_slong_t)envp);
+    }
+    return 135;
+}
+
+int test_main(guest_ulong_t *stack)
+{
+    guest_ulong_t argc = stack[0];
     char **argv = (char **)&stack[1];
     char mode;
 
@@ -1325,12 +1560,15 @@ int test_main(ulong *stack)
     if (argc == 3 && argv[2] && argv[2][0] == 'k') {
         return test_script_inherit();
     }
+    if (argc == 3 && argv[2] && argv[2][0] == 'l') {
+        return test_mdwe_inherit();
+    }
     mode = argv[1][0];
     if (mode == 'p') {
         return test_process_controls();
     }
     if (mode == 'v') {
-        return test_vma_name();
+        return test_vma_name(argc == 3 && argv[2][0] == 'h');
     }
     if (mode == 'm') {
         return test_mdwe_basic();
@@ -1361,6 +1599,15 @@ int test_main(ulong *stack)
     }
     if (mode == 'k') {
         return test_script_inherit();
+    }
+    if (mode == 'l') {
+        return test_mdwe_inherit();
+    }
+    if (mode == 't') {
+        return test_exec_race(argc == 3 ? argv[2] : 0, 0);
+    }
+    if (mode == 'u') {
+        return test_exec_race(argc == 3 ? argv[2] : 0, 1);
     }
     return 101;
 }

--- a/tests/integration/syscall-user-dispatch.S
+++ b/tests/integration/syscall-user-dispatch.S
@@ -225,6 +225,8 @@ blocked_syscall_after:
 inclusive_blocked:
     mov $__NR_getpid, %eax
     syscall
+inclusive_blocked_after:
+    nop
 inclusive_blocked_end:
     cmp $__NR_getpid, %rax
     jne bad_return
@@ -302,7 +304,7 @@ inclusive_dispatch:
     jne bad_siginfo
     cmpl $SYS_USER_DISPATCH, 8(%rsi)
     jne bad_siginfo
-    lea inclusive_blocked_end(%rip), %rax
+    lea inclusive_blocked_after(%rip), %rax
     cmpq %rax, 16(%rsi)
     jne bad_siginfo
     cmpl $__NR_getpid, 24(%rsi)

--- a/tests/integration/syscall-user-dispatch.S
+++ b/tests/integration/syscall-user-dispatch.S
@@ -1,0 +1,151 @@
+.equ __NR_rt_sigaction, 13
+.equ __NR_getpid, 39
+.equ __NR_fork, 57
+.equ __NR_exit, 60
+.equ __NR_wait4, 61
+.equ __NR_prctl, 157
+
+.equ SIGSYS, 31
+.equ EINVAL, 22
+.equ SA_SIGINFO, 4
+.equ SA_RESTORER, 0x04000000
+.equ PR_SET_SYSCALL_USER_DISPATCH, 59
+.equ PR_SYS_DISPATCH_ON, 1
+.equ SYSCALL_DISPATCH_FILTER_BLOCK, 1
+.equ SYS_USER_DISPATCH, 2
+
+.section .text
+.global _start
+.type _start, @function
+_start:
+    /* Unknown prctl commands must be rejected in the guest. */
+    mov $__NR_prctl, %eax
+    mov $0x7fffffff, %edi
+    xor %esi, %esi
+    xor %edx, %edx
+    xor %r10d, %r10d
+    xor %r8d, %r8d
+    syscall
+    cmp $-EINVAL, %rax
+    jne unknown_prctl_failed
+
+    mov $__NR_rt_sigaction, %eax
+    mov $SIGSYS, %edi
+    lea action(%rip), %rsi
+    xor %edx, %edx
+    mov $8, %r10d
+    syscall
+    test %rax, %rax
+    js setup_failed
+
+    mov $__NR_prctl, %eax
+    mov $PR_SET_SYSCALL_USER_DISPATCH, %edi
+    mov $PR_SYS_DISPATCH_ON, %esi
+    lea dispatch_allowed(%rip), %rdx
+    mov $(dispatch_allowed_end - dispatch_allowed), %r10d
+    lea selector(%rip), %r8
+    syscall
+    test %rax, %rax
+    js setup_failed
+
+    /* Linux clears syscall user dispatch in a fork child. */
+    mov $__NR_fork, %eax
+    syscall
+    test %rax, %rax
+    jz fork_child
+    js fork_failed
+
+    mov %eax, %edi
+    lea child_status(%rip), %rsi
+    xor %edx, %edx
+    xor %r10d, %r10d
+    mov $__NR_wait4, %eax
+    syscall
+    test %rax, %rax
+    js fork_failed
+    cmpl $0, child_status(%rip)
+    jne fork_failed
+    jmp test_blocked_syscall
+
+fork_child:
+    movb $1, test_stage(%rip)
+    movb $SYSCALL_DISPATCH_FILTER_BLOCK, selector(%rip)
+    mov $__NR_getpid, %eax
+    syscall
+    xor %edi, %edi
+    jmp exit_now
+
+test_blocked_syscall:
+    movb $2, test_stage(%rip)
+    movb $SYSCALL_DISPATCH_FILTER_BLOCK, selector(%rip)
+
+    /* This syscall is outside dispatch_allowed and must raise guest SIGSYS. */
+    mov $__NR_getpid, %eax
+    syscall
+
+    mov $10, %edi
+    jmp exit_now
+
+unknown_prctl_failed:
+    mov $13, %edi
+    jmp exit_now
+
+setup_failed:
+    mov $11, %edi
+    jmp exit_now
+
+fork_failed:
+    mov $14, %edi
+    jmp exit_now
+
+.size _start, .-_start
+
+.p2align 4
+dispatch_allowed:
+    cmpb $1, test_stage(%rip)
+    je fork_dispatch_inherited
+    cmp $SIGSYS, %edi
+    jne bad_siginfo
+    cmpl $SYS_USER_DISPATCH, 8(%rsi)
+    jne bad_siginfo
+    xor %edi, %edi
+    jmp exit_now
+
+bad_siginfo:
+    mov $12, %edi
+    jmp exit_now
+
+fork_dispatch_inherited:
+    mov $14, %edi
+
+exit_now:
+    mov $__NR_exit, %eax
+    syscall
+    ud2
+
+sigreturn:
+    mov $15, %eax
+    syscall
+    ud2
+dispatch_allowed_end:
+
+.section .rodata
+.p2align 3
+action:
+    .quad dispatch_allowed
+    .quad SA_SIGINFO | SA_RESTORER
+    .quad sigreturn
+    .quad 0
+
+.section .data
+selector:
+    .byte 0
+test_stage:
+    .byte 0
+
+.section .bss
+.p2align 2
+child_status:
+    .skip 4
+
+.section .note.GNU-stack,"",@progbits

--- a/tests/integration/syscall-user-dispatch.S
+++ b/tests/integration/syscall-user-dispatch.S
@@ -6,13 +6,17 @@
 .equ __NR_prctl, 157
 
 .equ SIGSYS, 31
+.equ EFAULT, 14
 .equ EINVAL, 22
 .equ SA_SIGINFO, 4
 .equ SA_RESTORER, 0x04000000
 .equ PR_SET_SYSCALL_USER_DISPATCH, 59
+.equ PR_SYS_DISPATCH_OFF, 0
 .equ PR_SYS_DISPATCH_ON, 1
+.equ SYSCALL_DISPATCH_FILTER_ALLOW, 0
 .equ SYSCALL_DISPATCH_FILTER_BLOCK, 1
 .equ SYS_USER_DISPATCH, 2
+.equ AUDIT_ARCH_X86_64, 0xc000003e
 
 .section .text
 .global _start
@@ -29,6 +33,77 @@ _start:
     cmp $-EINVAL, %rax
     jne unknown_prctl_failed
 
+    /* Match the kernel's parameter validation before enabling dispatch. */
+    mov $__NR_prctl, %eax
+    mov $PR_SET_SYSCALL_USER_DISPATCH, %edi
+    mov $-1, %rsi
+    xor %edx, %edx
+    xor %r10d, %r10d
+    xor %r8d, %r8d
+    syscall
+    cmp $-EINVAL, %rax
+    jne bad_param_failed
+
+    mov $__NR_prctl, %eax
+    mov $PR_SET_SYSCALL_USER_DISPATCH, %edi
+    mov $PR_SYS_DISPATCH_OFF, %esi
+    mov $1, %edx
+    xor %r10d, %r10d
+    xor %r8d, %r8d
+    syscall
+    cmp $-EINVAL, %rax
+    jne bad_param_failed
+
+    mov $__NR_prctl, %eax
+    mov $PR_SET_SYSCALL_USER_DISPATCH, %edi
+    mov $PR_SYS_DISPATCH_OFF, %esi
+    xor %edx, %edx
+    mov $1, %r10d
+    xor %r8d, %r8d
+    syscall
+    cmp $-EINVAL, %rax
+    jne bad_param_failed
+
+    mov $__NR_prctl, %eax
+    mov $PR_SET_SYSCALL_USER_DISPATCH, %edi
+    mov $PR_SYS_DISPATCH_OFF, %esi
+    xor %edx, %edx
+    xor %r10d, %r10d
+    lea selector(%rip), %r8
+    syscall
+    cmp $-EINVAL, %rax
+    jne bad_param_failed
+
+    mov $__NR_prctl, %eax
+    mov $PR_SET_SYSCALL_USER_DISPATCH, %edi
+    mov $PR_SYS_DISPATCH_ON, %esi
+    mov $1, %edx
+    xor %r10d, %r10d
+    lea selector(%rip), %r8
+    syscall
+    cmp $-EINVAL, %rax
+    jne bad_param_failed
+
+    mov $__NR_prctl, %eax
+    mov $PR_SET_SYSCALL_USER_DISPATCH, %edi
+    mov $PR_SYS_DISPATCH_ON, %esi
+    xor %edx, %edx
+    mov $1, %r10d
+    mov $-1, %r8
+    syscall
+    cmp $-EFAULT, %rax
+    jne bad_param_failed
+
+    mov $__NR_prctl, %eax
+    mov $PR_SET_SYSCALL_USER_DISPATCH, %edi
+    mov $PR_SYS_DISPATCH_ON, %esi
+    mov $1, %edx
+    mov $-1, %r10
+    lea selector(%rip), %r8
+    syscall
+    cmp $-EINVAL, %rax
+    jne bad_param_failed
+
     mov $__NR_rt_sigaction, %eax
     mov $SIGSYS, %edi
     lea action(%rip), %rsi
@@ -37,6 +112,13 @@ _start:
     syscall
     test %rax, %rax
     js setup_failed
+
+    /* A syscall issued inside the configured range is always allowed. */
+    movb $SYSCALL_DISPATCH_FILTER_BLOCK, selector(%rip)
+    call allowed_getpid
+    test %rax, %rax
+    jle allowed_range_failed
+    movb $SYSCALL_DISPATCH_FILTER_ALLOW, selector(%rip)
 
     mov $__NR_prctl, %eax
     mov $PR_SET_SYSCALL_USER_DISPATCH, %edi
@@ -77,12 +159,39 @@ fork_child:
 
 test_blocked_syscall:
     movb $2, test_stage(%rip)
+    movb $0, signal_seen(%rip)
     movb $SYSCALL_DISPATCH_FILTER_BLOCK, selector(%rip)
 
     /* This syscall is outside dispatch_allowed and must raise guest SIGSYS. */
+blocked_syscall:
     mov $__NR_getpid, %eax
     syscall
+blocked_syscall_after:
+    cmp $__NR_getpid, %rax
+    jne bad_return
+    cmpb $1, signal_seen(%rip)
+    jne bad_siginfo
 
+    /* Turning dispatch off makes the selector irrelevant. */
+    mov $__NR_prctl, %eax
+    mov $PR_SET_SYSCALL_USER_DISPATCH, %edi
+    mov $PR_SYS_DISPATCH_OFF, %esi
+    xor %edx, %edx
+    xor %r10d, %r10d
+    xor %r8d, %r8d
+    syscall
+    test %rax, %rax
+    js setup_failed
+    movb $SYSCALL_DISPATCH_FILTER_BLOCK, selector(%rip)
+    mov $__NR_getpid, %eax
+    syscall
+    test %rax, %rax
+    jle disable_failed
+
+    xor %edi, %edi
+    jmp exit_now
+
+bad_return:
     mov $10, %edi
     jmp exit_now
 
@@ -98,6 +207,18 @@ fork_failed:
     mov $14, %edi
     jmp exit_now
 
+bad_param_failed:
+    mov $15, %edi
+    jmp exit_now
+
+allowed_range_failed:
+    mov $16, %edi
+    jmp exit_now
+
+disable_failed:
+    mov $17, %edi
+    jmp exit_now
+
 .size _start, .-_start
 
 .p2align 4
@@ -106,10 +227,20 @@ dispatch_allowed:
     je fork_dispatch_inherited
     cmp $SIGSYS, %edi
     jne bad_siginfo
+    cmpl $0, 4(%rsi)
+    jne bad_siginfo
     cmpl $SYS_USER_DISPATCH, 8(%rsi)
     jne bad_siginfo
-    xor %edi, %edi
-    jmp exit_now
+    lea blocked_syscall_after(%rip), %rax
+    cmpq %rax, 16(%rsi)
+    jne bad_siginfo
+    cmpl $__NR_getpid, 24(%rsi)
+    jne bad_siginfo
+    cmpl $AUDIT_ARCH_X86_64, 28(%rsi)
+    jne bad_siginfo
+    movb $1, signal_seen(%rip)
+    movb $SYSCALL_DISPATCH_FILTER_ALLOW, selector(%rip)
+    ret
 
 bad_siginfo:
     mov $12, %edi
@@ -117,6 +248,12 @@ bad_siginfo:
 
 fork_dispatch_inherited:
     mov $14, %edi
+    jmp exit_now
+
+allowed_getpid:
+    mov $__NR_getpid, %eax
+    syscall
+    ret
 
 exit_now:
     mov $__NR_exit, %eax
@@ -141,6 +278,8 @@ action:
 selector:
     .byte 0
 test_stage:
+    .byte 0
+signal_seen:
     .byte 0
 
 .section .bss

--- a/tests/integration/syscall-user-dispatch.S
+++ b/tests/integration/syscall-user-dispatch.S
@@ -13,6 +13,7 @@
 .equ PR_SET_SYSCALL_USER_DISPATCH, 59
 .equ PR_SYS_DISPATCH_OFF, 0
 .equ PR_SYS_DISPATCH_ON, 1
+.equ PR_SYS_DISPATCH_INCLUSIVE_ON, 2
 .equ SYSCALL_DISPATCH_FILTER_ALLOW, 0
 .equ SYSCALL_DISPATCH_FILTER_BLOCK, 1
 .equ SYS_USER_DISPATCH, 2
@@ -39,6 +40,26 @@ _start:
     mov $-1, %rsi
     xor %edx, %edx
     xor %r10d, %r10d
+    xor %r8d, %r8d
+    syscall
+    cmp $-EINVAL, %rax
+    jne bad_param_failed
+
+    mov $__NR_prctl, %eax
+    mov $PR_SET_SYSCALL_USER_DISPATCH, %edi
+    mov $PR_SYS_DISPATCH_INCLUSIVE_ON, %esi
+    lea inclusive_blocked(%rip), %rdx
+    xor %r10d, %r10d
+    xor %r8d, %r8d
+    syscall
+    cmp $-EINVAL, %rax
+    jne bad_param_failed
+
+    mov $__NR_prctl, %eax
+    mov $PR_SET_SYSCALL_USER_DISPATCH, %edi
+    mov $PR_SYS_DISPATCH_INCLUSIVE_ON, %esi
+    mov $-1, %rdx
+    mov $2, %r10d
     xor %r8d, %r8d
     syscall
     cmp $-EINVAL, %rax
@@ -188,6 +209,38 @@ blocked_syscall_after:
     test %rax, %rax
     jle disable_failed
 
+    /* Inclusive mode blocks syscalls inside, rather than outside, the range. */
+    movb $3, test_stage(%rip)
+    movb $0, signal_seen(%rip)
+    mov $__NR_prctl, %eax
+    mov $PR_SET_SYSCALL_USER_DISPATCH, %edi
+    mov $PR_SYS_DISPATCH_INCLUSIVE_ON, %esi
+    lea inclusive_blocked(%rip), %rdx
+    mov $(inclusive_blocked_end - inclusive_blocked), %r10d
+    xor %r8d, %r8d
+    syscall
+    test %rax, %rax
+    js setup_failed
+
+inclusive_blocked:
+    mov $__NR_getpid, %eax
+    syscall
+inclusive_blocked_end:
+    cmp $__NR_getpid, %rax
+    jne bad_return
+    cmpb $1, signal_seen(%rip)
+    jne bad_siginfo
+
+    mov $__NR_prctl, %eax
+    mov $PR_SET_SYSCALL_USER_DISPATCH, %edi
+    mov $PR_SYS_DISPATCH_OFF, %esi
+    xor %edx, %edx
+    xor %r10d, %r10d
+    xor %r8d, %r8d
+    syscall
+    test %rax, %rax
+    js setup_failed
+
     xor %edi, %edi
     jmp exit_now
 
@@ -225,6 +278,8 @@ disable_failed:
 dispatch_allowed:
     cmpb $1, test_stage(%rip)
     je fork_dispatch_inherited
+    cmpb $3, test_stage(%rip)
+    je inclusive_dispatch
     cmp $SIGSYS, %edi
     jne bad_siginfo
     cmpl $0, 4(%rsi)
@@ -240,6 +295,21 @@ dispatch_allowed:
     jne bad_siginfo
     movb $1, signal_seen(%rip)
     movb $SYSCALL_DISPATCH_FILTER_ALLOW, selector(%rip)
+    ret
+
+inclusive_dispatch:
+    cmp $SIGSYS, %edi
+    jne bad_siginfo
+    cmpl $SYS_USER_DISPATCH, 8(%rsi)
+    jne bad_siginfo
+    lea inclusive_blocked_end(%rip), %rax
+    cmpq %rax, 16(%rsi)
+    jne bad_siginfo
+    cmpl $__NR_getpid, 24(%rsi)
+    jne bad_siginfo
+    cmpl $AUDIT_ARCH_X86_64, 28(%rsi)
+    jne bad_siginfo
+    movb $1, signal_seen(%rip)
     ret
 
 bad_siginfo:

--- a/tests/integration/syscall-user-dispatch.S
+++ b/tests/integration/syscall-user-dispatch.S
@@ -4,6 +4,7 @@
 .equ __NR_exit, 60
 .equ __NR_wait4, 61
 .equ __NR_prctl, 157
+.equ __NR_tunnel_virtual, 600
 
 .equ SIGSYS, 31
 .equ EFAULT, 14
@@ -193,6 +194,25 @@ blocked_syscall_after:
     cmpb $1, signal_seen(%rip)
     jne bad_siginfo
 
+    /* An ordinary syscall 600 is not an authenticated loader notification. */
+    movb $4, test_stage(%rip)
+    movb $0, signal_seen(%rip)
+    movb $SYSCALL_DISPATCH_FILTER_BLOCK, selector(%rip)
+blocked_tunnel_syscall:
+    mov $__NR_tunnel_virtual, %eax
+    xor %edi, %edi
+    xor %esi, %esi
+    xor %edx, %edx
+    xor %r10d, %r10d
+    xor %r8d, %r8d
+    xor %r9d, %r9d
+    syscall
+blocked_tunnel_syscall_after:
+    cmp $__NR_tunnel_virtual, %rax
+    jne bad_return
+    cmpb $1, signal_seen(%rip)
+    jne bad_siginfo
+
     /* Turning dispatch off makes the selector irrelevant. */
     mov $__NR_prctl, %eax
     mov $PR_SET_SYSCALL_USER_DISPATCH, %edi
@@ -282,6 +302,8 @@ dispatch_allowed:
     je fork_dispatch_inherited
     cmpb $3, test_stage(%rip)
     je inclusive_dispatch
+    cmpb $4, test_stage(%rip)
+    je tunnel_dispatch
     cmp $SIGSYS, %edi
     jne bad_siginfo
     cmpl $0, 4(%rsi)
@@ -292,6 +314,22 @@ dispatch_allowed:
     cmpq %rax, 16(%rsi)
     jne bad_siginfo
     cmpl $__NR_getpid, 24(%rsi)
+    jne bad_siginfo
+    cmpl $AUDIT_ARCH_X86_64, 28(%rsi)
+    jne bad_siginfo
+    movb $1, signal_seen(%rip)
+    movb $SYSCALL_DISPATCH_FILTER_ALLOW, selector(%rip)
+    ret
+
+tunnel_dispatch:
+    cmp $SIGSYS, %edi
+    jne bad_siginfo
+    cmpl $SYS_USER_DISPATCH, 8(%rsi)
+    jne bad_siginfo
+    lea blocked_tunnel_syscall_after(%rip), %rax
+    cmpq %rax, 16(%rsi)
+    jne bad_siginfo
+    cmpl $__NR_tunnel_virtual, 24(%rsi)
     jne bad_siginfo
     cmpl $AUDIT_ARCH_X86_64, 28(%rsi)
     jne bad_siginfo

--- a/tests/integration/test-prctl-i386-abi.sh
+++ b/tests/integration/test-prctl-i386-abi.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+set -eu
+
+emulator=$1
+source_file=$2
+workdir=$(mktemp -d)
+trap 'rm -rf "$workdir"' EXIT HUP INT TERM
+
+if command -v clang-19 >/dev/null 2>&1; then
+    clang=clang-19
+elif command -v clang >/dev/null 2>&1; then
+    clang=clang
+else
+    echo "SKIP: clang is required to build the i386 guest"
+    exit 77
+fi
+
+"$clang" --target=i386-linux-gnu -fuse-ld=lld -nostdlib -static -no-pie \
+    -Wl,--build-id=none "$source_file" -o "$workdir/prctl-i386-abi"
+
+set +e
+LATX_AOT=0 LATX_KZT=0 timeout -s KILL 10 \
+    "$emulator" "$workdir/prctl-i386-abi"
+ret=$?
+set -e
+
+case $ret in
+0) echo "PASS: i386 prctl ABI behavior" ;;
+20) echo "FAIL: i386 prctl pointer translation" >&2 ;;
+21) echo "FAIL: i386 PR_GET_AUXV compat layout" >&2 ;;
+22) echo "FAIL: i386 PR_SET_MM compat translation" >&2 ;;
+23) echo "FAIL: i386 syscall user dispatch" >&2 ;;
+24) echo "FAIL: i386 TSC control" >&2 ;;
+25) echo "FAIL: i386 MDWE mmap2/mprotect enforcement" >&2 ;;
+26) echo "FAIL: i386 current prctl controls" >&2 ;;
+124) echo "FAIL: i386 prctl ABI test timed out" >&2 ;;
+*) echo "FAIL: unexpected i386 guest exit status $ret" >&2 ;;
+esac
+
+test "$ret" -eq 0

--- a/tests/integration/test-prctl-i386-exec-race.sh
+++ b/tests/integration/test-prctl-i386-exec-race.sh
@@ -1,0 +1,95 @@
+#!/bin/sh
+set -eu
+
+emulator=$1
+emulator_path=$(realpath "$emulator")
+source_file=$2
+native_helper_source=$3
+shim_source=$4
+workdir=$(mktemp -d)
+trap 'rm -rf "$workdir"' EXIT HUP INT TERM
+
+if command -v clang-19 >/dev/null 2>&1; then
+    clang=clang-19
+elif command -v clang >/dev/null 2>&1; then
+    clang=clang
+else
+    echo "SKIP: clang is required to build the i386 guest"
+    exit 77
+fi
+
+"$clang" --target=i386-linux-gnu -fuse-ld=lld -nostdlib -static -no-pie \
+    -Wl,--build-id=none "$source_file" -o "$workdir/prctl-i386-exec-race"
+"${CC:-cc}" -O2 -Wall -Wextra "$native_helper_source" \
+    -o "$workdir/prctl-native-env-helper"
+"${CC:-cc}" -O2 -Wall -Wextra -DPRCTL_EXEC_RACE_FAIL \
+    "$native_helper_source" -o "$workdir/prctl-native-fail-helper"
+"${CC:-cc}" -shared -fPIC -O2 -Wall -Wextra "$shim_source" \
+    -o "$workdir/prctl-exec-race-shim.so"
+printf '#!%s carrier\nPR378_EXEC_RACE_ORIGINAL\n' \
+    "$workdir/prctl-native-env-helper" >"$workdir/prctl-carrier-script"
+printf '#!%s carrier\nPR378_EXEC_RACE_REPLACEMENT\n' \
+    "$workdir/prctl-native-fail-helper" \
+    >"$workdir/prctl-carrier-replacement"
+chmod +x "$workdir/prctl-carrier-script" \
+    "$workdir/prctl-carrier-replacement"
+printf '#!%s %s\n' "$emulator_path" "$workdir/prctl-i386-exec-race" \
+    >"$workdir/prctl-i386-script"
+chmod +x "$workdir/prctl-i386-script"
+
+run_race()
+{
+    name=$1
+    initial=$2
+    replacement=$3
+    mode=$4
+    target="$workdir/$name-target"
+    alternate="$workdir/$name-alternate"
+    ready="$workdir/$name-ready"
+    release="$workdir/$name-release"
+
+    cp "$initial" "$target"
+    cp "$replacement" "$alternate"
+    env LATX_AOT=0 LATX_KZT=0 \
+        LD_PRELOAD="$workdir/prctl-exec-race-shim.so" \
+        LATX_EXEC_RACE_TARGET="$target" \
+        LATX_EXEC_RACE_READY="$ready" \
+        LATX_EXEC_RACE_RELEASE="$release" \
+        timeout -s KILL 15 "$emulator" "$workdir/prctl-i386-exec-race" \
+            "$mode" "$target" &
+    pid=$!
+
+    i=0
+    while test ! -e "$ready" && test "$i" -lt 100; do
+        sleep 0.05
+        i=$((i + 1))
+    done
+    if test ! -e "$ready"; then
+        touch "$release"
+        wait "$pid" || true
+        echo "FAIL: $name exec race did not reach the inspection barrier" >&2
+        return 1
+    fi
+    mv "$target" "$workdir/$name-swap"
+    mv "$alternate" "$target"
+    mv "$workdir/$name-swap" "$alternate"
+    touch "$release"
+    if ! wait "$pid"; then
+        echo "FAIL: $name exec race used a different file after inspection" >&2
+        return 1
+    fi
+    echo "PASS: $name exec classification and execution used one file"
+}
+
+run_race execve-native-to-i386 "$workdir/prctl-native-env-helper" \
+    "$workdir/prctl-i386-exec-race" t
+run_race execve-i386-to-native "$workdir/prctl-i386-script" \
+    "$workdir/prctl-native-fail-helper" t
+run_race execve-script-carrier "$workdir/prctl-carrier-script" \
+    "$workdir/prctl-carrier-replacement" t
+run_race execveat-native-to-i386 "$workdir/prctl-native-env-helper" \
+    "$workdir/prctl-i386-exec-race" u
+run_race execveat-i386-to-native "$workdir/prctl-i386-script" \
+    "$workdir/prctl-native-fail-helper" u
+run_race execveat-script-carrier "$workdir/prctl-carrier-script" \
+    "$workdir/prctl-carrier-replacement" u

--- a/tests/integration/test-prctl-i386-mremap.sh
+++ b/tests/integration/test-prctl-i386-mremap.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+set -eu
+
+emulator=$1
+source_file=$2
+workdir=$(mktemp -d)
+trap 'rm -rf "$workdir"' EXIT HUP INT TERM
+
+if command -v clang-19 >/dev/null 2>&1; then
+    clang=clang-19
+elif command -v clang >/dev/null 2>&1; then
+    clang=clang
+else
+    echo "SKIP: clang is required to build the i386 guest"
+    exit 77
+fi
+
+"$clang" --target=i386-linux-gnu -fuse-ld=lld -nostdlib -static -no-pie \
+    -O2 -fomit-frame-pointer -ffreestanding -fno-builtin \
+    -fno-stack-protector -Wl,--build-id=none "$source_file" \
+    -o "$workdir/prctl-i386-mremap"
+
+host_mode=
+if [ "$(getconf PAGESIZE)" -gt 4096 ]; then
+    host_mode=h
+fi
+
+set +e
+LATX_AOT=0 LATX_KZT=0 timeout -s KILL 15 \
+    "$emulator" "$workdir/prctl-i386-mremap" "$host_mode"
+ret=$?
+set -e
+
+case $ret in
+0) echo "PASS: i386 shared and shadow mremap semantics" ;;
+30) echo "FAIL: i386 shared mremap alias semantics" >&2 ;;
+31) echo "FAIL: i386 partial shared mremap fail-closed semantics" >&2 ;;
+32) echo "FAIL: i386 shadow mremap fail-closed semantics" >&2 ;;
+124) echo "FAIL: i386 mremap test timed out" >&2 ;;
+*) echo "FAIL: unexpected i386 mremap exit status $ret" >&2 ;;
+esac
+
+test "$ret" -eq 0

--- a/tests/integration/test-prctl-x86-abi.sh
+++ b/tests/integration/test-prctl-x86-abi.sh
@@ -18,20 +18,17 @@ fi
 "$clang" --target=x86_64-linux-gnu -fuse-ld=lld -nostdlib -static \
     -Wl,--build-id=none "$source_file" -o "$workdir/prctl-x86-abi"
 
-run_mode()
+run_test()
 {
-    mode=$1
-    label=$2
-
     set +e
-    LATX_AOT=0 LATX_KZT=0 LATX_TU="$mode" timeout -s KILL 10 \
+    LATX_AOT=0 LATX_KZT=0 timeout -s KILL 10 \
         "$emulator" "$workdir/prctl-x86-abi"
     ret=$?
     set -e
 
     case $ret in
 0)
-    echo "PASS: $label x86_64 prctl ABI behavior"
+    echo "PASS: x86_64 prctl ABI behavior"
     ;;
 20)
     echo "FAIL: PR_GET_PDEATHSIG pointer semantics" >&2
@@ -64,12 +61,11 @@ run_mode()
     echo "FAIL: x86_64 prctl ABI test timed out" >&2
     ;;
 *)
-    echo "FAIL: $label unexpected guest exit status $ret" >&2
+    echo "FAIL: unexpected guest exit status $ret" >&2
     ;;
     esac
 
     test "$ret" -eq 0
 }
 
-run_mode 0 non-tu
-run_mode 1 tu
+run_test

--- a/tests/integration/test-prctl-x86-abi.sh
+++ b/tests/integration/test-prctl-x86-abi.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+set -eu
+
+emulator=$1
+source_file=$2
+workdir=$(mktemp -d)
+trap 'rm -rf "$workdir"' EXIT HUP INT TERM
+
+if command -v clang-19 >/dev/null 2>&1; then
+    clang=clang-19
+elif command -v clang >/dev/null 2>&1; then
+    clang=clang
+else
+    echo "SKIP: clang is required to build the x86_64 guest"
+    exit 77
+fi
+
+"$clang" --target=x86_64-linux-gnu -fuse-ld=lld -nostdlib -static \
+    -Wl,--build-id=none "$source_file" -o "$workdir/prctl-x86-abi"
+
+set +e
+LATX_AOT=0 LATX_KZT=0 timeout -s KILL 10 \
+    "$emulator" "$workdir/prctl-x86-abi"
+ret=$?
+set -e
+
+case $ret in
+0)
+    echo "PASS: x86_64 prctl ABI behavior"
+    ;;
+20)
+    echo "FAIL: PR_GET_PDEATHSIG pointer semantics" >&2
+    ;;
+21)
+    echo "FAIL: PR_GET_AUXV guest copy semantics" >&2
+    ;;
+22)
+    echo "FAIL: PR_GET_TSC/PR_SET_TSC semantics" >&2
+    ;;
+23)
+    echo "FAIL: PR_GET_MDWE/PR_SET_MDWE enforcement" >&2
+    ;;
+24)
+    echo "FAIL: RDTSC executed while PR_TSC_SIGSEGV was active" >&2
+    ;;
+25)
+    echo "FAIL: RDTSC delivered an unexpected signal" >&2
+    ;;
+26)
+    echo "FAIL: PR_SET_VMA pointer/address translation" >&2
+    ;;
+27)
+    echo "FAIL: PR_SET_MM guest ABI translation" >&2
+    ;;
+28)
+    echo "FAIL: x86 speculation-control emulation" >&2
+    ;;
+124)
+    echo "FAIL: x86_64 prctl ABI test timed out" >&2
+    ;;
+*)
+    echo "FAIL: unexpected guest exit status $ret" >&2
+    ;;
+esac
+
+exit "$ret"

--- a/tests/integration/test-prctl-x86-abi.sh
+++ b/tests/integration/test-prctl-x86-abi.sh
@@ -18,15 +18,20 @@ fi
 "$clang" --target=x86_64-linux-gnu -fuse-ld=lld -nostdlib -static \
     -Wl,--build-id=none "$source_file" -o "$workdir/prctl-x86-abi"
 
-set +e
-LATX_AOT=0 LATX_KZT=0 timeout -s KILL 10 \
-    "$emulator" "$workdir/prctl-x86-abi"
-ret=$?
-set -e
+run_mode()
+{
+    mode=$1
+    label=$2
 
-case $ret in
+    set +e
+    LATX_AOT=0 LATX_KZT=0 LATX_TU="$mode" timeout -s KILL 10 \
+        "$emulator" "$workdir/prctl-x86-abi"
+    ret=$?
+    set -e
+
+    case $ret in
 0)
-    echo "PASS: x86_64 prctl ABI behavior"
+    echo "PASS: $label x86_64 prctl ABI behavior"
     ;;
 20)
     echo "FAIL: PR_GET_PDEATHSIG pointer semantics" >&2
@@ -59,8 +64,12 @@ case $ret in
     echo "FAIL: x86_64 prctl ABI test timed out" >&2
     ;;
 *)
-    echo "FAIL: unexpected guest exit status $ret" >&2
+    echo "FAIL: $label unexpected guest exit status $ret" >&2
     ;;
-esac
+    esac
 
-exit "$ret"
+    test "$ret" -eq 0
+}
+
+run_mode 0 non-tu
+run_mode 1 tu

--- a/tests/integration/test-prctl-x86-exec-race.sh
+++ b/tests/integration/test-prctl-x86-exec-race.sh
@@ -1,0 +1,96 @@
+#!/bin/sh
+set -eu
+
+emulator=$1
+emulator_path=$(realpath "$emulator")
+source_file=$2
+native_helper_source=$3
+shim_source=$4
+workdir=$(mktemp -d)
+trap 'rm -rf "$workdir"' EXIT HUP INT TERM
+
+if command -v clang-19 >/dev/null 2>&1; then
+    clang=clang-19
+elif command -v clang >/dev/null 2>&1; then
+    clang=clang
+else
+    echo "SKIP: clang is required to build the x86_64 guest"
+    exit 77
+fi
+
+"$clang" --target=x86_64-linux-gnu -fuse-ld=lld -nostdlib -static -no-pie \
+    -O2 -ffreestanding -fno-builtin -fno-stack-protector \
+    -Wl,--build-id=none "$source_file" -o "$workdir/prctl-x86-semantics"
+"${CC:-cc}" -O2 -Wall -Wextra "$native_helper_source" \
+    -o "$workdir/prctl-native-env-helper"
+"${CC:-cc}" -O2 -Wall -Wextra -DPRCTL_EXEC_RACE_FAIL \
+    "$native_helper_source" -o "$workdir/prctl-native-fail-helper"
+"${CC:-cc}" -shared -fPIC -O2 -Wall -Wextra "$shim_source" \
+    -o "$workdir/prctl-exec-race-shim.so"
+printf '#!%s %s\n' "$emulator_path" "$workdir/prctl-x86-semantics" \
+    >"$workdir/prctl-x86-script"
+chmod +x "$workdir/prctl-x86-script"
+printf '#!%s carrier\nPR378_EXEC_RACE_ORIGINAL\n' \
+    "$workdir/prctl-native-env-helper" >"$workdir/prctl-carrier-script"
+printf '#!%s carrier\nPR378_EXEC_RACE_REPLACEMENT\n' \
+    "$workdir/prctl-native-fail-helper" \
+    >"$workdir/prctl-carrier-replacement"
+chmod +x "$workdir/prctl-carrier-script" \
+    "$workdir/prctl-carrier-replacement"
+
+run_race()
+{
+    name=$1
+    initial=$2
+    replacement=$3
+    mode=$4
+    target="$workdir/$name-target"
+    alternate="$workdir/$name-alternate"
+    ready="$workdir/$name-ready"
+    release="$workdir/$name-release"
+
+    cp "$initial" "$target"
+    cp "$replacement" "$alternate"
+    env LATX_AOT=0 LATX_KZT=0 \
+        LD_PRELOAD="$workdir/prctl-exec-race-shim.so" \
+        LATX_EXEC_RACE_TARGET="$target" \
+        LATX_EXEC_RACE_READY="$ready" \
+        LATX_EXEC_RACE_RELEASE="$release" \
+        timeout -s KILL 15 "$emulator" "$workdir/prctl-x86-semantics" \
+            "$mode" "$target" &
+    pid=$!
+
+    i=0
+    while test ! -e "$ready" && test "$i" -lt 100; do
+        sleep 0.05
+        i=$((i + 1))
+    done
+    if test ! -e "$ready"; then
+        touch "$release"
+        wait "$pid" || true
+        echo "FAIL: $name exec race did not reach the inspection barrier" >&2
+        return 1
+    fi
+    mv "$target" "$workdir/$name-swap"
+    mv "$alternate" "$target"
+    mv "$workdir/$name-swap" "$alternate"
+    touch "$release"
+    if ! wait "$pid"; then
+        echo "FAIL: $name exec race used a different file after inspection" >&2
+        return 1
+    fi
+    echo "PASS: $name exec classification and execution used one file"
+}
+
+run_race execve-x86-to-native "$workdir/prctl-x86-script" \
+    "$workdir/prctl-native-fail-helper" t
+run_race execve-native-to-x86 "$workdir/prctl-native-env-helper" \
+    "$workdir/prctl-x86-script" t
+run_race execve-script-carrier "$workdir/prctl-carrier-script" \
+    "$workdir/prctl-carrier-replacement" t
+run_race execveat-x86-to-native "$workdir/prctl-x86-script" \
+    "$workdir/prctl-native-fail-helper" u
+run_race execveat-native-to-x86 "$workdir/prctl-native-env-helper" \
+    "$workdir/prctl-x86-script" u
+run_race execveat-script-carrier "$workdir/prctl-carrier-script" \
+    "$workdir/prctl-carrier-replacement" u

--- a/tests/integration/test-prctl-x86-inherit.sh
+++ b/tests/integration/test-prctl-x86-inherit.sh
@@ -51,6 +51,12 @@ run_mode()
 36)
     echo "FAIL: inherited TSC mode delivered an unexpected signal" >&2
     ;;
+37)
+    echo "FAIL: guest environment forged inherited MDWE state" >&2
+    ;;
+38)
+    echo "FAIL: guest environment forged inherited TSC state" >&2
+    ;;
 124)
     echo "FAIL: x86_64 prctl inheritance test timed out" >&2
     ;;

--- a/tests/integration/test-prctl-x86-inherit.sh
+++ b/tests/integration/test-prctl-x86-inherit.sh
@@ -18,20 +18,17 @@ fi
 "$clang" --target=x86_64-linux-gnu -fuse-ld=lld -nostdlib -static \
     -Wl,--build-id=none "$source_file" -o "$workdir/prctl-x86-inherit"
 
-run_mode()
+run_test()
 {
-    mode=$1
-    label=$2
-
     set +e
-    LATX_AOT=0 LATX_KZT=0 LATX_TU="$mode" timeout -s KILL 10 \
+    LATX_AOT=0 LATX_KZT=0 timeout -s KILL 10 \
         "$emulator" "$workdir/prctl-x86-inherit" "$emulator"
     ret=$?
     set -e
 
     case $ret in
 0)
-    echo "PASS: $label x86_64 prctl state inheritance"
+    echo "PASS: x86_64 prctl state inheritance"
     ;;
 31)
     echo "FAIL: unexpected exec test stage" >&2
@@ -61,12 +58,11 @@ run_mode()
     echo "FAIL: x86_64 prctl inheritance test timed out" >&2
     ;;
 *)
-    echo "FAIL: $label unexpected guest exit status $ret" >&2
+    echo "FAIL: unexpected guest exit status $ret" >&2
     ;;
     esac
 
     test "$ret" -eq 0
 }
 
-run_mode 0 non-tu
-run_mode 1 tu
+run_test

--- a/tests/integration/test-prctl-x86-inherit.sh
+++ b/tests/integration/test-prctl-x86-inherit.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+set -eu
+
+emulator=$1
+source_file=$2
+workdir=$(mktemp -d)
+trap 'rm -rf "$workdir"' EXIT HUP INT TERM
+
+if command -v clang-19 >/dev/null 2>&1; then
+    clang=clang-19
+elif command -v clang >/dev/null 2>&1; then
+    clang=clang
+else
+    echo "SKIP: clang is required to build the x86_64 guest"
+    exit 77
+fi
+
+"$clang" --target=x86_64-linux-gnu -fuse-ld=lld -nostdlib -static \
+    -Wl,--build-id=none "$source_file" -o "$workdir/prctl-x86-inherit"
+
+set +e
+LATX_AOT=0 LATX_KZT=0 timeout -s KILL 10 \
+    "$emulator" "$workdir/prctl-x86-inherit" "$emulator"
+ret=$?
+set -e
+
+case $ret in
+0)
+    echo "PASS: x86_64 prctl state inheritance"
+    ;;
+31)
+    echo "FAIL: unexpected exec test stage" >&2
+    ;;
+32)
+    echo "FAIL: guest self-exec failed" >&2
+    ;;
+33)
+    echo "FAIL: inherited PR_TSC_SIGSEGV did not trap RDTSC" >&2
+    ;;
+34)
+    echo "FAIL: PR_MDWE inheritance semantics" >&2
+    ;;
+35)
+    echo "FAIL: PR_TSC inheritance semantics" >&2
+    ;;
+36)
+    echo "FAIL: inherited TSC mode delivered an unexpected signal" >&2
+    ;;
+124)
+    echo "FAIL: x86_64 prctl inheritance test timed out" >&2
+    ;;
+*)
+    echo "FAIL: unexpected guest exit status $ret" >&2
+    ;;
+esac
+
+exit "$ret"

--- a/tests/integration/test-prctl-x86-inherit.sh
+++ b/tests/integration/test-prctl-x86-inherit.sh
@@ -18,15 +18,20 @@ fi
 "$clang" --target=x86_64-linux-gnu -fuse-ld=lld -nostdlib -static \
     -Wl,--build-id=none "$source_file" -o "$workdir/prctl-x86-inherit"
 
-set +e
-LATX_AOT=0 LATX_KZT=0 timeout -s KILL 10 \
-    "$emulator" "$workdir/prctl-x86-inherit" "$emulator"
-ret=$?
-set -e
+run_mode()
+{
+    mode=$1
+    label=$2
 
-case $ret in
+    set +e
+    LATX_AOT=0 LATX_KZT=0 LATX_TU="$mode" timeout -s KILL 10 \
+        "$emulator" "$workdir/prctl-x86-inherit" "$emulator"
+    ret=$?
+    set -e
+
+    case $ret in
 0)
-    echo "PASS: x86_64 prctl state inheritance"
+    echo "PASS: $label x86_64 prctl state inheritance"
     ;;
 31)
     echo "FAIL: unexpected exec test stage" >&2
@@ -50,8 +55,12 @@ case $ret in
     echo "FAIL: x86_64 prctl inheritance test timed out" >&2
     ;;
 *)
-    echo "FAIL: unexpected guest exit status $ret" >&2
+    echo "FAIL: $label unexpected guest exit status $ret" >&2
     ;;
-esac
+    esac
 
-exit "$ret"
+    test "$ret" -eq 0
+}
+
+run_mode 0 non-tu
+run_mode 1 tu

--- a/tests/integration/test-prctl-x86-privileged.sh
+++ b/tests/integration/test-prctl-x86-privileged.sh
@@ -36,8 +36,8 @@ for mode in 0 1; do
     ret=$?
     set -e
     if [ "$ret" -ne 0 ]; then
-        echo "FAIL: $label privileged PR_SET_MM semantics returned $ret" >&2
+        echo "FAIL: $label user-namespace PR_SET_MM semantics returned $ret" >&2
         exit "$ret"
     fi
-    echo "PASS: $label privileged PR_SET_MM semantics"
+    echo "PASS: $label user-namespace PR_SET_MM semantics"
 done

--- a/tests/integration/test-prctl-x86-privileged.sh
+++ b/tests/integration/test-prctl-x86-privileged.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+set -eu
+
+emulator=$1
+source_file=$2
+workdir=$(mktemp -d)
+trap 'rm -rf "$workdir"' EXIT HUP INT TERM
+
+if command -v clang-19 >/dev/null 2>&1; then
+    clang=clang-19
+elif command -v clang >/dev/null 2>&1; then
+    clang=clang
+else
+    echo "SKIP: clang is required to build the x86_64 guest"
+    exit 77
+fi
+if ! unshare -Ur true 2>/dev/null; then
+    echo "SKIP: an unprivileged user namespace is required"
+    exit 77
+fi
+
+"$clang" --target=x86_64-linux-gnu -fuse-ld=lld -nostdlib -static -no-pie \
+    -ffreestanding -fno-builtin -fno-stack-protector \
+    -Wl,--build-id=none "$source_file" -o "$workdir/prctl-x86-semantics"
+
+for mode in 0 1; do
+    if [ "$mode" -eq 0 ]; then
+        label=non-tu
+    else
+        label=tu
+    fi
+    set +e
+    unshare -Ur env LATX_AOT=0 LATX_KZT=0 LATX_TU="$mode" \
+        timeout -s KILL 10 "$emulator" \
+        "$workdir/prctl-x86-semantics" x
+    ret=$?
+    set -e
+    if [ "$ret" -ne 0 ]; then
+        echo "FAIL: $label privileged PR_SET_MM semantics returned $ret" >&2
+        exit "$ret"
+    fi
+    echo "PASS: $label privileged PR_SET_MM semantics"
+done

--- a/tests/integration/test-prctl-x86-privileged.sh
+++ b/tests/integration/test-prctl-x86-privileged.sh
@@ -23,23 +23,15 @@ fi
     -ffreestanding -fno-builtin -fno-stack-protector \
     -Wl,--build-id=none "$source_file" -o "$workdir/prctl-x86-semantics"
 
-for mode in 0 1; do
-    if [ "$mode" -eq 0 ]; then
-        label=non-tu
-    else
-        label=tu
-    fi
-    guest="$workdir/prctl-x86-semantics-$mode"
-    cp "$workdir/prctl-x86-semantics" "$guest"
-    set +e
-    unshare -Ur env LATX_AOT=0 LATX_KZT=0 LATX_TU="$mode" \
-        timeout -s KILL 10 "$emulator" \
-        "$guest" x "$guest"
-    ret=$?
-    set -e
-    if [ "$ret" -ne 0 ]; then
-        echo "FAIL: $label user-namespace PR_SET_MM semantics returned $ret" >&2
-        exit "$ret"
-    fi
-    echo "PASS: $label user-namespace PR_SET_MM semantics"
-done
+guest="$workdir/prctl-x86-semantics-privileged"
+cp "$workdir/prctl-x86-semantics" "$guest"
+set +e
+unshare -Ur env LATX_AOT=0 LATX_KZT=0 timeout -s KILL 10 \
+    "$emulator" "$guest" x "$guest"
+ret=$?
+set -e
+if [ "$ret" -ne 0 ]; then
+    echo "FAIL: user-namespace PR_SET_MM semantics returned $ret" >&2
+    exit "$ret"
+fi
+echo "PASS: user-namespace PR_SET_MM semantics"

--- a/tests/integration/test-prctl-x86-privileged.sh
+++ b/tests/integration/test-prctl-x86-privileged.sh
@@ -29,10 +29,12 @@ for mode in 0 1; do
     else
         label=tu
     fi
+    guest="$workdir/prctl-x86-semantics-$mode"
+    cp "$workdir/prctl-x86-semantics" "$guest"
     set +e
     unshare -Ur env LATX_AOT=0 LATX_KZT=0 LATX_TU="$mode" \
         timeout -s KILL 10 "$emulator" \
-        "$workdir/prctl-x86-semantics" x
+        "$guest" x "$guest"
     ret=$?
     set -e
     if [ "$ret" -ne 0 ]; then

--- a/tests/integration/test-prctl-x86-semantics.sh
+++ b/tests/integration/test-prctl-x86-semantics.sh
@@ -18,7 +18,7 @@ else
 fi
 
 "$clang" --target=x86_64-linux-gnu -fuse-ld=lld -nostdlib -static -no-pie \
-    -ffreestanding -fno-builtin -fno-stack-protector \
+    -O2 -ffreestanding -fno-builtin -fno-stack-protector \
     -Wl,--build-id=none "$source_file" -o "$workdir/prctl-x86-semantics"
 "${CC:-cc}" -O2 -Wall -Wextra "$native_helper_source" \
     -o "$workdir/prctl-native-env-helper"
@@ -51,7 +51,11 @@ run_case()
 }
 
 run_case p
-run_case v
+if [ "$(getconf PAGESIZE)" -gt 4096 ]; then
+    run_case v h
+else
+    run_case v
+fi
 run_case m
 run_case r
 run_case s

--- a/tests/integration/test-prctl-x86-semantics.sh
+++ b/tests/integration/test-prctl-x86-semantics.sh
@@ -61,4 +61,5 @@ for mode in 0 1; do
     run_case "$mode" "$label" f
     run_case "$mode" "$label" i
     run_case "$mode" "$label" e "$workdir/prctl-native-env-helper"
+    run_case "$mode" "$label" a "$workdir/prctl-native-env-helper"
 done

--- a/tests/integration/test-prctl-x86-semantics.sh
+++ b/tests/integration/test-prctl-x86-semantics.sh
@@ -3,6 +3,7 @@ set -eu
 
 emulator=$1
 source_file=$2
+native_helper_source=$3
 workdir=$(mktemp -d)
 trap 'rm -rf "$workdir"' EXIT HUP INT TERM
 
@@ -18,16 +19,19 @@ fi
 "$clang" --target=x86_64-linux-gnu -fuse-ld=lld -nostdlib -static -no-pie \
     -ffreestanding -fno-builtin -fno-stack-protector \
     -Wl,--build-id=none "$source_file" -o "$workdir/prctl-x86-semantics"
+"${CC:-cc}" -O2 -Wall -Wextra "$native_helper_source" \
+    -o "$workdir/prctl-native-env-helper"
 
 run_case()
 {
     mode=$1
     label=$2
     case_name=$3
+    shift 3
 
     set +e
     env LATX_AOT=0 LATX_KZT=0 LATX_TU="$mode" timeout -s KILL 10 \
-        "$emulator" "$workdir/prctl-x86-semantics" "$case_name"
+        "$emulator" "$workdir/prctl-x86-semantics" "$case_name" "$@"
     ret=$?
     set -e
 
@@ -56,4 +60,5 @@ for mode in 0 1; do
     run_case "$mode" "$label" s
     run_case "$mode" "$label" f
     run_case "$mode" "$label" i
+    run_case "$mode" "$label" e "$workdir/prctl-native-env-helper"
 done

--- a/tests/integration/test-prctl-x86-semantics.sh
+++ b/tests/integration/test-prctl-x86-semantics.sh
@@ -29,43 +29,34 @@ chmod +x "$workdir/relative/state-script"
 
 run_case()
 {
-    mode=$1
-    label=$2
-    case_name=$3
-    shift 3
+    case_name=$1
+    shift
 
     set +e
-    env LATX_AOT=0 LATX_KZT=0 LATX_TU="$mode" timeout -s KILL 10 \
+    env LATX_AOT=0 LATX_KZT=0 timeout -s KILL 10 \
         "$emulator" "$workdir/prctl-x86-semantics" "$case_name" "$@"
     ret=$?
     set -e
 
     if [ "$ret" -eq 0 ]; then
-        echo "PASS: $label $case_name prctl semantics"
+        echo "PASS: $case_name prctl semantics"
         return
     fi
     if [ "$ret" -eq 124 ]; then
-        echo "FAIL: $label $case_name prctl semantics timed out" >&2
+        echo "FAIL: $case_name prctl semantics timed out" >&2
     else
-        echo "FAIL: $label $case_name prctl semantics returned $ret" >&2
+        echo "FAIL: $case_name prctl semantics returned $ret" >&2
     fi
     exit "$ret"
 }
 
-for mode in 0 1; do
-    if [ "$mode" -eq 0 ]; then
-        label=non-tu
-    else
-        label=tu
-    fi
-    run_case "$mode" "$label" p
-    run_case "$mode" "$label" v
-    run_case "$mode" "$label" m
-    run_case "$mode" "$label" r
-    run_case "$mode" "$label" s
-    run_case "$mode" "$label" f
-    run_case "$mode" "$label" i
-    run_case "$mode" "$label" e "$workdir/prctl-native-env-helper"
-    run_case "$mode" "$label" a "$workdir/prctl-native-env-helper"
-    run_case "$mode" "$label" d "$workdir/relative"
-done
+run_case p
+run_case v
+run_case m
+run_case r
+run_case s
+run_case f
+run_case i
+run_case e "$workdir/prctl-native-env-helper"
+run_case a "$workdir/prctl-native-env-helper"
+run_case d "$workdir/relative"

--- a/tests/integration/test-prctl-x86-semantics.sh
+++ b/tests/integration/test-prctl-x86-semantics.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+set -eu
+
+emulator=$1
+source_file=$2
+workdir=$(mktemp -d)
+trap 'rm -rf "$workdir"' EXIT HUP INT TERM
+
+if command -v clang-19 >/dev/null 2>&1; then
+    clang=clang-19
+elif command -v clang >/dev/null 2>&1; then
+    clang=clang
+else
+    echo "SKIP: clang is required to build the x86_64 guest"
+    exit 77
+fi
+
+"$clang" --target=x86_64-linux-gnu -fuse-ld=lld -nostdlib -static -no-pie \
+    -ffreestanding -fno-builtin -fno-stack-protector \
+    -Wl,--build-id=none "$source_file" -o "$workdir/prctl-x86-semantics"
+
+run_case()
+{
+    mode=$1
+    label=$2
+    case_name=$3
+
+    set +e
+    env LATX_AOT=0 LATX_KZT=0 LATX_TU="$mode" timeout -s KILL 10 \
+        "$emulator" "$workdir/prctl-x86-semantics" "$case_name"
+    ret=$?
+    set -e
+
+    if [ "$ret" -eq 0 ]; then
+        echo "PASS: $label $case_name prctl semantics"
+        return
+    fi
+    if [ "$ret" -eq 124 ]; then
+        echo "FAIL: $label $case_name prctl semantics timed out" >&2
+    else
+        echo "FAIL: $label $case_name prctl semantics returned $ret" >&2
+    fi
+    exit "$ret"
+}
+
+for mode in 0 1; do
+    if [ "$mode" -eq 0 ]; then
+        label=non-tu
+    else
+        label=tu
+    fi
+    run_case "$mode" "$label" p
+    run_case "$mode" "$label" v
+    run_case "$mode" "$label" m
+    run_case "$mode" "$label" r
+    run_case "$mode" "$label" s
+    run_case "$mode" "$label" f
+    run_case "$mode" "$label" i
+done

--- a/tests/integration/test-prctl-x86-semantics.sh
+++ b/tests/integration/test-prctl-x86-semantics.sh
@@ -2,6 +2,7 @@
 set -eu
 
 emulator=$1
+emulator_path=$(realpath "$emulator")
 source_file=$2
 native_helper_source=$3
 workdir=$(mktemp -d)
@@ -21,6 +22,10 @@ fi
     -Wl,--build-id=none "$source_file" -o "$workdir/prctl-x86-semantics"
 "${CC:-cc}" -O2 -Wall -Wextra "$native_helper_source" \
     -o "$workdir/prctl-native-env-helper"
+mkdir "$workdir/relative"
+printf '#!%s %s\n' "$emulator_path" "$workdir/prctl-x86-semantics" \
+    >"$workdir/relative/state-script"
+chmod +x "$workdir/relative/state-script"
 
 run_case()
 {
@@ -62,4 +67,5 @@ for mode in 0 1; do
     run_case "$mode" "$label" i
     run_case "$mode" "$label" e "$workdir/prctl-native-env-helper"
     run_case "$mode" "$label" a "$workdir/prctl-native-env-helper"
+    run_case "$mode" "$label" d "$workdir/relative"
 done

--- a/tests/integration/test-syscall-user-dispatch.sh
+++ b/tests/integration/test-syscall-user-dispatch.sh
@@ -18,20 +18,17 @@ fi
 "$clang" --target=x86_64-linux-gnu -fuse-ld=lld -nostdlib -static \
     -Wl,--build-id=none "$source_file" -o "$workdir/syscall-user-dispatch"
 
-run_mode()
+run_test()
 {
-    mode=$1
-    label=$2
-
     set +e
-    LATX_AOT=0 LATX_KZT=0 LATX_TU="$mode" timeout -s KILL 10 \
+    LATX_AOT=0 LATX_KZT=0 timeout -s KILL 10 \
         "$emulator" "$workdir/syscall-user-dispatch"
     ret=$?
     set -e
 
     case $ret in
 0)
-    echo "PASS: $label syscall user dispatch delivered guest SIGSYS"
+    echo "PASS: syscall user dispatch delivered guest SIGSYS"
     ;;
 10)
     echo "FAIL: blocked guest syscall was executed" >&2
@@ -64,12 +61,11 @@ run_mode()
     echo "FAIL: guest syscall dispatch leaked into the host (SIGSYS)" >&2
     ;;
 *)
-    echo "FAIL: $label unexpected guest exit status $ret" >&2
+    echo "FAIL: unexpected guest exit status $ret" >&2
     ;;
     esac
 
     test "$ret" -eq 0
 }
 
-run_mode 0 non-tu
-run_mode 1 tu
+run_test

--- a/tests/integration/test-syscall-user-dispatch.sh
+++ b/tests/integration/test-syscall-user-dispatch.sh
@@ -18,15 +18,20 @@ fi
 "$clang" --target=x86_64-linux-gnu -fuse-ld=lld -nostdlib -static \
     -Wl,--build-id=none "$source_file" -o "$workdir/syscall-user-dispatch"
 
-set +e
-LATX_AOT=0 LATX_KZT=0 timeout -s KILL 10 \
-    "$emulator" "$workdir/syscall-user-dispatch"
-ret=$?
-set -e
+run_mode()
+{
+    mode=$1
+    label=$2
 
-case $ret in
+    set +e
+    LATX_AOT=0 LATX_KZT=0 LATX_TU="$mode" timeout -s KILL 10 \
+        "$emulator" "$workdir/syscall-user-dispatch"
+    ret=$?
+    set -e
+
+    case $ret in
 0)
-    echo "PASS: syscall user dispatch delivered guest SIGSYS"
+    echo "PASS: $label syscall user dispatch delivered guest SIGSYS"
     ;;
 10)
     echo "FAIL: blocked guest syscall was executed" >&2
@@ -43,6 +48,15 @@ case $ret in
 14)
     echo "FAIL: syscall user dispatch was inherited across fork" >&2
     ;;
+15)
+    echo "FAIL: syscall user dispatch parameter validation" >&2
+    ;;
+16)
+    echo "FAIL: syscall inside the allowed dispatch range was blocked" >&2
+    ;;
+17)
+    echo "FAIL: PR_SYS_DISPATCH_OFF did not disable dispatch" >&2
+    ;;
 124)
     echo "FAIL: syscall user dispatch test timed out" >&2
     ;;
@@ -50,8 +64,12 @@ case $ret in
     echo "FAIL: guest syscall dispatch leaked into the host (SIGSYS)" >&2
     ;;
 *)
-    echo "FAIL: unexpected guest exit status $ret" >&2
+    echo "FAIL: $label unexpected guest exit status $ret" >&2
     ;;
-esac
+    esac
 
-exit "$ret"
+    test "$ret" -eq 0
+}
+
+run_mode 0 non-tu
+run_mode 1 tu

--- a/tests/integration/test-syscall-user-dispatch.sh
+++ b/tests/integration/test-syscall-user-dispatch.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+set -eu
+
+emulator=$1
+source_file=$2
+workdir=$(mktemp -d)
+trap 'rm -rf "$workdir"' EXIT HUP INT TERM
+
+if command -v clang-19 >/dev/null 2>&1; then
+    clang=clang-19
+elif command -v clang >/dev/null 2>&1; then
+    clang=clang
+else
+    echo "SKIP: clang is required to build the x86_64 guest"
+    exit 77
+fi
+
+"$clang" --target=x86_64-linux-gnu -fuse-ld=lld -nostdlib -static \
+    -Wl,--build-id=none "$source_file" -o "$workdir/syscall-user-dispatch"
+
+set +e
+LATX_AOT=0 LATX_KZT=0 timeout -s KILL 10 \
+    "$emulator" "$workdir/syscall-user-dispatch"
+ret=$?
+set -e
+
+case $ret in
+0)
+    echo "PASS: syscall user dispatch delivered guest SIGSYS"
+    ;;
+10)
+    echo "FAIL: blocked guest syscall was executed" >&2
+    ;;
+11)
+    echo "FAIL: syscall user dispatch setup failed" >&2
+    ;;
+12)
+    echo "FAIL: guest SIGSYS metadata was invalid" >&2
+    ;;
+13)
+    echo "FAIL: unknown prctl was not rejected with EINVAL" >&2
+    ;;
+14)
+    echo "FAIL: syscall user dispatch was inherited across fork" >&2
+    ;;
+124)
+    echo "FAIL: syscall user dispatch test timed out" >&2
+    ;;
+159)
+    echo "FAIL: guest syscall dispatch leaked into the host (SIGSYS)" >&2
+    ;;
+*)
+    echo "FAIL: unexpected guest exit status $ret" >&2
+    ;;
+esac
+
+exit "$ret"


### PR DESCRIPTION
## Summary

Emulate x86 guest-visible `prctl` state in linux-user, preventing guest controls from changing the LoongArch translator process.

## Root cause

Wine 11.9 WoW64 enables syscall user dispatch with `PR_SET_SYSCALL_USER_DISPATCH`. The x86 guest request previously fell through to the generic `prctl` path and was passed to the host kernel. This enabled syscall user dispatch on LATX itself, so the host kernel delivered `SIGSYS` on a subsequent guest `rt_sigreturn`; the shell reported `x86_64-emu: Bad system call` and the Windows application never displayed its window.

## Changes

- Emulate x86 syscall user dispatch and construct guest `SIGSYS` metadata without enabling host syscall user dispatch.
- Model applicable x86 guest-visible `prctl` controls, including TSC mode, MDWE, `PR_SET_MM`, auxiliary-vector state, VMA names, timer-ID restore mode, private futex hash configuration and RSEQ slice extension.
- Preserve the required state and reset rules across threads, fork and exec.
- Integrate the model with mmap, mprotect, mremap, shared memory, POSIX timers and guest `/proc` views.
- Translate pointer-bearing operations, keep target-neutral host operations on the generic path, and reject unsupported commands instead of passing them through.
- Add freestanding x86_64 and i386 regression coverage for syscall dispatch, ABI behavior, host-state leakage and cross-subsystem interactions.

## Validation

- Deterministic regression terminates the translator with host `SIGSYS` before the fix and exits successfully after the fix.
- The focused x86_64 and i386 prctl, SUD/seccomp, exec/execveat, mremap, process_vm and CEF userns regressions pass.
- `lat-pr-fast`: 18/18 passed.
- Optimized x86_64 and i386 builds pass; a paired 100,000,000-iteration RDTSC benchmark found no measurable regression.
- Exact `wine-11.9 (Staging)` completes fresh-prefix `wineboot` without terminal `SIGSYS`.
- Windows Steam starts its CEF network, storage and renderer processes and creates the CEF client UI surface under default launch arguments without terminal `SIGSYS`.
- Final GitHub gate: DCO, 15 build jobs, three LATU jobs and `lat-pr-fast` all passed (20/20, no failures or skips).
