### PR TITLE
LATX: add type-aware RunFunctionFmt

### DIFF
--- a/target/i386/latx/context/callback-args.c
+++ b/target/i386/latx/context/callback-args.c
@@ -1,0 +1,174 @@
+/*
+ * This file is derived from Box64.
+ *
+ * SPDX-FileCopyrightText: 2020 ptitSeb
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "callback-args.h"
+
+#include <assert.h>
+#include <string.h>
+
+static bool callback_arg_is_sse(char type)
+{
+    return type == 'f' || type == 'd';
+}
+
+static bool callback_arg_is_gpr(char type)
+{
+    switch (type) {
+    case 'p':
+    case 'i':
+    case 'u':
+    case 'I':
+    case 'U':
+    case 'L':
+    case 'l':
+    case 'w':
+    case 'W':
+    case 'c':
+    case 'C':
+        return true;
+    default:
+        return false;
+    }
+}
+
+bool latx_callback_stack_args(const char *fmt, size_t *stack_count)
+{
+    size_t gpr_count = 0;
+    size_t xmm_count = 0;
+    size_t count = 0;
+
+    if (!fmt || !stack_count) {
+        return false;
+    }
+
+    for (; *fmt; fmt++) {
+        if (callback_arg_is_sse(*fmt)) {
+            if (xmm_count < LATX_CALLBACK_XMM_ARGS) {
+                xmm_count++;
+            } else {
+                count++;
+            }
+        } else if (callback_arg_is_gpr(*fmt)) {
+            if (gpr_count < LATX_CALLBACK_GPR_ARGS) {
+                gpr_count++;
+            } else {
+                count++;
+            }
+        } else {
+            return false;
+        }
+    }
+
+    *stack_count = count;
+    return true;
+}
+
+size_t latx_callback_stack_words(uintptr_t rsp, size_t stack_args)
+{
+    size_t stack_words = stack_args;
+
+    if ((rsp - stack_words * sizeof(uint64_t)) & 0xf) {
+        stack_words++;
+    }
+    return stack_words;
+}
+
+static void callback_store_gpr(LatxCallbackArgs *args, uint64_t value)
+{
+    if (args->gpr_count < LATX_CALLBACK_GPR_ARGS) {
+        args->gpr[args->gpr_count++] = value;
+    } else {
+        args->stack[args->stack_count++] = value;
+    }
+}
+
+static void callback_store_xmm(LatxCallbackArgs *args, uint64_t value)
+{
+    if (args->xmm_count < LATX_CALLBACK_XMM_ARGS) {
+        args->xmm[args->xmm_count++] = value;
+    } else {
+        args->stack[args->stack_count++] = value;
+    }
+}
+
+static uint64_t callback_double_bits(double value)
+{
+    uint64_t bits;
+
+    memcpy(&bits, &value, sizeof(bits));
+    return bits;
+}
+
+static uint64_t callback_float_bits(double promoted)
+{
+    float value = promoted;
+    uint32_t bits;
+
+    memcpy(&bits, &value, sizeof(bits));
+    return bits;
+}
+
+void latx_callback_collect_args(LatxCallbackArgs *args, const char *fmt,
+                                va_list *ap)
+{
+    for (; *fmt; fmt++) {
+        switch (*fmt) {
+        case 'f':
+            callback_store_xmm(args,
+                               callback_float_bits(va_arg(*ap, double)));
+            break;
+        case 'd':
+            callback_store_xmm(args,
+                               callback_double_bits(va_arg(*ap, double)));
+            break;
+        case 'p':
+            callback_store_gpr(args,
+                               (uintptr_t)va_arg(*ap, void *));
+            break;
+        case 'i':
+            callback_store_gpr(args,
+                               (uint64_t)(int64_t)va_arg(*ap, int));
+            break;
+        case 'u':
+            callback_store_gpr(args, va_arg(*ap, uint32_t));
+            break;
+        case 'I':
+            callback_store_gpr(args,
+                               (uint64_t)va_arg(*ap, int64_t));
+            break;
+        case 'U':
+            callback_store_gpr(args, va_arg(*ap, uint64_t));
+            break;
+        case 'L':
+            callback_store_gpr(args, va_arg(*ap, unsigned long));
+            break;
+        case 'l':
+            callback_store_gpr(args,
+                               (uint64_t)(int64_t)va_arg(*ap, long));
+            break;
+        case 'w':
+            callback_store_gpr(
+                args, (uint64_t)(int64_t)(int16_t)va_arg(*ap, int));
+            break;
+        case 'W':
+            callback_store_gpr(args,
+                               (uint16_t)va_arg(*ap, int));
+            break;
+        case 'c':
+            callback_store_gpr(
+                args, (uint64_t)(int64_t)(int8_t)va_arg(*ap, int));
+            break;
+        case 'C':
+            callback_store_gpr(args,
+                               (uint8_t)va_arg(*ap, int));
+            break;
+        default:
+            assert(false);
+        }
+    }
+}

--- a/target/i386/latx/context/callback-args.h
+++ b/target/i386/latx/context/callback-args.h
@@ -1,0 +1,34 @@
+/*
+ * This file is derived from Box64.
+ *
+ * SPDX-FileCopyrightText: 2020 ptitSeb
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef LATX_CALLBACK_ARGS_H
+#define LATX_CALLBACK_ARGS_H
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#define LATX_CALLBACK_GPR_ARGS 6
+#define LATX_CALLBACK_XMM_ARGS 8
+
+typedef struct LatxCallbackArgs {
+    uint64_t gpr[LATX_CALLBACK_GPR_ARGS];
+    uint64_t xmm[LATX_CALLBACK_XMM_ARGS];
+    uint64_t *stack;
+    size_t gpr_count;
+    size_t xmm_count;
+    size_t stack_count;
+} LatxCallbackArgs;
+
+bool latx_callback_stack_args(const char *fmt, size_t *stack_count);
+size_t latx_callback_stack_words(uintptr_t rsp, size_t stack_args);
+void latx_callback_collect_args(LatxCallbackArgs *args, const char *fmt,
+                                va_list *ap);
+
+#endif /* LATX_CALLBACK_ARGS_H */

