### PR TITLE
LATX: fix XCB Render wrapper signatures

### DIFF
--- a/target/i386/latx/context/wrapper.c
+++ b/target/i386/latx/context/wrapper.c
@@ -1437,12 +1437,11 @@ typedef void (*vFpC_t)(void*, uint8_t);
 typedef unsigned __int128 (*HFpp_t)(void*, void*);
 typedef uint32_t (*uFbuU_t)(void*, uint32_t, uint64_t);
 typedef void* (*pFbppU_t)(void*, void*, void*, uint64_t);
-typedef void* (*pFbpCpppwwwwwwWW_t)(void*, void*, uint8_t, void*, void*, void*, int16_t, int16_t, int16_t, int16_t, int16_t, int16_t, uint16_t, uint16_t);
+typedef uint32_t (*uFbCuuuwwwwwwWW_t)(void*, uint8_t, uint32_t, uint32_t, uint32_t, int16_t, int16_t, int16_t, int16_t, int16_t, int16_t, uint16_t, uint16_t);
 typedef uint32_t (*uFbuuWW_t)(void*, uint32_t, uint32_t, uint16_t, uint16_t);
-typedef uint32_t (*uFbuuiup_t)(void*, uint32_t, uint32_t, int32_t, uint32_t, void*);
+typedef uint32_t (*uFbuuuup_t)(void*, uint32_t, uint32_t, uint32_t, uint32_t, void*);
 typedef void* (*pFbuuUUU_t)(void*, uint32_t, uint32_t, uint64_t, uint64_t, uint64_t);
 typedef void* (*pFbuuuuuwwuuuuUUUup_t)(void*, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, int16_t, int16_t, uint32_t, uint32_t, uint32_t, uint32_t, uint64_t, uint64_t, uint64_t, uint32_t, void*);
-typedef float (*fFbu_t)(void*, uint32_t);
 //endxcbV2
 typedef void (*vFpLi_t)(void*, uintptr_t, int32_t);
 typedef void (*vFpLL_t)(void*, uintptr_t, uintptr_t);
