### PR TITLE
LATX: clear stale jump caches after invalid-TB SIGILL

### DIFF
--- a/accel/tcg/cpu-exec.c
+++ b/accel/tcg/cpu-exec.c
@@ -632,11 +632,14 @@ void tb_set_jmp_target(TranslationBlock *tb, int n, uintptr_t addr)
             if (tb->lazylink[n] == 2) {
                 /* TB unlink */
                 tb->lazylink[n] = 1;
-                *(uint64_t*)jmp_rw = tb->lazylinkinst[n];
-                flush_idcache_range(jmp_rx, jmp_rw, 8);
+                tb_target_set_jmp_pair(jmp_rx, jmp_rw,
+                                       tb->lazylinkinst[n]);
             }
         } else {
             /* TB link */
+            if (!tb_target_jmp_in_range(jmp_rx, addr)) {
+                return;
+            }
             assert(tb->lazylink[n] == 1);
             tb->lazylink[n] = 2;
             tb->lazylinkinst[n] = *(uint64_t*)jmp_rx; /* save inst */

--- a/linux-user/signal.c
+++ b/linux-user/signal.c
@@ -26,6 +26,7 @@
 #include "signal-common.h"
 #include "hw/core/tcg-cpu-ops.h"
 #include "tcg/tcg.h"
+#include "exec/tb-hash.h"
 #include "fpu/softfloat.h"
 #ifdef CONFIG_LATX_AOT
 #include "aot.h"
@@ -1134,19 +1135,47 @@ static void host_signal_handler(int host_signum, siginfo_t *info,
     }
 
 #ifdef CONFIG_LATX_FAST_JMPCACHE
-    if (host_signum == SIGILL &&
-        *(unsigned int *)UC_PC(uc) == FASTTB_ILLINST_MAGIC) {
-            TranslationBlock *current_tb = tcg_tb_lookup(UC_PC(uc));
-            if (current_tb) {
+    if (host_signum == SIGILL) {
+        TranslationBlock *current_tb = tcg_tb_lookup(UC_PC(uc));
+        if (current_tb) {
+            for (int n = 0; n < 2; n++) {
+                if (current_tb->jmp_target_arg[n] !=
+                        TB_JMP_RESET_OFFSET_INVALID &&
+                    current_tb->jmp_reset_offset[n] !=
+                        TB_JMP_RESET_OFFSET_INVALID &&
+                    UC_PC(uc) == (uintptr_t)current_tb->tc.ptr +
+                        current_tb->jmp_target_arg[n] + 4) {
+                    /*
+                     * The sentinel may already have been overwritten by
+                     * the time its SIGILL is delivered.  Retry the pair to
+                     * recompute its scratch register from a consistent PC.
+                     */
+                    UC_PC(uc) = (uintptr_t)current_tb->tc.ptr +
+                        current_tb->jmp_target_arg[n];
+                    return;
+                }
+            }
+            if (*(unsigned int *)UC_PC(uc) == FASTTB_ILLINST_MAGIC) {
 #if defined(CONFIG_LATX_DEBUG)
                 fprintf(stderr, "[FAST_JMPCACHE] SIGILL handled\n");
 #endif
+                /*
+                 * The invalidating thread may have missed this CPU's fast
+                 * cache slot while another TB with the same hash occupied
+                 * the regular jump cache.  Clear it here before returning to
+                 * the dispatcher, otherwise it can select this sentinel
+                 * again indefinitely.
+                 */
+                uint32_t hash = tb_jmp_cache_hash_func(current_tb->pc);
+                qatomic_cmpxchg(&cpu->tb_jmp_cache[hash], current_tb, NULL);
+                latx_fast_jmp_cache_clear(cpu, hash);
                 /* set the next TB and point the epc to the epilogue */
                 UC_GR(uc)[reg_statics_map[S_UD1]] = current_tb->pc;
                 UC_PC(uc) = context_switch_native_to_bt_ret_0;
+                return;
             }
-            return;
         }
+    }
 #endif
 #ifdef CONFIG_LATX
     if (option_fork_unlink && host_signum == SIGRTMIN + 1 &&

--- a/target/i386/latx/translator/translate.c
+++ b/target/i386/latx/translator/translate.c
@@ -3294,6 +3294,12 @@ void latx_tb_set_jmp_target(TranslationBlock *tb, int n,
                                    TranslationBlock *next_tb)
 {
     assert(!use_tu_jmp(tb));
+    tb_set_jmp_target(tb, n, (uintptr_t)next_tb->tc.ptr);
+#ifdef CONFIG_LATX_LAZYLINK
+    if (tb->lazylink[n] != 2) {
+        return;
+    }
+#endif
 #ifdef CONFIG_LATX_INSTS_PATTERN
     if (n) {
         if (next_tb->eflag_use) {
@@ -3302,9 +3308,6 @@ void latx_tb_set_jmp_target(TranslationBlock *tb, int n,
             tb->bool_flags |= TARGET1_ELIMINATE;
         }
     }
-#endif
-    tb_set_jmp_target(tb, n, (uintptr_t)next_tb->tc.ptr);
-#ifdef CONFIG_LATX_INSTS_PATTERN
     /* TODO: TU */
     /* Eflags elimination */
     if (!next_tb->eflag_use &&

--- a/tcg/loongarch/tcg-target.c.inc
+++ b/tcg/loongarch/tcg-target.c.inc
@@ -38,6 +38,9 @@
   */
 
 #include "../tcg-pool.c.inc"
+#ifdef CONFIG_LATX_FAST_JMPCACHE
+#include "exec/fasttb.h"
+#endif
 
 //#define LOONGARCH_DEBUG
 
@@ -1894,6 +1897,39 @@ void tb_target_set_nop(uintptr_t tc_ptr, uintptr_t jmp_rx,
 }
 #endif
 
+void tb_target_set_jmp_pair(uintptr_t jmp_rx, uintptr_t jmp_rw,
+                            uint64_t pair)
+{
+    tcg_insn_unit i1 = pair;
+    tcg_insn_unit i2 = pair >> 32;
+
+#ifdef CONFIG_LATX_FAST_JMPCACHE
+    if ((i1 >> 26) == OPC_B) {
+        /* Stop an old first instruction from using a partially updated pair. */
+        qatomic_set((uint32_t *)(jmp_rw + 4), FASTTB_ILLINST_MAGIC);
+        flush_idcache_range(jmp_rx + 4, jmp_rw + 4, 4);
+        qatomic_set((uint32_t *)jmp_rw, i1);
+        flush_idcache_range(jmp_rx, jmp_rw, 4);
+    } else {
+        /* The old direct branch hides i2 until i1 is published. */
+        qatomic_set((uint32_t *)(jmp_rw + 4), i2);
+        flush_idcache_range(jmp_rx + 4, jmp_rw + 4, 4);
+        qatomic_set((uint32_t *)jmp_rw, i1);
+        flush_idcache_range(jmp_rx, jmp_rw, 4);
+    }
+#else
+    *(uint64_t *)jmp_rw = pair;
+    flush_idcache_range(jmp_rx, jmp_rw, 8);
+#endif
+}
+
+bool tb_target_jmp_in_range(uintptr_t jmp_rx, uintptr_t addr)
+{
+    ptrdiff_t offset = addr - jmp_rx;
+
+    return offset == sextreg(offset, 0, 28);
+}
+
 void tb_target_set_jmp_target(uintptr_t tc_ptr, uintptr_t jmp_rx,
                               uintptr_t jmp_rw, uintptr_t addr)
 {
@@ -1916,8 +1952,7 @@ void tb_target_set_jmp_target(uintptr_t tc_ptr, uintptr_t jmp_rx,
         i2 = 0x4c000000 | lower << 10 | TCG_REG_T0 << 5;
     }
     uint64_t pair = (uint64_t)i2 << 32 | i1;
-    *(uint64_t *)jmp_rw = pair;
-    flush_idcache_range(jmp_rx, jmp_rw, 8);
+    tb_target_set_jmp_pair(jmp_rx, jmp_rw, pair);
 #else
     tcg_insn_unit insn;
 

--- a/tcg/loongarch/tcg-target.h
+++ b/tcg/loongarch/tcg-target.h
@@ -162,6 +162,10 @@ typedef enum {
 
 /* not defined -- call should be eliminated at compile time */
 void tb_target_set_jmp_target(uintptr_t, uintptr_t, uintptr_t, uintptr_t);
+#ifdef CONFIG_LATX_LAZYLINK
+void tb_target_set_jmp_pair(uintptr_t, uintptr_t, uint64_t);
+bool tb_target_jmp_in_range(uintptr_t, uintptr_t);
+#endif
 #ifdef CONFIG_LATX_XCOMISX_OPT
 void tb_target_set_nop(uintptr_t, uintptr_t, uintptr_t, uintptr_t);
 #endif


### PR DESCRIPTION

## Summary / 变更说明

修复 LATX 在 JIT 代码失效期间可能反复执行无效翻译块、导致程序卡住的问题。

LATX 使用 `0x88888888` 非法指令标记已失效的翻译块。线程执行该指令产生 `SIGILL` 后，原处理逻辑可能没有彻底清除当前 CPU 中指向旧翻译块的缓存，导致调度器再次进入同一个旧块并反复触发 `SIGILL`。

本次修改在处理该 `SIGILL` 时：

- 使用原子比较交换清除仍指向旧翻译块的普通跳转缓存，避免覆盖并发写入的新翻译块。
- 同时清除对应的 LATX 快速跳转缓存。
- 返回调度器重新查找或生成翻译代码。

修改只作用于无效翻译块的异常处理，不在正常翻译块中增加检查指令。

## Validation / 验证

在 LoongArch 主机上关闭 AOT 验证，设置 `LATX_AOT=0`。

- `ninja -C build64 `：编译通过。
- 单独运行 `TestMetaspaceAllocationFailure.java` 中使用 `CompressedClassSpaceSize=10M` 的测试动作 10 次：
  - 10/10 均正常达到规定的 100 次循环。
  - 单次耗时 45 至 48 秒。
  - 未出现超时或 JVM 崩溃。
- 连续运行以下完整测试 3 次：

  ```sh
  make test-prebuilt \
    TEST="jdk/jfr/event/runtime/TestMetaspaceAllocationFailure.java" \
    JTREG="VERBOSE=all"
  ```

  - 3/3 均得到 `TEST RESULT: Passed. Skipped: jtreg.SkippedException: Exceeded MAX_ITERATIONS of 100`。
  - 耗时分别为 144、146、146 秒。
  - `SkippedException` 是测试达到 100 次循环上限后的预期结果。

## Checklist / 检查项

- [x] I have read `CONTRIBUTING.md`. / 我已阅读 `CONTRIBUTING.md`。
- [x] Every commit contains a DCO sign-off (`git commit -s`). /
  每个提交都包含 DCO 签署（`git commit -s`）。
- [x] I have included relevant build or test results, or explained why they
  are not applicable. /
  我已提供相关构建或测试结果，或说明了不适用的原因。