### PR TITLE
LATX: forward SCTP peeloff requests

### DIFF
--- a/linux-user/qemu.h
+++ b/linux-user/qemu.h
@@ -143,7 +143,8 @@ typedef struct TaskState {
     struct emulated_sigtable sigtab[TARGET_NSIG];
     /* This thread's signal mask, as requested by the guest program.
      * The actual signal mask of this thread may differ:
-     *  + we don't let SIGSEGV and SIGBUS be blocked while running guest code
+     *  + we don't let internal synchronous signals be blocked while running
+     *    guest code
      *  + sometimes we block all signals to avoid races
      */
     sigset_t signal_mask;

--- a/linux-user/signal.c
+++ b/linux-user/signal.c
@@ -1240,10 +1240,10 @@ static void host_signal_handler(int host_signum, siginfo_t *info,
     ts->signal_pending = 1;
 
     /* Block host signals until target signal handler entered. We
-     * can't block SIGSEGV or SIGBUS while we're executing guest
-     * code in case the guest code provokes one in the window between
-     * now and it getting out to the main loop. Signals will be
-     * unblocked again in process_pending_signals().
+     * can't block the synchronous signals used internally while we're
+     * executing guest code, in case the guest code provokes one in the
+     * window between now and it getting out to the main loop. Signals
+     * will be unblocked again in process_pending_signals().
      *
      * WARNING: we cannot use sigfillset() here because the uc_sigmask
      * field is a kernel sigset_t, which is much smaller than the
@@ -1259,10 +1259,12 @@ static void host_signal_handler(int host_signum, siginfo_t *info,
     memset(puc_sigmask, 0xff, SIGSET_T_SIZE);
     sigdelset(puc_sigmask, SIGSEGV);
     sigdelset(puc_sigmask, SIGBUS);
+    sigdelset(puc_sigmask, SIGILL);
 #else
     memset(&uc->uc_sigmask, 0xff, SIGSET_T_SIZE);
     sigdelset(&uc->uc_sigmask, SIGSEGV);
     sigdelset(&uc->uc_sigmask, SIGBUS);
+    sigdelset(&uc->uc_sigmask, SIGILL);
 #endif
 
     /* interrupt the virtual CPU as soon as possible */
@@ -1612,6 +1614,7 @@ void process_pending_signals(CPUArchState *cpu_env)
         set = ts->signal_mask;
         sigdelset(&set, SIGSEGV);
         sigdelset(&set, SIGBUS);
+        sigdelset(&set, SIGILL);
         sigprocmask(SIG_SETMASK, &set, 0);
     }
     ts->in_sigsuspend = 0;

--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -3270,6 +3270,11 @@ set_timeout:
 static abi_long do_getsockopt(int sockfd, int level, int optname,
                               abi_ulong optval_addr, abi_ulong optlen)
 {
+    struct target_sctp_peeloff_arg {
+        uint32_t associd;
+        int32_t sd;
+    } *target_peeloff;
+    sctp_peeloff_arg_t peeloff;
     abi_long ret;
     int len, val;
     socklen_t lv;
@@ -3713,12 +3718,41 @@ get_timeout:
         break;
 #endif /* SOL_NETLINK */
     case IPPROTO_SCTP:
+        if (get_user_u32(len, optlen)) {
+            return -TARGET_EFAULT;
+        }
+
+        if (optname == SCTP_SOCKOPT_PEELOFF) {
+            if (len < sizeof(*target_peeloff)) {
+                return -TARGET_EINVAL;
+            }
+            target_peeloff = lock_user(VERIFY_WRITE, optval_addr,
+                                       sizeof(*target_peeloff), 1);
+            if (!target_peeloff) {
+                return -TARGET_EFAULT;
+            }
+            peeloff.associd = tswap32(target_peeloff->associd);
+            peeloff.sd = tswap32(target_peeloff->sd);
+            lv = sizeof(peeloff);
+            ret = get_errno(getsockopt(sockfd, level, optname, &peeloff, &lv));
+            if (ret < 0) {
+                unlock_user(target_peeloff, optval_addr, 0);
+                return ret;
+            }
+            target_peeloff->associd = tswap32(peeloff.associd);
+            target_peeloff->sd = tswap32(peeloff.sd);
+            unlock_user(target_peeloff, optval_addr,
+                        sizeof(*target_peeloff));
+            if (put_user_u32(lv, optlen)) {
+                close(peeloff.sd);
+                return -TARGET_EFAULT;
+            }
+            break;
+        }
+
         if (optname != SCTP_GET_LOCAL_ADDRS &&
             optname != SCTP_GET_PEER_ADDRS) {
             goto unimplemented;
-        }
-        if (get_user_u32(len, optlen)) {
-            return -TARGET_EFAULT;
         }
         if (len < sizeof(struct sctp_getaddrs)) {
             return -TARGET_EINVAL;


### PR DESCRIPTION
## Summary / 变更说明

<!-- What does this change do and why? / 这项变更做了什么，为什么需要？ -->

1. 保持宿主机 `SIGILL` 信号处于未屏蔽状态。

   LATX 使用宿主机 `SIGILL` 离开带有快速跳转缓存失效标记的翻译代码块。此前 guest 信号处理可能同时屏蔽宿主机 `SIGILL`，导致执行失效标记时进程直接退出，LATX 信号处理函数无法接管。

   修改后，宿主机 `SIGILL` 在执行 guest 代码及进入 guest 信号处理函数时保持未屏蔽。Guest 自身的信号屏蔽状态仍单独记录，不会改变 guest 程序看到的信号行为。

2. 转发 SCTP peeloff 请求。

   `SctpMultiChannel.branch()` 使用
   `getsockopt(IPPROTO_SCTP, SCTP_SOCKOPT_PEELOFF, ...)` 将一个 SCTP
   关联拆分成独立套接字。此前 LATX 未处理该选项，直接返回
   `EOPNOTSUPP`，导致 Java 抛出 `SocketException: Operation not supported`。

   修改后，LATX 会逐字段转换 peeloff 参数，将请求转发给宿主内核，并将
   新文件描述符和结果长度返回给 guest。如果结果复制失败，会关闭新文件
   描述符，避免资源泄漏。

## Validation / 验证

运行 com/sun/nio/sctp/SctpMultiChannel/Branch.java：
修复前父节点失败：
Passed = 11, failed = 1，失败位置为 Branch.java:122。
修复后连续运行 3 次，全部得到：
Passed = 19, failed = 0。

## Checklist / 检查项

- [ ] I have read `CONTRIBUTING.md`. / 我已阅读 `CONTRIBUTING.md`。
- [ ] Every commit contains a DCO sign-off (`git commit -s`). /
      每个提交都包含 DCO 签署（`git commit -s`）。
- [ ] I have included relevant build or test results, or explained why they
      are not applicable. /
      我已提供相关构建或测试结果，或说明了不适用的原因。