@@ -3000,10 +2999,9 @@ void vFpC(uintptr_t fcn) { __CPU; vFpC_t fn = (vFpC_t)fcn; fn((void*)R_RDI, (uin
 void HFpp(uintptr_t fcn) { __CPU; HFpp_t fn = (HFpp_t)fcn; unsigned __int128 u128 = fn((void*)R_RDI, (void*)R_RSI); R_RAX=(u128&0xFFFFFFFFFFFFFFFFL); R_RDX=(u128>>64)&0xFFFFFFFFFFFFFFFFL; DEBUG_LOG; (void)cpu; }
 void uFbuU(uintptr_t fcn) { __CPU; uFbuU_t fn = (uFbuU_t)fcn; void *aligned_xcb = align_xcb_connection((void*)R_RDI); R_RAX=(uint32_t)fn(aligned_xcb, (uint32_t)R_RSI, (uint64_t)R_RDX); unalign_xcb_connection(aligned_xcb, (void*)R_RDI); DEBUG_LOG; (void)cpu; }
 void pFbppU(uintptr_t fcn) { __CPU; pFbppU_t fn = (pFbppU_t)fcn; void *aligned_xcb = align_xcb_connection((void*)R_RDI); R_RAX=(uintptr_t)fn(aligned_xcb, (void*)R_RSI, (void*)R_RDX, (uint64_t)R_RCX); unalign_xcb_connection(aligned_xcb, (void*)R_RDI); DEBUG_LOG; (void)cpu; }
-void pFbpCpppwwwwwwWW(uintptr_t fcn) { __CPU; pFbpCpppwwwwwwWW_t fn = (pFbpCpppwwwwwwWW_t)fcn; void *aligned_xcb = align_xcb_connection((void*)R_RDI); R_RAX=(uintptr_t)fn(aligned_xcb, (void*)R_RSI, (uint8_t)R_RDX, (void*)R_RCX, (void*)R_R8, (void*)R_R9, *(int16_t*)(R_RSP + 8), *(int16_t*)(R_RSP + 16), *(int16_t*)(R_RSP + 24), *(int16_t*)(R_RSP + 32), *(int16_t*)(R_RSP + 40), *(int16_t*)(R_RSP + 48), *(uint16_t*)(R_RSP + 56), *(uint16_t*)(R_RSP + 64)); unalign_xcb_connection(aligned_xcb, (void*)R_RDI); DEBUG_LOG; (void)cpu; }
+void uFbCuuuwwwwwwWW(uintptr_t fcn) { __CPU; uFbCuuuwwwwwwWW_t fn = (uFbCuuuwwwwwwWW_t)fcn; void *aligned_xcb = align_xcb_connection((void*)R_RDI); R_RAX=(uint32_t)fn(aligned_xcb, (uint8_t)R_RSI, (uint32_t)R_RDX, (uint32_t)R_RCX, (uint32_t)R_R8, (int16_t)R_R9, *(int16_t*)(R_RSP + 8), *(int16_t*)(R_RSP + 16), *(int16_t*)(R_RSP + 24), *(int16_t*)(R_RSP + 32), *(int16_t*)(R_RSP + 40), *(uint16_t*)(R_RSP + 48), *(uint16_t*)(R_RSP + 56)); unalign_xcb_connection(aligned_xcb, (void*)R_RDI); DEBUG_LOG; (void)cpu; }
 void uFbuuWW(uintptr_t fcn) { __CPU; uFbuuWW_t fn = (uFbuuWW_t)fcn; void *aligned_xcb = align_xcb_connection((void*)R_RDI); R_RAX=(uint32_t)fn(aligned_xcb, (uint32_t)R_RSI, (uint32_t)R_RDX, (uint16_t)R_RCX, (uint16_t)R_R8); unalign_xcb_connection(aligned_xcb, (void*)R_RDI); DEBUG_LOG; (void)cpu; }
-void uFbuuiup(uintptr_t fcn) { __CPU; uFbuuiup_t fn = (uFbuuiup_t)fcn; void *aligned_xcb = align_xcb_connection((void*)R_RDI); R_RAX=(uint32_t)fn(aligned_xcb, (uint32_t)R_RSI, (uint32_t)R_RDX, (int32_t)R_RCX, (uint32_t)R_R8, (void*)R_R9); unalign_xcb_connection(aligned_xcb, (void*)R_RDI); DEBUG_LOG; (void)cpu; }
-void fFbu(uintptr_t fcn) { __CPU; fFbu_t fn = (fFbu_t)fcn; void *aligned_xcb = align_xcb_connection((void*)R_RDI); R_XMMS(0)=fn(aligned_xcb, (uint32_t)R_RSI); unalign_xcb_connection(aligned_xcb, (void*)R_RDI); DEBUG_LOG; (void)cpu; }
+void uFbuuuup(uintptr_t fcn) { __CPU; uFbuuuup_t fn = (uFbuuuup_t)fcn; void *aligned_xcb = align_xcb_connection((void*)R_RDI); R_RAX=(uint32_t)fn(aligned_xcb, (uint32_t)R_RSI, (uint32_t)R_RDX, (uint32_t)R_RCX, (uint32_t)R_R8, (void*)R_R9); unalign_xcb_connection(aligned_xcb, (void*)R_RDI); DEBUG_LOG; (void)cpu; }
 void pFbuuUUU(uintptr_t fcn) { __CPU; pFbuuUUU_t fn = (pFbuuUUU_t)fcn; void *aligned_xcb = align_xcb_connection((void*)R_RDI); R_RAX=(uintptr_t)fn(aligned_xcb, (uint32_t)R_RSI, (uint32_t)R_RDX, (uint64_t)R_RCX, (uint64_t)R_R8, (uint64_t)R_R9); unalign_xcb_connection(aligned_xcb, (void*)R_RDI); DEBUG_LOG; (void)cpu; }
 void pFbuuuuuwwuuuuUUUup(uintptr_t fcn) { __CPU; pFbuuuuuwwuuuuUUUup_t fn = (pFbuuuuuwwuuuuUUUup_t)fcn; void *aligned_xcb = align_xcb_connection((void*)R_RDI); R_RAX=(uintptr_t)fn(aligned_xcb, (uint32_t)R_RSI, (uint32_t)R_RDX, (uint32_t)R_RCX, (uint32_t)R_R8, (uint32_t)R_R9, *(int16_t*)(R_RSP + 8), *(int16_t*)(R_RSP + 16), *(uint32_t*)(R_RSP + 24), *(uint32_t*)(R_RSP + 32), *(uint32_t*)(R_RSP + 40), *(uint32_t*)(R_RSP + 48), *(uint64_t*)(R_RSP + 56), *(uint64_t*)(R_RSP + 64), *(uint64_t*)(R_RSP + 72), *(uint32_t*)(R_RSP + 80), *(void**)(R_RSP + 88)); unalign_xcb_connection(aligned_xcb, (void*)R_RDI); DEBUG_LOG; (void)cpu; }
 //xcbV2end

--- a/target/i386/latx/include/wrappedlibxcbrender_private.h
+++ b/target/i386/latx/include/wrappedlibxcbrender_private.h
@@ -33,7 +33,7 @@
 //GO(xcb_render_change_picture_value_list_unpack, 
 //GO(xcb_render_color_end, 
 //GO(xcb_render_color_next, 
-GO(xcb_render_composite, pFbpCpppwwwwwwWW)
+GO(xcb_render_composite, uFbCuuuwwwwwwWW)
 //GO(xcb_render_composite_checked, 
 //GO(xcb_render_composite_glyphs_16, 
 //GO(xcb_render_composite_glyphs_16_checked, 
@@ -81,10 +81,10 @@ GO(xcb_render_create_cursor_checked, uFbuuWW)
 //GO(xcb_render_create_linear_gradient_stops, 
 //GO(xcb_render_create_linear_gradient_stops_end, 
 //GO(xcb_render_create_linear_gradient_stops_length, 
-GO(xcb_render_create_picture, uFbuuiup)
+GO(xcb_render_create_picture, uFbuuuup)
 //GO(xcb_render_create_picture_aux, 
 //GO(xcb_render_create_picture_aux_checked, 
-GO(xcb_render_create_picture_checked, uFbuuiup)
+GO(xcb_render_create_picture_checked, uFbuuuup)
 //GO(xcb_render_create_picture_sizeof, 
 //GO(xcb_render_create_picture_value_list, 
 //GO(xcb_render_create_picture_value_list_serialize, 
@@ -120,7 +120,7 @@ GO(xcb_render_create_picture_checked, uFbuuiup)
 //GO(xcb_render_free_glyphs_glyphs_length, 
 //GO(xcb_render_free_glyphs_sizeof, 
 GO(xcb_render_free_picture, uFbu)
-GO(xcb_render_free_picture_checked, fFbu)
+GO(xcb_render_free_picture_checked, uFbu)
 //GO(xcb_render_glyph_end, 
 //GO(xcb_render_glyphinfo_end, 
 //GO(xcb_render_glyphinfo_next, 
@@ -162,7 +162,7 @@ DATA(xcb_render_id, 2*sizeof(void*))
 //GO(xcb_render_query_filters_reply, 
 //GO(xcb_render_query_filters_sizeof, 
 //GO(xcb_render_query_filters_unchecked, 
-GO(xcb_render_query_pict_formats, uFbu)
+GO(xcb_render_query_pict_formats, uFb)
 //GO(xcb_render_query_pict_formats_formats, 
 //GO(xcb_render_query_pict_formats_formats_iterator, 
 //GO(xcb_render_query_pict_formats_formats_length, 

--- a/target/i386/latx/include/wrapper.h
+++ b/target/i386/latx/include/wrapper.h
@@ -1474,10 +1474,9 @@ void vFpC(uintptr_t fcn);
 void HFpp(uintptr_t fcn);
 void uFbuU(uintptr_t fcn);
 void pFbppU(uintptr_t fcn);
-void pFbpCpppwwwwwwWW(uintptr_t fcn);
+void uFbCuuuwwwwwwWW(uintptr_t fcn);
 void uFbuuWW(uintptr_t fcn);
-void uFbuuiup(uintptr_t fcn);
-void fFbu(uintptr_t fcn);
+void uFbuuuup(uintptr_t fcn);
 void pFbuuUUU(uintptr_t fcn);
 void pFbuuuuuwwuuuuUUUup(uintptr_t fcn);
 //endxcbV2


### PR DESCRIPTION
## Summary

- Correct the active xcb_render_composite wrapper signature so 32-bit Picture IDs and all coordinate and size arguments reach native libxcb-render unchanged.
- Fix four additional active libxcb-render declarations found by auditing the wrapper table against the public XCB Render headers.
- Remove the obsolete generated wrapper signatures after confirming that no other wrapper uses them.

## Root cause

The xcb_render_composite wrapper described the operation and source Picture arguments with the wrong types. KZT therefore narrowed a source Picture ID such as 0x400028 to 0x28 before calling native libxcb-render. The X server rejected the resulting Composite request with RenderBadPicture.

The same audit found incorrect declarations for xcb_render_create_picture, xcb_render_create_picture_checked, xcb_render_free_picture_checked, and xcb_render_query_pict_formats. These mismatches included a wrong cookie return class and an extra argument.

## Impact

GTK and Cairo applications using the KZT libxcb-render path can issue Render Composite requests with the original resource IDs. The corrected related declarations also prevent latent ABI errors in Picture creation, checked Picture release, and format queries.

## Validation

- Compared every active libxcb-render wrapper declaration with the public XCB Render prototypes; all active declarations match after this change.
- Built latx-x86_64 successfully on LoongArch.
- Ran gtkperf with LATX_KZT=1 for 20 consecutive native X11 runs; all completed without RenderBadPicture.
- Ran three LATX_KZT=0 control executions; all completed.
- Confirmed with GDB that execution enters the corrected KZT wrapper with the complete source Picture ID 0x400028 rather than the truncated value 0x28.