--- a/target/i386/latx/context/callback.c
+++ b/target/i386/latx/context/callback.c
@@ -7,14 +7,28 @@
  */
 
 #include <stdarg.h>
+
 #include "callback.h"
 #include "lsenv.h"
 #include "qemu.h"
 
 #ifdef TARGET_X86_64
+#define CALLBACK_GPR_ARGS 6
+
+typedef struct CallbackFrame {
+    CPUX86State *cpu;
+    CPUState *cs;
+    uintptr_t old_rbp;
+    size_t stack_words;
+} CallbackFrame;
+
+static const int callback_gpr_regs[CALLBACK_GPR_ARGS] = {
+    R_EDI, R_ESI, R_EDX, R_ECX, R_R8, R_R9,
+};
+
 static int64_t Pop64(CPUX86State *cpu)
 {
-    uint64_t *st = ((uint64_t*)(cpu->regs[R_ESP]));
+    uint64_t *st = (uint64_t *)cpu->regs[R_ESP];
     cpu->regs[R_ESP] += 8;
 
     return *st;
@@ -23,24 +37,19 @@ static int64_t Pop64(CPUX86State *cpu)
 static void Push64(CPUX86State *cpu, uint64_t v)
 {
     cpu->regs[R_ESP] -= 8;
-    *((uint64_t*)cpu->regs[R_ESP]) = v;
-
+    *(uint64_t *)cpu->regs[R_ESP] = v;
 }
-#endif
 
-uint64_t RunFunctionWithState(uintptr_t fnc, int nargs, ...)
+static CallbackFrame callback_frame_enter(size_t stack_args)
 {
-#ifdef TARGET_X86_64
-    lsassert(fnc);
-    lsassert(CODEIS64);
     CPUX86State *cpu = (CPUX86State *)lsenv->cpu_state;
-    CPUState * cs = env_cpu(cpu);
-
-    int align = (nargs>6)?(((nargs-6)&1)):0;
-    int stackn = align + ((nargs>6)?(nargs-6):0);
+    CallbackFrame frame = {
+        .cpu = cpu,
+        .cs = env_cpu(cpu),
+    };
 
     Push64(cpu, cpu->regs[R_EBP]);
-    uintptr_t old_rbp = cpu->regs[R_EBP] = cpu->regs[R_ESP];      // mov rbp, rsp
+    frame.old_rbp = cpu->regs[R_EBP] = cpu->regs[R_ESP];
 
     Push64(cpu, cpu->regs[R_EDI]);
     Push64(cpu, cpu->regs[R_ESI]);
@@ -56,37 +65,33 @@ uint64_t RunFunctionWithState(uintptr_t fnc, int nargs, ...)
     Push64(cpu, cpu->regs[R_R14]);
     Push64(cpu, cpu->regs[R_R15]);
 
-    cpu->regs[R_ESP] -= stackn*sizeof(void*);   // need to push in reverse order
-    uint64_t *p = (uint64_t*)cpu->regs[R_ESP];
+    frame.stack_words = stack_args + (stack_args & 1);
+    cpu->regs[R_ESP] -= frame.stack_words * sizeof(uint64_t);
 
-    va_list va;
-    va_start (va, nargs);
-    for (int i=0; i<nargs; ++i) {
-        if(i<6) {
-            int nn[] = {R_EDI, R_ESI, R_EDX, R_ECX, R_R8, R_R9};
-            cpu->regs[nn[i]] = va_arg(va, uint64_t);
-        } else {
-            *p = va_arg(va, uint64_t);
-            p++;
-        }
-    }
+    return frame;
+}
 
-    Push64(cpu, (uint64_t)&RunFunctionWithState);
-    va_end (va);
-
+static uint64_t callback_frame_run(CallbackFrame *frame, uintptr_t fnc)
+{
+    CPUX86State *cpu = frame->cpu;
+    CPUState *cs = frame->cs;
     uintptr_t oldip = cpu->eip;
-    cpu->eip=fnc;
+    uintptr_t old_running;
     sigjmp_buf buf;
-    memcpy(&buf, &cs->jmp_env, sizeof(sigjmp_buf));
 
-    uintptr_t old_running = qatomic_read(&cs->running);
+    /* cpu-exec.c recognizes this exact address as the callback sentinel. */
+    Push64(cpu, (uint64_t)&RunFunctionWithState);
+    cpu->eip = fnc;
+    memcpy(&buf, &cs->jmp_env, sizeof(buf));
+
+    old_running = qatomic_read(&cs->running);
     cpu_loop(cpu);
     qatomic_set(&cs->running, old_running);
 
-    memcpy(&cs->jmp_env, &buf, sizeof(sigjmp_buf));
+    memcpy(&cs->jmp_env, &buf, sizeof(buf));
     cpu->eip = oldip;
 
-    cpu->regs[R_ESP] += stackn*sizeof(void*);
+    cpu->regs[R_ESP] += frame->stack_words * sizeof(uint64_t);
     cpu->regs[R_R15] = Pop64(cpu);
     cpu->regs[R_R14] = Pop64(cpu);
     cpu->regs[R_R13] = Pop64(cpu);
@@ -101,10 +106,42 @@ uint64_t RunFunctionWithState(uintptr_t fnc, int nargs, ...)
     cpu->regs[R_ESI] = Pop64(cpu);
     cpu->regs[R_EDI] = Pop64(cpu);
 
-    cpu->regs[R_ESP] = old_rbp;          // mov rsp, rbp
-    cpu->regs[R_EBP] = Pop64(cpu);     // pop rbp
+    cpu->regs[R_ESP] = frame->old_rbp;
+    cpu->regs[R_EBP] = Pop64(cpu);
 
     return cpu->regs[R_EAX];
+}
+#endif
+
+uint64_t RunFunctionWithState(uintptr_t fnc, int nargs, ...)
+{
+#ifdef TARGET_X86_64
+    size_t stack_args;
+    CallbackFrame frame;
+    uint64_t *stack;
+    va_list ap;
+
+    lsassert(fnc);
+    lsassert(CODEIS64);
+
+    stack_args = nargs > CALLBACK_GPR_ARGS
+                     ? nargs - CALLBACK_GPR_ARGS
+                     : 0;
+    frame = callback_frame_enter(stack_args);
+    stack = (uint64_t *)frame.cpu->regs[R_ESP];
+
+    va_start(ap, nargs);
+    for (int i = 0; i < nargs; i++) {
+        if (i < CALLBACK_GPR_ARGS) {
+            frame.cpu->regs[callback_gpr_regs[i]] =
+                va_arg(ap, uint64_t);
+        } else {
+            *stack++ = va_arg(ap, uint64_t);
+        }
+    }
+    va_end(ap);
+
+    return callback_frame_run(&frame, fnc);
 #else
     return 0;
 #endif

--- a/target/i386/latx/context/callback.c
+++ b/target/i386/latx/context/callback.c
@@ -8,13 +8,12 @@
 
 #include <stdarg.h>
 
+#include "callback-args.h"
 #include "callback.h"
 #include "lsenv.h"
 #include "qemu.h"
 
 #ifdef TARGET_X86_64
-#define CALLBACK_GPR_ARGS 6
-
 typedef struct CallbackFrame {
     CPUX86State *cpu;
     CPUState *cs;
@@ -22,7 +21,7 @@ typedef struct CallbackFrame {
     size_t stack_words;
 } CallbackFrame;
 
-static const int callback_gpr_regs[CALLBACK_GPR_ARGS] = {
+static const int callback_gpr_regs[LATX_CALLBACK_GPR_ARGS] = {
     R_EDI, R_ESI, R_EDX, R_ECX, R_R8, R_R9,
 };
 
@@ -40,7 +39,8 @@ static void Push64(CPUX86State *cpu, uint64_t v)
     *(uint64_t *)cpu->regs[R_ESP] = v;
 }
 
-static CallbackFrame callback_frame_enter(size_t stack_args)
+static CallbackFrame callback_frame_enter(size_t stack_args,
+                                          bool align_guest_entry)
 {
     CPUX86State *cpu = (CPUX86State *)lsenv->cpu_state;
     CallbackFrame frame = {
@@ -65,7 +65,10 @@ static CallbackFrame callback_frame_enter(size_t stack_args)
     Push64(cpu, cpu->regs[R_R14]);
     Push64(cpu, cpu->regs[R_R15]);
 
-    frame.stack_words = stack_args + (stack_args & 1);
+    frame.stack_words = align_guest_entry
+                            ? latx_callback_stack_words(cpu->regs[R_ESP],
+                                                        stack_args)
+                            : stack_args + (stack_args & 1);
     cpu->regs[R_ESP] -= frame.stack_words * sizeof(uint64_t);
 
     return frame;
@@ -122,17 +125,18 @@ uint64_t RunFunctionWithState(uintptr_t fnc, int nargs, ...)
     va_list ap;
 
     lsassert(fnc);
+    lsassert(nargs >= 0);
     lsassert(CODEIS64);
 
-    stack_args = nargs > CALLBACK_GPR_ARGS
-                     ? nargs - CALLBACK_GPR_ARGS
+    stack_args = nargs > LATX_CALLBACK_GPR_ARGS
+                     ? nargs - LATX_CALLBACK_GPR_ARGS
                      : 0;
-    frame = callback_frame_enter(stack_args);
+    frame = callback_frame_enter(stack_args, false);
     stack = (uint64_t *)frame.cpu->regs[R_ESP];
 
     va_start(ap, nargs);
     for (int i = 0; i < nargs; i++) {
-        if (i < CALLBACK_GPR_ARGS) {
+        if (i < LATX_CALLBACK_GPR_ARGS) {
             frame.cpu->regs[callback_gpr_regs[i]] =
                 va_arg(ap, uint64_t);
         } else {
@@ -140,6 +144,45 @@ uint64_t RunFunctionWithState(uintptr_t fnc, int nargs, ...)
         }
     }
     va_end(ap);
+
+    return callback_frame_run(&frame, fnc);
+#else
+    return 0;
+#endif
+}
+
+uint64_t RunFunctionFmt(uintptr_t fnc, const char *fmt, ...)
+{
+#ifdef TARGET_X86_64
+    size_t stack_args;
+    CallbackFrame frame;
+    LatxCallbackArgs args;
+    va_list ap;
+
+    lsassert(fnc);
+    lsassert(fmt);
+    lsassert(CODEIS64);
+    if (!fnc || !fmt || !CODEIS64 ||
+        !latx_callback_stack_args(fmt, &stack_args)) {
+        return 0;
+    }
+
+    frame = callback_frame_enter(stack_args, true);
+    args = (LatxCallbackArgs) {
+        .stack = (uint64_t *)frame.cpu->regs[R_ESP],
+    };
+
+    va_start(ap, fmt);
+    latx_callback_collect_args(&args, fmt, &ap);
+    va_end(ap);
+
+    g_assert(args.stack_count == stack_args);
+    for (size_t i = 0; i < args.gpr_count; i++) {
+        frame.cpu->regs[callback_gpr_regs[i]] = args.gpr[i];
+    }
+    for (size_t i = 0; i < args.xmm_count; i++) {
+        frame.cpu->xmm_regs[i].ZMM_Q(0) = args.xmm[i];
+    }
 
     return callback_frame_run(&frame, fnc);
 #else

--- a/target/i386/latx/context/gtkclass.c
+++ b/target/i386/latx/context/gtkclass.c
@@ -66,7 +66,7 @@ static uintptr_t my_##NAME##_fct_##A = 0;   \
 static RET my_##NAME##_##A DEF              \
 {                                           \
     printf_log(LOG_DEBUG, "Calling " #NAME "_" #A " wrapper\n");             \
-    return (RET)RunFunctionWithState(my_##NAME##_fct_##A, strlen(FMT), __VA_ARGS__);\
+    return (RET)RunFunctionFmt(my_##NAME##_fct_##A, FMT, __VA_ARGS__);\
 }
 
 #define FIND(A, NAME) \

--- a/target/i386/latx/context/meson.build
+++ b/target/i386/latx/context/meson.build
@@ -71,6 +71,7 @@ my_file = files(
   'myalign.c',
   'obstack.c',
   'globalsymbols.c',
+  'callback-args.c',
   'callback.c',
   'kzt_public_loader_observer.c',
   'kzt_relocation_transaction.c',

--- a/target/i386/latx/context/wrappedlibx11.c
+++ b/target/i386/latx/context/wrappedlibx11.c
@@ -664,7 +664,7 @@ static void* findXPendingAsyncHandlerFct(void* fct)
 static uintptr_t my_XSynchronizeProc_fct_##A = 0;                       \
 static int my_XSynchronizeProc_##A(void *dpy)                           \
 {                                                                       \
-    return (int)RunFunctionWithState(my_XSynchronizeProc_fct_##A, 1, dpy);\
+    return (int)RunFunctionFmt(my_XSynchronizeProc_fct_##A, "p", dpy); \
 }
 SUPER()
 #undef GO

--- a/target/i386/latx/include/callback.h
+++ b/target/i386/latx/include/callback.h
@@ -4,7 +4,7 @@
 #include <stdint.h>
 
 uint64_t RunFunctionWithState(uintptr_t fnc, int nargs, ...);
+uint64_t RunFunctionFmt(uintptr_t fnc, const char *fmt, ...);
 #define RunFunction RunFunctionWithState
-#define RunFunctionFmt(fnc,fmt, ...) RunFunctionWithState(fnc, strlen(fmt), ## __VA_ARGS__)
 
 #endif //__CALLBACK_H__

--- a/tests/unit/check-x11-synchronize-callback.py
+++ b/tests/unit/check-x11-synchronize-callback.py
@@ -9,7 +9,7 @@ def main() -> int:
     source = pathlib.Path(sys.argv[1]).read_text()
 
     callback = """static int my_XSynchronizeProc_##A(void *dpy)"""
-    dispatch = """RunFunctionWithState(my_XSynchronizeProc_fct_##A, 1, dpy)"""
+    dispatch = """RunFunctionFmt(my_XSynchronizeProc_fct_##A, "p", dpy)"""
     reverse = """AddBridge(lib->priv.w.bridge, iFp, fct, 0, NULL)"""
 
     assert callback in source, (

--- a/tests/unit/meson.build
+++ b/tests/unit/meson.build
@@ -40,6 +40,24 @@ if 'CONFIG_LATX' in config_host
   )
 endif
 
+if 'CONFIG_LATX' in config_host
+  test_callback_args = executable(
+    'test-callback-args',
+    files(
+      'test-callback-args.c',
+      '../../target/i386/latx/context/callback-args.c',
+    ),
+    include_directories: include_directories('../..'),
+    build_by_default: false,
+  )
+
+  test(
+    'test-callback-args',
+    test_callback_args,
+    suite: 'lat-pr-fast',
+  )
+endif
+
 test(
   'test-x11-synchronize-callback',
   python,

--- a/tests/unit/test-callback-args.c
+++ b/tests/unit/test-callback-args.c
@@ -1,0 +1,184 @@
+/*
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include <limits.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "target/i386/latx/context/callback-args.h"
+
+#define TEST_ASSERT(condition)                                             \
+    do {                                                                   \
+        if (!(condition)) {                                                \
+            fprintf(stderr, "%s:%d: assertion failed: %s\n",             \
+                    __FILE__, __LINE__, #condition);                       \
+            abort();                                                       \
+        }                                                                  \
+    } while (0)
+
+static void collect_args(LatxCallbackArgs *args, uint64_t *stack,
+                         const char *fmt, ...)
+{
+    va_list ap;
+
+    memset(args, 0, sizeof(*args));
+    args->stack = stack;
+    va_start(ap, fmt);
+    latx_callback_collect_args(args, fmt, &ap);
+    va_end(ap);
+}
+
+static uint64_t double_bits(double value)
+{
+    uint64_t bits;
+
+    memcpy(&bits, &value, sizeof(bits));
+    return bits;
+}
+
+static uint64_t float_bits(float value)
+{
+    uint32_t bits;
+
+    memcpy(&bits, &value, sizeof(bits));
+    return bits;
+}
+
+static void test_integer_widths_and_stack(void)
+{
+    LatxCallbackArgs args;
+    uint64_t stack[5] = { 0 };
+    size_t stack_count;
+    int marker;
+
+    TEST_ASSERT(latx_callback_stack_args("piuIULlwWcC", &stack_count));
+    TEST_ASSERT(stack_count == 5);
+    collect_args(&args, stack, "piuIULlwWcC", &marker, -1,
+                 UINT32_MAX, INT64_MIN, UINT64_MAX,
+                 ULONG_MAX, -2L, -3, 0xfffe, -4, 0xfe);
+
+    TEST_ASSERT(args.gpr_count == 6);
+    TEST_ASSERT(args.xmm_count == 0);
+    TEST_ASSERT(args.stack_count == 5);
+    TEST_ASSERT(args.gpr[0] == (uintptr_t)&marker);
+    TEST_ASSERT(args.gpr[1] == UINT64_MAX);
+    TEST_ASSERT(args.gpr[2] == UINT32_MAX);
+    TEST_ASSERT(args.gpr[3] == (uint64_t)INT64_MIN);
+    TEST_ASSERT(args.gpr[4] == UINT64_MAX);
+    TEST_ASSERT(args.gpr[5] == ULONG_MAX);
+    TEST_ASSERT(stack[0] == UINT64_C(0xfffffffffffffffe));
+    TEST_ASSERT(stack[1] == UINT64_C(0xfffffffffffffffd));
+    TEST_ASSERT(stack[2] == UINT64_C(0xfffe));
+    TEST_ASSERT(stack[3] == UINT64_C(0xfffffffffffffffc));
+    TEST_ASSERT(stack[4] == UINT64_C(0xfe));
+}
+
+static void test_gpr_and_xmm_are_independent(void)
+{
+    LatxCallbackArgs args;
+    size_t stack_count;
+
+    TEST_ASSERT(latx_callback_stack_args("idididididid", &stack_count));
+    TEST_ASSERT(stack_count == 0);
+    collect_args(&args, NULL, "idididididid",
+                 1, 1.25, 2, 2.25, 3, 3.25,
+                 4, 4.25, 5, 5.25, 6, 6.25);
+
+    TEST_ASSERT(args.gpr_count == 6);
+    TEST_ASSERT(args.xmm_count == 6);
+    TEST_ASSERT(args.stack_count == 0);
+    for (size_t i = 0; i < 6; i++) {
+        TEST_ASSERT(args.gpr[i] == i + 1);
+        TEST_ASSERT(args.xmm[i] == double_bits(i + 1.25));
+    }
+}
+
+static void test_overflow_keeps_source_order(void)
+{
+    LatxCallbackArgs args;
+    uint64_t stack[2] = { 0 };
+    size_t stack_count;
+
+    TEST_ASSERT(latx_callback_stack_args("iiiiiiddddddddid",
+                                         &stack_count));
+    TEST_ASSERT(stack_count == 2);
+    collect_args(&args, stack, "iiiiiiddddddddid",
+                 1, 2, 3, 4, 5, 6,
+                 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5,
+                 7, 9.5);
+
+    TEST_ASSERT(args.gpr_count == 6);
+    TEST_ASSERT(args.xmm_count == 8);
+    TEST_ASSERT(args.stack_count == 2);
+    TEST_ASSERT(stack[0] == 7);
+    TEST_ASSERT(stack[1] == double_bits(9.5));
+}
+
+static void test_float_promotion_and_overflow(void)
+{
+    LatxCallbackArgs args;
+    uint64_t stack[1] = { 0 };
+    size_t stack_count;
+
+    TEST_ASSERT(latx_callback_stack_args("fffffffff", &stack_count));
+    TEST_ASSERT(stack_count == 1);
+    collect_args(&args, stack, "fffffffff",
+                 1.125, 2.125, 3.125, 4.125, 5.125,
+                 6.125, 7.125, 8.125, 9.125);
+
+    TEST_ASSERT(args.gpr_count == 0);
+    TEST_ASSERT(args.xmm_count == 8);
+    TEST_ASSERT(args.stack_count == 1);
+    for (size_t i = 0; i < 8; i++) {
+        TEST_ASSERT(args.xmm[i] == float_bits(i + 1.125f));
+    }
+    TEST_ASSERT(stack[0] == float_bits(9.125f));
+}
+
+static void test_invalid_and_empty_format(void)
+{
+    size_t stack_count = 99;
+
+    TEST_ASSERT(latx_callback_stack_args("", &stack_count));
+    TEST_ASSERT(stack_count == 0);
+    stack_count = 99;
+    TEST_ASSERT(!latx_callback_stack_args("px", &stack_count));
+    TEST_ASSERT(stack_count == 99);
+    TEST_ASSERT(!latx_callback_stack_args(NULL, &stack_count));
+}
+
+static void test_stack_alignment(void)
+{
+    const uintptr_t stack_pointers[] = { 0x1000, 0x1008 };
+
+    for (size_t i = 0; i < sizeof(stack_pointers) /
+                              sizeof(stack_pointers[0]); i++) {
+        for (size_t stack_args = 0; stack_args < 4; stack_args++) {
+            size_t stack_words = latx_callback_stack_words(
+                stack_pointers[i], stack_args);
+            uintptr_t before_sentinel = stack_pointers[i] -
+                stack_words * sizeof(uint64_t);
+            uintptr_t guest_entry = before_sentinel - sizeof(uint64_t);
+
+            TEST_ASSERT(stack_words >= stack_args);
+            TEST_ASSERT(stack_words <= stack_args + 1);
+            TEST_ASSERT((before_sentinel & 0xf) == 0);
+            TEST_ASSERT((guest_entry & 0xf) == 8);
+        }
+    }
+}
+
+int main(void)
+{
+    test_integer_widths_and_stack();
+    test_gpr_and_xmm_are_independent();
+    test_overflow_keeps_source_order();
+    test_float_promotion_and_overflow();
+    test_invalid_and_empty_format();
+    test_stack_alignment();
+    return 0;
+}


### PR DESCRIPTION
## Summary

- Add a real type-aware `RunFunctionFmt` for x86-64 callback arguments.
- Keep `RunFunctionWithState` and the canonical callback-return sentinel unchanged.
- Share callback frame setup/restoration between the raw and formatted entry points.
- Route GTK class callbacks and `XSynchronizeProc` through the typed path.
- Add focused argument-marshalling tests without adding them to the default product build.

## Why

The existing `RunFunctionFmt` macro only counted format characters and forwarded every argument through `RunFunctionWithState` as an integer value. It could not place `float` or `double` arguments in XMM registers, did not model the independent INTEGER and SSE register pools, and made C varargs handling dependent on calling every value as `uint64_t`.

This follows up on the review feedback in #386 and also makes future Box64 callback-wrapper synchronization more direct.

## Validation

- LoongArch64 `CONFIG_LATX_KZT=y` debug full build.
- `lat-pr-fast`: 21/21 passed.
- Argument-marshalling tests passed in debug, `NDEBUG/O2`, and ASan+UBSan builds.
- Mixed x86-64 guest callback runtime probe passed with `TU=0` and `TU=1`, covering six register plus one stacked integer argument, eight XMM plus one stacked `double`, promoted `float`, stack ordering/alignment, nested callbacks, and return-value preservation.
- X11 pointer callback end-to-end probe passed repeatedly in debug and release builds.
- Confirmed the new test executable is excluded from a normal `ninja` build and built by its explicit test target.