### PR TITLE
LATX, fix: Cover Vulkan proc-address wrappers

### DIFF
--- a/target/i386/latx/context/wrapper.c
+++ b/target/i386/latx/context/wrapper.c
@@ -1517,6 +1517,8 @@ typedef void (*vFppipipiu_t)(void*, void*, int32_t, void*, int32_t, void*, int32
 typedef uint32_t (*uFpddpippppp_t)(void*, double, double, void*, int32_t, void*, void*, void*, void*, void*);
 typedef int32_t (*iFpippu_t)(void*, int32_t, void*, void*, uint32_t);
 typedef uint32_t (*uFpupppp_t)(void*, uint32_t, void*, void*, void*, void*);
+typedef uint64_t (*UFpu_t)(void*, uint32_t);
+typedef int32_t (*iFpupppp_t)(void*, uint32_t, void*, void*, void*, void*);
 //endxcbV2
 typedef void (*vFpLi_t)(void*, uintptr_t, int32_t);
 typedef void (*vFpLL_t)(void*, uintptr_t, uintptr_t);
@@ -3155,6 +3157,8 @@ void vFppipipiu(uintptr_t fcn) { __CPU; vFppipipiu_t fn = (vFppipipiu_t)fcn; fn(
 void uFpddpippppp(uintptr_t fcn) { __CPU; uFpddpippppp_t fn = (uFpddpippppp_t)fcn; R_RAX=(uint32_t)fn((void*)R_RDI, R_XMMD(0), R_XMMD(1), (void*)R_RSI, (int32_t)R_RDX, (void*)R_RCX, (void*)R_R8, (void*)R_R9, *(void**)(R_RSP + 8), *(void**)(R_RSP + 16)); DEBUG_LOG; (void)cpu; }
 void iFpippu(uintptr_t fcn) { __CPU; iFpippu_t fn = (iFpippu_t)fcn; R_RAX=(int32_t)fn((void*)R_RDI, (int32_t)R_RSI, (void*)R_RDX, (void*)R_RCX, (uint32_t)R_R8); DEBUG_LOG; (void)cpu; }
 void uFpupppp(uintptr_t fcn) { __CPU; uFpupppp_t fn = (uFpupppp_t)fcn; R_RAX=(uint32_t)fn((void*)R_RDI, (uint32_t)R_RSI, (void*)R_RDX, (void*)R_RCX, (void*)R_R8, (void*)R_R9); DEBUG_LOG; (void)cpu; }
+void UFpu(uintptr_t fcn) { __CPU; UFpu_t fn = (UFpu_t)fcn; R_RAX=fn((void*)R_RDI, (uint32_t)R_RSI); DEBUG_LOG; (void)cpu; }
+void iFpupppp(uintptr_t fcn) { __CPU; iFpupppp_t fn = (iFpupppp_t)fcn; R_RAX=(int32_t)fn((void*)R_RDI, (uint32_t)R_RSI, (void*)R_RDX, (void*)R_RCX, (void*)R_R8, (void*)R_R9); DEBUG_LOG; (void)cpu; }
 //xcbV2end
 #undef R_RAX
 #undef R_RDI

--- a/target/i386/latx/include/wrappedvulkan_private.h
+++ b/target/i386/latx/include/wrappedvulkan_private.h
@@ -973,3 +973,44 @@ GO(vkCmdInitializeGraphScratchMemoryAMDX, vFpUU)
 GOM(vkCreateExecutionGraphPipelinesAMDX, iFEpUuppp)
 GO(vkGetExecutionGraphPipelineNodeIndexAMDX, iFpUpp)
 GO(vkGetExecutionGraphPipelineScratchSizeAMDX, iFpUp)
+
+// VK_KHR_dynamic_rendering_local_read
+GO(vkCmdSetRenderingAttachmentLocationsKHR, vFpp)
+GO(vkCmdSetRenderingInputAttachmentIndicesKHR, vFpp)
+
+// VK_KHR_line_rasterization
+GO(vkCmdSetLineStippleKHR, vFpuW)
+
+// VK_NV_cooperative_matrix2
+GO(vkGetPhysicalDeviceCooperativeMatrixFlexibleDimensionsPropertiesNV, iFppp)
+
+// VK_NV_cooperative_vector
+GO(vkGetPhysicalDeviceCooperativeVectorPropertiesNV, iFppp)
+
+// VK_ARM_tensors
+GO(vkGetPhysicalDeviceExternalTensorPropertiesARM, vFppp)
+
+// VK_ARM_data_graph
+GO(vkGetPhysicalDeviceQueueFamilyDataGraphProcessingEnginePropertiesARM, vFppp)
+GO(vkGetPhysicalDeviceQueueFamilyDataGraphPropertiesARM, iFpupp)
+
+// VK_ARM_performance_counters_by_region
+GO(vkEnumeratePhysicalDeviceQueueFamilyPerformanceCountersByRegionARM, iFpuppp)
+
+// VK_EXT_descriptor_heap
+GO(vkGetPhysicalDeviceDescriptorSizeEXT, UFpu)
+
+// VK_KHR_swapchain_maintenance1
+GO(vkReleaseSwapchainImagesKHR, iFpp)
+
+// VK_ARM_shader_instrumentation
+GO(vkEnumeratePhysicalDeviceShaderInstrumentationMetricsARM, iFppp)
+
+// VK_KHR_maintenance10
+GO(vkCmdEndRendering2KHR, vFpp)
+
+// VK_ARM_data_graph_instruction_set_tosa
+GO(vkGetPhysicalDeviceQueueFamilyDataGraphEngineOperationPropertiesARM, iFpupp)
+
+// VK_ARM_data_graph_optical_flow
+GO(vkGetPhysicalDeviceQueueFamilyDataGraphOpticalFlowImageFormatsARM, iFpupppp)

--- a/target/i386/latx/include/wrappedvulkan_private.h
+++ b/target/i386/latx/include/wrappedvulkan_private.h
@@ -845,6 +845,14 @@ GO(vkGetDeviceImageSubresourceLayoutKHR, vFppp)
 GO(vkGetImageSubresourceLayout2KHR, vFpUpp)
 GO(vkGetRenderingAreaGranularityKHR, vFppp)
 
+// VK_KHR_maintenance6
+GO(vkCmdBindDescriptorBufferEmbeddedSamplers2EXT, vFpp)
+GO(vkCmdBindDescriptorSets2KHR, vFpp)
+GO(vkCmdPushConstants2KHR, vFpp)
+GO(vkCmdPushDescriptorSet2KHR, vFpp)
+GO(vkCmdPushDescriptorSetWithTemplate2KHR, vFpp)
+GO(vkCmdSetDescriptorBufferOffsets2EXT, vFpp)
+
 // VK_NV_memory_decompression
 GO(vkCmdDecompressMemoryIndirectCountNV, vFpUUu)
 GO(vkCmdDecompressMemoryNV, vFpup)

--- a/target/i386/latx/include/wrapper.h
+++ b/target/i386/latx/include/wrapper.h
@@ -1554,5 +1554,7 @@ void vFppipipiu(uintptr_t fcn);
 void uFpddpippppp(uintptr_t fcn);
 void iFpippu(uintptr_t fcn);
 void uFpupppp(uintptr_t fcn);
+void UFpu(uintptr_t fcn);
+void iFpupppp(uintptr_t fcn);
 //endxcbV2
 #endif // __WRAPPER_H_


### PR DESCRIPTION
## Background

Vulkan applications do not necessarily import every command as an exported `libvulkan.so.1` symbol. Extension commands are commonly requested at runtime through `vkGetInstanceProcAddr` or `vkGetDeviceProcAddr`.

The host Vulkan implementation can return a valid native function pointer for a supported command, but LAT can only expose that pointer to the x86 guest when the command has a known wrapper signature. If the signature is absent from `wrappedvulkan_private.h`, `resolveSymbol()` returns `NULL` even though the host lookup succeeded. A guest that later calls the returned entry point then fails through a null function pointer.

This was observed with Steam using DXVK when it requested `vkCmdSetDescriptorBufferOffsets2EXT` from `VK_KHR_maintenance6`.

## Changes

- Add the six `VK_KHR_maintenance6` commands involved in the failing descriptor-buffer path.
- Add another fifteen stable, platform-neutral Vulkan commands that the current host Vulkan implementation exposed during the same runtime coverage run.
- Add the two exact generic bridge signatures required by those commands:
  - `UFpu`: a 64-bit result with pointer and 32-bit integer arguments.
  - `iFpupppp`: a 32-bit result with pointer, 32-bit integer, and four pointer arguments.
- Keep platform-specific Android, Fuchsia, Metal, QNX, and similar APIs out of scope.

This PR is independent of the KZT host-pointer address-policy work: it fixes missing Vulkan proc-address metadata rather than guest/host virtual-address classification.

## Validation

- Checked every added prototype and return type against Khronos Vulkan-Headers 1.4.360.
- Built `latx-x86_64` successfully on LoongArch64.
- Instrumented the Vulkan proc-address path: runtime-exposed commands without wrapper metadata decreased from 21 to 0 for the exercised Steam/DXVK startup.
- Ran Wine 11.14 with Steam and DXVK 3.0.2 using default `LATX_KZT=1` for 90 seconds:
  - Steam and steamwebhelper windows remained visible.
  - no access violation or fatal GPU-process exit;
  - no new crash dump.
- `test-kzt-address-policy` passed.
- `git diff --check` passed.

## Scope

This covers the stable generic/Linux Vulkan entry points observed from the tested driver. It does not claim blanket support for every future, provisional, vendor-only, or non-Linux platform command in the Vulkan registry.