### PR TITLE
LATX, fix: Emulate i386 robust-list registration

### DIFF
--- a/linux-user/qemu.h
+++ b/linux-user/qemu.h
@@ -230,6 +230,10 @@ typedef struct TaskState {
     /* This thread's sigaltstack, if it has one */
     struct target_sigaltstack sigaltstack_used;
 #ifdef TARGET_I386
+#if defined(CONFIG_LATX) && !defined(TARGET_X86_64)
+    /* i386 robust futex list head in guest address space. */
+    abi_ulong robust_list_head;
+#endif
     /* This thread's syscall user dispatch state; ~0 means disabled. */
     abi_ulong sys_dispatch;
     abi_ulong sys_dispatch_selector;

--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -9928,6 +9928,9 @@ static int do_fork(CPUArchState *env, unsigned int flags, abi_ulong newsp,
             if (flags & CLONE_CHILD_SETTID)
                 put_user_u32(sys_gettid(), child_tidptr);
             ts = (TaskState *)cpu->opaque;
+#if defined(CONFIG_LATX) && defined(TARGET_I386) && !defined(TARGET_X86_64)
+            qatomic_set(&ts->robust_list_head, 0);
+#endif
             /* Linux clears syscall user dispatch in every fork child. */
 #ifdef TARGET_I386
             ts->sys_dispatch = 0;
@@ -11065,6 +11068,38 @@ static int do_safe_futex(int *uaddr, int op, int val,
 #endif /* HOST_LONG_BITS == 64 */
     return -TARGET_ENOSYS;
 }
+
+#if defined(CONFIG_LATX) && defined(TARGET_I386) && !defined(TARGET_X86_64)
+#define I386_ROBUST_LIST_HEAD_SIZE       (3 * sizeof(uint32_t))
+
+static abi_long i386_latx_set_robust_list(CPUState *cpu, abi_ulong head,
+                                           abi_ulong len)
+{
+    if (len != I386_ROBUST_LIST_HEAD_SIZE) {
+        return -TARGET_EINVAL;
+    }
+
+    /* The i386 list layout cannot be registered with the native kernel. */
+    qatomic_set(&((TaskState *)cpu->opaque)->robust_list_head, head);
+    return 0;
+}
+
+static abi_long i386_latx_get_robust_list(CPUState *cpu, abi_long pid,
+                                           abi_ulong head_ptr,
+                                           abi_ulong len_ptr)
+{
+    TaskState *current = cpu->opaque;
+
+    if (pid && pid != sys_gettid()) {
+        return -TARGET_ESRCH;
+    }
+    if (put_user_u32(I386_ROBUST_LIST_HEAD_SIZE, len_ptr) ||
+        put_user_u32(qatomic_read(&current->robust_list_head), head_ptr)) {
+        return -TARGET_EFAULT;
+    }
+    return 0;
+}
+#endif
 
 /* ??? Using host futex calls even when target atomic operations
    are not really atomic probably breaks things.  However implementing
@@ -19713,8 +19748,15 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
 
 #ifdef TARGET_NR_set_robust_list
     case TARGET_NR_set_robust_list:
-         return get_errno(syscall(__NR_set_robust_list, arg1, arg2));
+#if defined(CONFIG_LATX) && defined(TARGET_I386) && !defined(TARGET_X86_64)
+        return i386_latx_set_robust_list(cpu, arg1, arg2);
+#else
+        return get_errno(syscall(__NR_set_robust_list, arg1, arg2));
+#endif
     case TARGET_NR_get_robust_list:
+#if defined(CONFIG_LATX) && defined(TARGET_I386) && !defined(TARGET_X86_64)
+        return i386_latx_get_robust_list(cpu, arg1, arg2, arg3);
+#else
         /* The ABI for supporting robust futexes has userspace pass
          * the kernel a pointer to a linked list which is updated by
          * userspace after the syscall; the list is walked by the kernel
@@ -19729,6 +19771,7 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
          */
         return get_errno(syscall(__NR_get_robust_list, arg1, g2h_untagged(arg2),
                         g2h_untagged(arg3)));
+#endif
 #endif
 
 #if defined(TARGET_NR_utimensat)


### PR DESCRIPTION
## Summary / 变更说明

- Title: `linux-user, fix: Emulate i386 robust-list registration`

Steam's i386 `steamclient` registers a 12-byte robust-list head while
initializing pthreads. Forwarding that guest layout to the LoongArch native
syscall fails because the host expects native-width list pointers.

This PR stores the i386 registration in `TaskState`, returns it through the
current guest task's `get_robust_list` ABI, and clears inherited state in a
fork child. It never passes the incompatible guest list to the host kernel.

No new in-tree robust-list fixture is added. The existing static i386 ABI probe
is run as a runtime check. Independent source review passed after the scope was
reduced to the observed Steam registration/query path.

## Validation / 验证

- `ninja -C build32 latx-i386`: passed.
- `ninja -C build64 latx-x86_64`: passed.
- `build32/latx-i386 ~/test/steam/artifacts/steam-latx-debug/tools/robust-list-i386`:
  passed with exit status 0.
- `git diff --check`: passed.
- Commit-level `scripts/checkpatch.pl`: 0 errors, 0 warnings.
- End-to-end `/usr/bin/steam` validation is deferred to the rebuilt combined
  integration branch, where this repair is exercised with the remaining Steam
  fixes.

## Remaining Scope / 风险

- This is not general robust-futex support: it does not emulate owner-death
  cleanup for a thread exit, process exit, fatal signal, or `exec`.
- `get_robust_list(pid, ...)` supports only the current guest task (`pid == 0`
  or its visible TID); another TID returns `ESRCH`.
- If Steam later demonstrates a held robust mutex across thread exit or
  `exec`, that lifecycle behavior requires a separate, fully scoped PR.
- The change applies only to the LATX i386 build. It is compiled out for
  x86_64.

## Checklist / 检查项

- [x] I have read `CONTRIBUTING.md`. / 我已阅读 `CONTRIBUTING.md`。
- [x] Every commit contains a DCO sign-off (`git commit -s`). /
      每个提交都包含 DCO 签署（`git commit -s`）。
- [x] I have included relevant build or test results, or explained why they
      are not applicable. / 我已提供相关构建或测试结果，或说明了不适用的原因。