### PR TITLE
LATX, fix: Decouple ordinary INT3 from KZT TB boundaries

### DIFF
--- a/target/i386/latx/ir1/ir1.c
+++ b/target/i386/latx/ir1/ir1.c
@@ -15,6 +15,10 @@
 #include "insts-pattern.h"
 #include "lsenv.h"
 
+#if defined(CONFIG_LATX_KZT)
+#include "bridge.h"
+#endif
+
 IR1_OPND al_ir1_opnd;
 IR1_OPND ah_ir1_opnd;
 IR1_OPND ax_ir1_opnd;
@@ -1719,8 +1723,9 @@ int ir1_is_syscall(IR1_INST *ir1)
 bool ir1_is_tb_ending(IR1_INST *ir1)
 {
 #if defined(CONFIG_LATX_KZT)
-    if (latx_kzt_runtime_enabled() &&
-        ir1_opcode(ir1) == dt_X86_INS_INT3) {
+    if (CODEIS64 && latx_kzt_runtime_enabled() &&
+        ir1_opcode(ir1) == dt_X86_INS_INT3 &&
+        kzt_is_registered_onebridge(ir1_addr(ir1))) {
         return true;
     }
 #endif

--- a/target/i386/latx/translator/tr-misc.c
+++ b/target/i386/latx/translator/tr-misc.c
@@ -269,17 +269,50 @@ bool translate_int_3(IR1_INST *pir1)
             do_translate_brick_tb(wrapper, function, &state_info, cpu,
                                   state_info.current_pc, tb);
             mmap_unlock();
-        } else {
-            la_break(0x5);
+            return true;
         }
-    } else {
-        la_break(0x5);
     }
-    return true;
-#else
-    la_break(0x5);
-    return true;
 #endif
+    /*
+     * Host SIGTRAP recovery maps the instruction after la_break() back to a
+     * guest PC.  A terminal INT3 has no following guest mapping, so record
+     * the software-interrupt next EIP explicitly instead.
+     */
+#ifdef TARGET_X86_64
+    IR2_OPND codemode_value_opnd = ra_alloc_itemp();
+    IR2_OPND not_64 = ra_alloc_label();
+
+    la_ld_d(codemode_value_opnd, env_ir2_opnd,
+            offsetof(CPUX86State, sys.codemode));
+    la_beq(codemode_value_opnd, zero_ir2_opnd, not_64);
+    ra_free_temp(codemode_value_opnd);
+    tr_save_x64_8_registers_to_env(0xff, option_save_xmm);
+    la_label(not_64);
+#endif
+    tr_save_fcsr_to_env();
+    tr_save_registers_to_env(0xff, 0xff, 0xff, options_to_save());
+
+    IR2_OPND intno = ra_alloc_itemp();
+    li_guest_addr(intno, EXCP03_INT3);
+    la_st_w(intno, env_ir2_opnd, lsenv_offset_exception_index(lsenv));
+    ra_free_temp(intno);
+
+    IR2_OPND next_pc = ra_alloc_itemp();
+    target_ulong call_offset __attribute__((unused)) =
+            aot_get_call_offset(ir1_addr_next(pir1));
+    aot_load_guest_addr(next_pc, ir1_addr_next(pir1),
+                        LOAD_CALL_TARGET, call_offset);
+    la_store_addrx(next_pc, env_ir2_opnd,
+                   lsenv_offset_exception_next_eip(lsenv));
+    ra_free_temp(next_pc);
+
+    IR2_OPND helper_addr_opnd = ra_alloc_dbt_arg2();
+    aot_load_host_addr(helper_addr_opnd, (ADDR)helper_raise_int,
+                       LOAD_HELPER_RAISE_INT, 0);
+    la_jirl(ra_ir2_opnd, helper_addr_opnd, 0);
+
+    tr_load_registers_from_env(0x1, 0, 0, options_to_save());
+    return true;
 }
 
 bool translate_in(IR1_INST *pir1)

