### PR TITLE
LATX, fix: Clear zero absolute LEA destinations

### DIFF
--- a/target/i386/latx/translator/mem-interface.c
+++ b/target/i386/latx/translator/mem-interface.c
@@ -463,7 +463,7 @@ imm_cache_exit:
     case 0:
         ra_free_temp_auto(dest_op);
         dest_op = zero_ir2_opnd;
-        if (!has_seg) {
+        if (!has_seg && !arg_dest_op) {
             return dest_op;
         }
         break;
@@ -550,12 +550,8 @@ skip:
         }
         dest_op = seg_op;
     } else if (!bitmap) {
-        /* no base, no index, no seg, no offset */
-#ifndef CONFIG_LATX_TU
-        lsassert(ir1_opnd_simm(opnd1));
-#else
-        /* fprintf(stderr, "maybe have bug in convert_mem_helper()\n"); */
-#endif
+        /* Only a specific-register conversion, such as LEA, reaches here. */
+        lsassert(arg_dest_op);
     }
 
     addr_size = ir1_addr_size(pir1);


### PR DESCRIPTION
While looking into #373, I found a concrete i386 LEA translation bug on current master.

`convert_mem_helper()` returned `zero_ir2_opnd` immediately for an address with no base, index, segment, or displacement. That works for callers that consume the returned operand, but `convert_mem_to_specific_gpr()` passes a destination register and discards the return value. For `lea edi,[0]`, EDI was therefore left unchanged. In apt this stale value corrupted the following TLS address calculation and caused a SIGSEGV.

This change keeps the existing early return for ordinary address conversion, but lets the specific-register path continue through `adjust_dest()` so the zero is actually written. The old assertion is replaced with one that documents this path.

Validation:

- focused `lea edi,[0]` check: exit 1 with the fix hunk reversed, exit 0 with it restored
- i386 `apt-get --version`: exit 0 with `LATX_AOT=0 LATX_TU=0`
- i386 `apt-get --version`: exit 0 with default translation settings
- i386 translator build: pass

Every guest run invoked `latx-i386` explicitly. The binfmt registration was not used or modified, and the tested apt command did not enter guest fork/exec paths.

The reproduced symptom was a deterministic SIGSEGV, not the timeout reported in #373, so this PR is related to that investigation but does not close the issue by itself. The original reproducer still needs to be retested.
