### PR TITLE
LATX, docs: Improve README presentation

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -37,18 +37,20 @@ LATX 感谢每一位贡献者。项目经历了两个发展阶段：2021 年至 
 
 开源后的完整贡献记录以提交历史和
 [GitHub Contributors](https://github.com/lat-opensource/lat/graphs/contributors)
-页面为准。特别感谢以下社区贡献者，排名不分先后：
+页面为准。请注意：该页面的统计包含本项目保留的 QEMU 上游历史提交，其中的
+提交次数不代表对 LATX 本身的贡献量。特别感谢以下社区贡献者，按开源后的
+活跃程度排序：
 
-- <a href="https://github.com/sunhaiyong1978"><img src="https://github.com/sunhaiyong1978.png?size=32" width="32" alt="@sunhaiyong1978"></a> **[Sun Haiyong](https://github.com/sunhaiyong1978)**
 - <a href="https://github.com/NiuGenen"><img src="https://github.com/NiuGenen.png?size=32" width="32" alt="@NiuGenen"></a> **[NiuGenen](https://github.com/NiuGenen)**
 - <a href="https://github.com/xiezyang"><img src="https://github.com/xiezyang.png?size=32" width="32" alt="@xiezyang"></a> **[Zhaoyang Xie](https://github.com/xiezyang)**
 - <a href="https://github.com/xiangzhai"><img src="https://github.com/xiangzhai.png?size=32" width="32" alt="@xiangzhai"></a> **[Leslie Zhai](https://github.com/xiangzhai)**
+- <a href="https://github.com/sunhaiyong1978"><img src="https://github.com/sunhaiyong1978.png?size=32" width="32" alt="@sunhaiyong1978"></a> **[Sun Haiyong](https://github.com/sunhaiyong1978)**
+- <a href="https://github.com/baibaidashixiong"><img src="https://github.com/baibaidashixiong.png?size=32" width="32" alt="@baibaidashixiong"></a> **[zqz](https://github.com/baibaidashixiong)**
 - <a href="https://github.com/zhaodongru"><img src="https://github.com/zhaodongru.png?size=32" width="32" alt="@zhaodongru"></a> **[Dongru Zhao](https://github.com/zhaodongru)**
 - <a href="https://github.com/phorcys"><img src="https://github.com/phorcys.png?size=32" width="32" alt="@phorcys"></a> **[phorcys](https://github.com/phorcys)**
-- <a href="https://github.com/ksco"><img src="https://github.com/ksco.png?size=32" width="32" alt="@ksco"></a> **[Yang Liu](https://github.com/ksco)**
-- <a href="https://github.com/Mikura-Kyouka"><img src="https://github.com/Mikura-Kyouka.png?size=32" width="32" alt="@Mikura-Kyouka"></a> **[Mikura Kyouka](https://github.com/Mikura-Kyouka)**
-- <a href="https://github.com/baibaidashixiong"><img src="https://github.com/baibaidashixiong.png?size=32" width="32" alt="@baibaidashixiong"></a> **[zqz](https://github.com/baibaidashixiong)**
 - <a href="https://github.com/wojiushixiaobai"><img src="https://github.com/wojiushixiaobai.png?size=32" width="32" alt="@wojiushixiaobai"></a> **[吴小白](https://github.com/wojiushixiaobai)**
+- <a href="https://github.com/Mikura-Kyouka"><img src="https://github.com/Mikura-Kyouka.png?size=32" width="32" alt="@Mikura-Kyouka"></a> **[Mikura Kyouka](https://github.com/Mikura-Kyouka)**
+- <a href="https://github.com/ksco"><img src="https://github.com/ksco.png?size=32" width="32" alt="@ksco"></a> **[Yang Liu](https://github.com/ksco)**
 
 以及所有通过 Issue 反馈、文档改进、版本测试参与项目的伙伴。
 
@@ -97,19 +99,21 @@ community management, workflow automation, and release testing.
 The complete post-open-source contribution record is tracked by the
 commit history and the
 [GitHub Contributors](https://github.com/lat-opensource/lat/graphs/contributors)
-page. Special thanks to the following community contributors, in no
-particular order:
+page. Note that this page's statistics include the upstream QEMU commit
+history retained by this repository, so its commit counts do not reflect
+contributions to LATX itself. Special thanks to the following community
+contributors, ordered by post-open-source activity:
 
-- <a href="https://github.com/sunhaiyong1978"><img src="https://github.com/sunhaiyong1978.png?size=32" width="32" alt="@sunhaiyong1978"></a> **[Sun Haiyong](https://github.com/sunhaiyong1978)**
 - <a href="https://github.com/NiuGenen"><img src="https://github.com/NiuGenen.png?size=32" width="32" alt="@NiuGenen"></a> **[NiuGenen](https://github.com/NiuGenen)**
 - <a href="https://github.com/xiezyang"><img src="https://github.com/xiezyang.png?size=32" width="32" alt="@xiezyang"></a> **[Zhaoyang Xie](https://github.com/xiezyang)**
 - <a href="https://github.com/xiangzhai"><img src="https://github.com/xiangzhai.png?size=32" width="32" alt="@xiangzhai"></a> **[Leslie Zhai](https://github.com/xiangzhai)**
+- <a href="https://github.com/sunhaiyong1978"><img src="https://github.com/sunhaiyong1978.png?size=32" width="32" alt="@sunhaiyong1978"></a> **[Sun Haiyong](https://github.com/sunhaiyong1978)**
+- <a href="https://github.com/baibaidashixiong"><img src="https://github.com/baibaidashixiong.png?size=32" width="32" alt="@baibaidashixiong"></a> **[zqz](https://github.com/baibaidashixiong)**
 - <a href="https://github.com/zhaodongru"><img src="https://github.com/zhaodongru.png?size=32" width="32" alt="@zhaodongru"></a> **[Dongru Zhao](https://github.com/zhaodongru)**
 - <a href="https://github.com/phorcys"><img src="https://github.com/phorcys.png?size=32" width="32" alt="@phorcys"></a> **[phorcys](https://github.com/phorcys)**
-- <a href="https://github.com/ksco"><img src="https://github.com/ksco.png?size=32" width="32" alt="@ksco"></a> **[Yang Liu](https://github.com/ksco)**
-- <a href="https://github.com/Mikura-Kyouka"><img src="https://github.com/Mikura-Kyouka.png?size=32" width="32" alt="@Mikura-Kyouka"></a> **[Mikura Kyouka](https://github.com/Mikura-Kyouka)**
-- <a href="https://github.com/baibaidashixiong"><img src="https://github.com/baibaidashixiong.png?size=32" width="32" alt="@baibaidashixiong"></a> **[zqz](https://github.com/baibaidashixiong)**
 - <a href="https://github.com/wojiushixiaobai"><img src="https://github.com/wojiushixiaobai.png?size=32" width="32" alt="@wojiushixiaobai"></a> **[吴小白](https://github.com/wojiushixiaobai)**
+- <a href="https://github.com/Mikura-Kyouka"><img src="https://github.com/Mikura-Kyouka.png?size=32" width="32" alt="@Mikura-Kyouka"></a> **[Mikura Kyouka](https://github.com/Mikura-Kyouka)**
+- <a href="https://github.com/ksco"><img src="https://github.com/ksco.png?size=32" width="32" alt="@ksco"></a> **[Yang Liu](https://github.com/ksco)**
 
 And everyone who participated through issue reports, documentation
 improvements, and release testing.

--- a/README.en.rst
+++ b/README.en.rst
@@ -109,7 +109,12 @@ Use the command for the host distribution. The lists also include ``file``,
 Meson version of at least 0.55.3 when available. Otherwise, it uses the Meson
 submodule fetched by ``--recursive``. Python 3.6 or newer is required.
 
-Debian / Ubuntu:
+Expand the entry for the host distribution:
+
+.. raw:: html
+
+   <details>
+   <summary>Debian / Ubuntu</summary>
 
 .. code-block:: bash
 
@@ -117,14 +122,22 @@ Debian / Ubuntu:
         pkg-config libglib2.0-dev libdrm-dev lsb-release make python3 \
         python3-setuptools binutils file tar wget xz-utils zstd
 
-Arch Linux:
+.. raw:: html
+
+   </details>
+   <details>
+   <summary>Arch Linux</summary>
 
 .. code-block:: bash
 
     sudo pacman -S --needed git make meson ninja gcc pkgconf glib2 python \
         python-setuptools openssl binutils file tar wget xz zstd
 
-AOSC OS:
+.. raw:: html
+
+   </details>
+   <details>
+   <summary>AOSC OS</summary>
 
 .. code-block:: bash
 
@@ -133,12 +146,20 @@ AOSC OS:
         pcre-static zlib-static zstd-static openssl-static pkg-config ninja \
         binutils file tar wget xz zstd
 
-Fedora:
+.. raw:: html
+
+   </details>
+   <details>
+   <summary>Fedora</summary>
 
 .. code-block:: bash
 
     sudo dnf install gcc gcc-c++ make git ninja-build meson openssl-devel \
         glib2-devel binutils file tar wget xz zstd
+
+.. raw:: html
+
+   </details>
 
 Check the basic tools before building:
 
@@ -280,7 +301,39 @@ Every commit must include a DCO ``Signed-off-by`` trailer.
 Contributors
 ============
 
-|contrib-luzeng| |contrib-hanlu| |contrib-wenqiang| |contrib-jing| |contrib-qi| |contrib-chaoyi| |contrib-rengan| |contrib-xiaotian| |contrib-haiyong| |contrib-niugenen|
+.. raw:: html
+
+   <table>
+     <tr>
+       <td align="center" colspan="8"><b>Internal development phase (2021–2024)</b></td>
+     </tr>
+     <tr>
+       <td align="center"><a href="https://github.com/luzeng87"><img src="https://github.com/luzeng87.png?size=64" width="64" height="64" alt="Lu Zeng"><br><sub><b>Lu Zeng</b></sub></a></td>
+       <td align="center"><a href="https://github.com/LaurenIsACoder"><img src="https://github.com/LaurenIsACoder.png?size=64" width="64" height="64" alt="Hanlu Li"><br><sub><b>Hanlu Li</b></sub></a></td>
+       <td align="center"><a href="https://github.com/ganjue66da"><img src="https://github.com/ganjue66da.png?size=64" width="64" height="64" alt="Wenqiang Wei"><br><sub><b>Wenqiang Wei</b></sub></a></td>
+       <td align="center"><a href="https://github.com/JonLeeTaoShan"><img src="https://github.com/JonLeeTaoShan.png?size=64" width="64" height="64" alt="Jing Li"><br><sub><b>Jing Li</b></sub></a></td>
+       <td align="center"><a href="https://github.com/specialpointcentral"><img src="https://github.com/specialpointcentral.png?size=64" width="64" height="64" alt="Qi Hu"><br><sub><b>Qi Hu</b></sub></a></td>
+       <td align="center"><a href="https://github.com/rmjskhy"><img src="https://github.com/rmjskhy.png?size=64" width="64" height="64" alt="Chaoyi Liu"><br><sub><b>Chaoyi Liu</b></sub></a></td>
+       <td align="center"><a href="https://github.com/y347812075"><img src="https://github.com/y347812075.png?size=64" width="64" height="64" alt="Rengan Yue"><br><sub><b>Rengan Yue</b></sub></a></td>
+       <td align="center"><a href="https://github.com/yetist"><img src="https://github.com/yetist.png?size=64" width="64" height="64" alt="Xiaotian Wu"><br><sub><b>Xiaotian Wu</b></sub></a></td>
+     </tr>
+     <tr>
+       <td align="center" colspan="8"><b>Open-source community (2025–)</b></td>
+     </tr>
+     <tr>
+       <td align="center"><a href="https://github.com/NiuGenen"><img src="https://github.com/NiuGenen.png?size=64" width="64" height="64" alt="NiuGenen"><br><sub><b>NiuGenen</b></sub></a></td>
+       <td align="center"><a href="https://github.com/xiezyang"><img src="https://github.com/xiezyang.png?size=64" width="64" height="64" alt="Zhaoyang Xie"><br><sub><b>Zhaoyang Xie</b></sub></a></td>
+       <td align="center"><a href="https://github.com/xiangzhai"><img src="https://github.com/xiangzhai.png?size=64" width="64" height="64" alt="Leslie Zhai"><br><sub><b>Leslie Zhai</b></sub></a></td>
+       <td align="center"><a href="https://github.com/sunhaiyong1978"><img src="https://github.com/sunhaiyong1978.png?size=64" width="64" height="64" alt="Sun Haiyong"><br><sub><b>Sun Haiyong</b></sub></a></td>
+       <td align="center"><a href="https://github.com/baibaidashixiong"><img src="https://github.com/baibaidashixiong.png?size=64" width="64" height="64" alt="zqz"><br><sub><b>zqz</b></sub></a></td>
+       <td align="center"><a href="https://github.com/zhaodongru"><img src="https://github.com/zhaodongru.png?size=64" width="64" height="64" alt="Dongru Zhao"><br><sub><b>Dongru Zhao</b></sub></a></td>
+       <td align="center"><a href="https://github.com/phorcys"><img src="https://github.com/phorcys.png?size=64" width="64" height="64" alt="phorcys"><br><sub><b>phorcys</b></sub></a></td>
+       <td align="center"><a href="https://github.com/wojiushixiaobai"><img src="https://github.com/wojiushixiaobai.png?size=64" width="64" height="64" alt="wojiushixiaobai"><br><sub><b>wojiushixiaobai</b></sub></a></td>
+     </tr>
+   </table>
+
+The avatars above show a subset of contributors; the order is for
+presentation only and implies no contribution ranking.
 
 LATX thanks every contributor. See `CONTRIBUTORS.md <CONTRIBUTORS.md>`_
 for contributors of each development phase and their contribution areas,
@@ -311,34 +364,3 @@ If you have any questions or suggestions, please feel free to engage with us thr
 
 .. _build, installation, and runtime Wiki guide: https://github.com/lat-opensource/lat/wiki/%E7%BC%96%E8%AF%91%E4%B8%8E%E8%BF%90%E8%A1%8C
 .. _Troubleshooting guide: https://github.com/lat-opensource/lat/wiki/%E8%B0%83%E8%AF%95%E4%B8%8E%E9%97%AE%E9%A2%98%E5%AE%9A%E4%BD%8D%E6%8C%87%E5%8D%97
-
-.. |contrib-luzeng| image:: https://github.com/luzeng87.png?size=64
-   :target: https://github.com/luzeng87
-   :alt: Lu Zeng
-.. |contrib-hanlu| image:: https://github.com/LaurenIsACoder.png?size=64
-   :target: https://github.com/LaurenIsACoder
-   :alt: Hanlu Li
-.. |contrib-wenqiang| image:: https://github.com/ganjue66da.png?size=64
-   :target: https://github.com/ganjue66da
-   :alt: Wenqiang Wei
-.. |contrib-jing| image:: https://github.com/JonLeeTaoShan.png?size=64
-   :target: https://github.com/JonLeeTaoShan
-   :alt: Jing Li
-.. |contrib-qi| image:: https://github.com/specialpointcentral.png?size=64
-   :target: https://github.com/specialpointcentral
-   :alt: Qi Hu
-.. |contrib-chaoyi| image:: https://github.com/rmjskhy.png?size=64
-   :target: https://github.com/rmjskhy
-   :alt: Chaoyi Liu
-.. |contrib-rengan| image:: https://github.com/y347812075.png?size=64
-   :target: https://github.com/y347812075
-   :alt: Rengan Yue
-.. |contrib-xiaotian| image:: https://github.com/yetist.png?size=64
-   :target: https://github.com/yetist
-   :alt: Xiaotian Wu
-.. |contrib-haiyong| image:: https://github.com/sunhaiyong1978.png?size=64
-   :target: https://github.com/sunhaiyong1978
-   :alt: Sun Haiyong
-.. |contrib-niugenen| image:: https://github.com/NiuGenen.png?size=64
-   :target: https://github.com/NiuGenen
-   :alt: NiuGenen

--- a/README.rst
+++ b/README.rst
@@ -95,7 +95,12 @@ sysctl 配置立即生效：
 不可用或版本过低时，会使用 ``--recursive`` 获取的 Meson 子模块。Python 版本
 必须不低于 3.6。
 
-Debian / Ubuntu：
+各发行版的依赖命令如下，点击展开对应的发行版：
+
+.. raw:: html
+
+   <details>
+   <summary>Debian / Ubuntu</summary>
 
 .. code-block:: bash
 
@@ -103,14 +108,22 @@ Debian / Ubuntu：
         pkg-config libglib2.0-dev libdrm-dev lsb-release make python3 \
         python3-setuptools binutils file tar wget xz-utils zstd
 
-Arch Linux：
+.. raw:: html
+
+   </details>
+   <details>
+   <summary>Arch Linux</summary>
 
 .. code-block:: bash
 
     sudo pacman -S --needed git make meson ninja gcc pkgconf glib2 python \
         python-setuptools openssl binutils file tar wget xz zstd
 
-安同 OS（AOSC OS）：
+.. raw:: html
+
+   </details>
+   <details>
+   <summary>安同 OS（AOSC OS）</summary>
 
 .. code-block:: bash
 
@@ -119,12 +132,20 @@ Arch Linux：
         pcre-static zlib-static zstd-static openssl-static pkg-config ninja \
         binutils file tar wget xz zstd
 
-Fedora：
+.. raw:: html
+
+   </details>
+   <details>
+   <summary>Fedora</summary>
 
 .. code-block:: bash
 
     sudo dnf install gcc gcc-c++ make git ninja-build meson openssl-devel \
         glib2-devel binutils file tar wget xz zstd
+
+.. raw:: html
+
+   </details>
 
 可以在构建前检查基础工具：
 
@@ -249,7 +270,38 @@ guest 运行期间热切换。
 贡献者
 ======
 
-|contrib-luzeng| |contrib-hanlu| |contrib-wenqiang| |contrib-jing| |contrib-qi| |contrib-chaoyi| |contrib-rengan| |contrib-xiaotian| |contrib-haiyong| |contrib-niugenen|
+.. raw:: html
+
+   <table>
+     <tr>
+       <td align="center" colspan="8"><b>内部开发阶段（2021–2024）</b></td>
+     </tr>
+     <tr>
+       <td align="center"><a href="https://github.com/luzeng87"><img src="https://github.com/luzeng87.png?size=64" width="64" height="64" alt="Lu Zeng"><br><sub><b>Lu Zeng</b></sub></a></td>
+       <td align="center"><a href="https://github.com/LaurenIsACoder"><img src="https://github.com/LaurenIsACoder.png?size=64" width="64" height="64" alt="Hanlu Li"><br><sub><b>Hanlu Li</b></sub></a></td>
+       <td align="center"><a href="https://github.com/ganjue66da"><img src="https://github.com/ganjue66da.png?size=64" width="64" height="64" alt="Wenqiang Wei"><br><sub><b>Wenqiang Wei</b></sub></a></td>
+       <td align="center"><a href="https://github.com/JonLeeTaoShan"><img src="https://github.com/JonLeeTaoShan.png?size=64" width="64" height="64" alt="Jing Li"><br><sub><b>Jing Li</b></sub></a></td>
+       <td align="center"><a href="https://github.com/specialpointcentral"><img src="https://github.com/specialpointcentral.png?size=64" width="64" height="64" alt="Qi Hu"><br><sub><b>Qi Hu</b></sub></a></td>
+       <td align="center"><a href="https://github.com/rmjskhy"><img src="https://github.com/rmjskhy.png?size=64" width="64" height="64" alt="Chaoyi Liu"><br><sub><b>Chaoyi Liu</b></sub></a></td>
+       <td align="center"><a href="https://github.com/y347812075"><img src="https://github.com/y347812075.png?size=64" width="64" height="64" alt="Rengan Yue"><br><sub><b>Rengan Yue</b></sub></a></td>
+       <td align="center"><a href="https://github.com/yetist"><img src="https://github.com/yetist.png?size=64" width="64" height="64" alt="Xiaotian Wu"><br><sub><b>Xiaotian Wu</b></sub></a></td>
+     </tr>
+     <tr>
+       <td align="center" colspan="8"><b>开源社区（2025–）</b></td>
+     </tr>
+     <tr>
+       <td align="center"><a href="https://github.com/NiuGenen"><img src="https://github.com/NiuGenen.png?size=64" width="64" height="64" alt="NiuGenen"><br><sub><b>NiuGenen</b></sub></a></td>
+       <td align="center"><a href="https://github.com/xiezyang"><img src="https://github.com/xiezyang.png?size=64" width="64" height="64" alt="Zhaoyang Xie"><br><sub><b>Zhaoyang Xie</b></sub></a></td>
+       <td align="center"><a href="https://github.com/xiangzhai"><img src="https://github.com/xiangzhai.png?size=64" width="64" height="64" alt="Leslie Zhai"><br><sub><b>Leslie Zhai</b></sub></a></td>
+       <td align="center"><a href="https://github.com/sunhaiyong1978"><img src="https://github.com/sunhaiyong1978.png?size=64" width="64" height="64" alt="Sun Haiyong"><br><sub><b>Sun Haiyong</b></sub></a></td>
+       <td align="center"><a href="https://github.com/baibaidashixiong"><img src="https://github.com/baibaidashixiong.png?size=64" width="64" height="64" alt="zqz"><br><sub><b>zqz</b></sub></a></td>
+       <td align="center"><a href="https://github.com/zhaodongru"><img src="https://github.com/zhaodongru.png?size=64" width="64" height="64" alt="Dongru Zhao"><br><sub><b>Dongru Zhao</b></sub></a></td>
+       <td align="center"><a href="https://github.com/phorcys"><img src="https://github.com/phorcys.png?size=64" width="64" height="64" alt="phorcys"><br><sub><b>phorcys</b></sub></a></td>
+       <td align="center"><a href="https://github.com/wojiushixiaobai"><img src="https://github.com/wojiushixiaobai.png?size=64" width="64" height="64" alt="wojiushixiaobai"><br><sub><b>wojiushixiaobai</b></sub></a></td>
+     </tr>
+   </table>
+
+以上为部分贡献者，头像顺序仅用于展示，不表示贡献排名。
 
 LATX 感谢每一位贡献者。各阶段贡献者与贡献领域说明见
 `CONTRIBUTORS.md <CONTRIBUTORS.md>`_，开源后的贡献记录见
@@ -278,34 +330,3 @@ LATX 感谢每一位贡献者。各阶段贡献者与贡献领域说明见
 
 .. _编译、安装和运行 Wiki: https://github.com/lat-opensource/lat/wiki/%E7%BC%96%E8%AF%91%E4%B8%8E%E8%BF%90%E8%A1%8C
 .. _调试与问题定位指南: https://github.com/lat-opensource/lat/wiki/%E8%B0%83%E8%AF%95%E4%B8%8E%E9%97%AE%E9%A2%98%E5%AE%9A%E4%BD%8D%E6%8C%87%E5%8D%97
-
-.. |contrib-luzeng| image:: https://github.com/luzeng87.png?size=64
-   :target: https://github.com/luzeng87
-   :alt: Lu Zeng
-.. |contrib-hanlu| image:: https://github.com/LaurenIsACoder.png?size=64
-   :target: https://github.com/LaurenIsACoder
-   :alt: Hanlu Li
-.. |contrib-wenqiang| image:: https://github.com/ganjue66da.png?size=64
-   :target: https://github.com/ganjue66da
-   :alt: Wenqiang Wei
-.. |contrib-jing| image:: https://github.com/JonLeeTaoShan.png?size=64
-   :target: https://github.com/JonLeeTaoShan
-   :alt: Jing Li
-.. |contrib-qi| image:: https://github.com/specialpointcentral.png?size=64
-   :target: https://github.com/specialpointcentral
-   :alt: Qi Hu
-.. |contrib-chaoyi| image:: https://github.com/rmjskhy.png?size=64
-   :target: https://github.com/rmjskhy
-   :alt: Chaoyi Liu
-.. |contrib-rengan| image:: https://github.com/y347812075.png?size=64
-   :target: https://github.com/y347812075
-   :alt: Rengan Yue
-.. |contrib-xiaotian| image:: https://github.com/yetist.png?size=64
-   :target: https://github.com/yetist
-   :alt: Xiaotian Wu
-.. |contrib-haiyong| image:: https://github.com/sunhaiyong1978.png?size=64
-   :target: https://github.com/sunhaiyong1978
-   :alt: Sun Haiyong
-.. |contrib-niugenen| image:: https://github.com/NiuGenen.png?size=64
-   :target: https://github.com/NiuGenen
-   :alt: NiuGenen


### PR DESCRIPTION
## What changed

- Render the closing section of `README.rst` and `README.en.rst` in a compact phase-grouped table layout, with a note that the page shows a subset and implies no ranking, plus a clarification that GitHub contributor statistics include the retained upstream QEMU history.
- Collapse per-distribution build dependency commands into expandable `<details>` sections to shorten the README reading path.

## Validation

- `git diff --check origin/master`
- `rst2html --strict README.rst`
- `rst2html --strict README.en.rst`
- Local HTML preview of both READMEs and `CONTRIBUTORS.md`.