--- a/tests/integration/int3-sigtrap-rip.S
+++ b/tests/integration/int3-sigtrap-rip.S
@@ -1,0 +1,79 @@
+.equ __NR_rt_sigaction, 13
+.equ __NR_rt_sigreturn, 15
+.equ __NR_exit, 60
+.equ SIGTRAP, 5
+.equ SA_SIGINFO, 0x00000004
+.equ SA_RESTORER, 0x04000000
+/* offsetof(ucontext_t, uc_mcontext.gregs[REG_RIP]) on x86_64. */
+.equ UCONTEXT_RIP_OFFSET, 168
+
+.section .data
+.align 8
+trap_action:
+    .quad trap_handler
+    .quad (SA_SIGINFO | SA_RESTORER)
+    .quad signal_restorer
+    .quad 0
+
+.section .bss
+.align 4
+trap_seen:
+    .long 0
+
+.section .text
+.global _start
+.type _start, @function
+_start:
+    mov $__NR_rt_sigaction, %eax
+    mov $SIGTRAP, %edi
+    lea trap_action(%rip), %rsi
+    xor %edx, %edx
+    mov $8, %r10d
+    syscall
+    test %rax, %rax
+    js install_failed
+
+    int3
+after_int3:
+    cmpl $1, trap_seen(%rip)
+    jne signal_not_delivered
+    xor %edi, %edi
+    jmp exit
+
+install_failed:
+    mov $10, %edi
+    jmp exit
+
+.type trap_handler, @function
+trap_handler:
+    cmp $SIGTRAP, %edi
+    jne wrong_signal
+    lea after_int3(%rip), %rax
+    cmp %rax, UCONTEXT_RIP_OFFSET(%rdx)
+    jne wrong_rip
+    movl $1, trap_seen(%rip)
+    ret
+.size trap_handler, .-trap_handler
+
+wrong_signal:
+    mov $11, %edi
+    jmp exit
+
+wrong_rip:
+    mov $12, %edi
+    jmp exit
+
+signal_not_delivered:
+    mov $13, %edi
+
+exit:
+    mov $__NR_exit, %eax
+    syscall
+
+.type signal_restorer, @function
+signal_restorer:
+    mov $__NR_rt_sigreturn, %eax
+    syscall
+.size signal_restorer, .-signal_restorer
+
+.section .note.GNU-stack,"",@progbits

--- a/tests/integration/registrations/process/meson.build
+++ b/tests/integration/registrations/process/meson.build
@@ -39,4 +39,14 @@ if 'x86_64-linux-user' in target_dirs
       files('../../guest-fatal-signal-status.S'),
     ],
   }]
+  if 'CONFIG_LATX_KZT' in config_host
+    latx_integration_tests += [{
+      'name': 'test-int3-sigtrap-rip',
+      'runner': find_program('../../test-int3-sigtrap-rip.sh'),
+      'args': [
+        emulators['latx-x86_64'],
+        files('../../int3-sigtrap-rip.S'),
+      ],
+    }]
+  endif
 endif

--- a/tests/integration/test-int3-sigtrap-rip.sh
+++ b/tests/integration/test-int3-sigtrap-rip.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+set -eu
+
+emulator=$1
+source_file=$2
+workdir=$(mktemp -d)
+trap 'rm -rf "$workdir"' EXIT HUP INT TERM
+
+if command -v clang-19 >/dev/null 2>&1; then
+    clang=clang-19
+elif command -v clang >/dev/null 2>&1; then
+    clang=clang
+else
+    echo "SKIP: clang is required to build the x86_64 guest"
+    exit 77
+fi
+
+"$clang" --target=x86_64-linux-gnu -fuse-ld=lld -nostdlib -static \
+    -Wl,--build-id=none "$source_file" -o "$workdir/int3-sigtrap-rip"
+
+for mode in 0 2; do
+    set +e
+    timeout 10s env LATX_AOT=0 LATX_KZT=$mode LATX_KZT_LIBS=core \
+        "$emulator" "$workdir/int3-sigtrap-rip"
+    ret=$?
+    set -e
+
+    case $ret in
+    0) ;;
+    10) echo "FAIL: rt_sigaction failed with LATX_KZT=$mode" >&2; exit $ret ;;
+    11) echo "FAIL: wrong signal reached the handler with LATX_KZT=$mode" >&2; exit $ret ;;
+    12) echo "FAIL: terminal INT3 restored the wrong RIP with LATX_KZT=$mode" >&2; exit $ret ;;
+    13) echo "FAIL: INT3 did not deliver SIGTRAP with LATX_KZT=$mode" >&2; exit $ret ;;
+    124) echo "FAIL: terminal INT3 test timed out with LATX_KZT=$mode" >&2; exit $ret ;;
+    *) echo "FAIL: unexpected exit status $ret with LATX_KZT=$mode" >&2; exit $ret ;;
+    esac
+done
+
+echo "PASS: terminal INT3 preserves SIGTRAP next RIP"


### PR DESCRIPTION
## Cause

Ordinary `INT3` was lowered to a host `break`, and its next guest EIP was recovered from the following host instruction mapping. KZT also ended every `INT3` translation block to protect onebridge metadata, so an ordinary terminal `INT3` had no following mapping and exposed a stale EIP.

Only registered onebridge stubs require this boundary: their `0xCC` byte is followed by wrapper metadata rather than guest instructions. Applying the boundary to every `INT3` unnecessarily changed ordinary guest code when KZT was enabled.

## Fix

Raise ordinary `INT3` through the software-interrupt path and record its next EIP explicitly. End a KZT `INT3` translation block only when its address identifies a registered 64-bit onebridge stub.

## Regression coverage

Add a static guest that verifies the `SIGTRAP` ucontext RIP and post-`rt_sigreturn` continuation with KZT disabled and enabled.
