### PR TITLE
LATX, fix: Resolve Steam i386 libraries beside selected

### DIFF
--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -166,7 +166,7 @@
 #include "exec/fasttb.h"
 #endif
 
-#ifdef CONFIG_LATX_TUNNEL_LIB
+#if defined(CONFIG_LATX) && defined(TARGET_I386)
 static bool is_tunnel_loader_address(const TaskState *ts, abi_ulong addr)
 {
     if (!ts->info || !ts->info->interpreter_path) {
@@ -177,6 +177,9 @@ static bool is_tunnel_loader_address(const TaskState *ts, abi_ulong addr)
            (page_get_flags(addr) & PAGE_TUNNEL_LOADER);
 }
 
+#endif
+
+#ifdef CONFIG_LATX_TUNNEL_LIB
 static bool is_tunnel_loader_notification(CPUArchState *env,
                                           abi_ulong method)
 {
@@ -12872,6 +12875,47 @@ static int has_x_permission(struct stat *st) {
     }
 }
 
+#if defined(CONFIG_LATX) && defined(TARGET_I386) && !defined(TARGET_X86_64)
+static char *latx_i386_interpreter_library(CPUArchState *env,
+                                            const char *pathname)
+{
+    TaskState *ts = env_cpu(env)->opaque;
+    const char *basename;
+    const char *program;
+    const char *so;
+    char *interpreter;
+    char *directory;
+    char *candidate;
+
+    basename = strrchr(pathname, '/');
+    if (!ts || !ts->bprm || !ts->bprm->filename ||
+        !is_tunnel_loader_address(ts, env->eip) ||
+        pathname[0] != '/' || !basename ||
+        !g_str_has_prefix(++basename, "lib")) {
+        return NULL;
+    }
+    program = strrchr(ts->bprm->filename, '/');
+    program = program ? program + 1 : ts->bprm->filename;
+    if (strcmp(program, "gldriverquery") && strcmp(program, "steam")) {
+        return NULL;
+    }
+    so = strstr(basename, ".so");
+    if (!so || (so[3] && so[3] != '.')) {
+        return NULL;
+    }
+
+    interpreter = realpath(path(ts->info->interpreter_path), NULL);
+    if (!interpreter) {
+        return NULL;
+    }
+    directory = g_path_get_dirname(interpreter);
+    free(interpreter);
+    candidate = g_build_filename(directory, basename, NULL);
+    g_free(directory);
+    return candidate;
+}
+#endif
+
 static int do_openat(void *cpu_env, int dirfd, const char *pathname, int flags, mode_t mode)
 {
     struct fake_open {
@@ -12980,7 +13024,26 @@ static int do_openat(void *cpu_env, int dirfd, const char *pathname, int flags, 
             }
         }
     }
-    return safe_openat(dirfd, path(pathname), flags, mode);
+    int ret = safe_openat(dirfd, realpath, flags, mode);
+
+#if defined(CONFIG_LATX) && defined(TARGET_I386) && !defined(TARGET_X86_64)
+    if (ret < 0 && errno == ENOENT && realpath == pathname &&
+        (flags & (O_ACCMODE | O_CREAT | O_TRUNC | O_APPEND)) == O_RDONLY) {
+        char *runtime_path;
+        int saved_errno = errno;
+
+        runtime_path = latx_i386_interpreter_library(cpu_env, pathname);
+        if (runtime_path) {
+            ret = safe_openat(dirfd, runtime_path, flags, mode);
+            g_free(runtime_path);
+        }
+        if (ret < 0) {
+            errno = saved_errno;
+        }
+    }
+#endif
+
+    return ret;
 }
 
 #define MAX_PATH_SIZE 1024


### PR DESCRIPTION
## Summary / 变更说明

- Title: `linux-user, fix: Resolve Steam i386 libraries beside selected loader`

Steam Runtime i386 `steam` and `gldriverquery` can request an absolute
`lib*.so*` that is absent from the configured runtime prefix even though the
selected PT_INTERP loader's directory contains the matching library. This
prevented `steam` from creating its GLX visual and blocked the client UI.

After the original read-only unprefixed open returns `ENOENT`, this PR retries
the same library basename beside the selected loader only for `steam` or
`gldriverquery`. It reuses the existing trusted loader-page check, retains the
original errno on an unsuccessful retry, and keeps the fallback i386-only. It
adds no launcher, `LAT_SET_ENV`, `PRESSURE_VESSEL_PREFIX`, or other environment
injection.

No dedicated automated test is added: a faithful fixture requires an i386
guest, a selected PT_INTERP loader, and a deliberately incomplete runtime
prefix. Steam Runtime `gldriverquery` directly exercises the affected path.
Independent review passed after the fallback was limited to the two observed
Steam executable basenames.

## Validation / 验证

- `ninja -C build32 --quiet latx-i386`: passed.
- `ninja -C build64 --quiet latx-x86_64`: passed.
- `git diff --check`: passed.
- Commit-level `scripts/checkpatch.pl`: 0 errors, 0 warnings.
- Steam Runtime regression:
  `ubuntu12_32/steam-runtime/run.sh ubuntu12_32/gldriverquery` passed the
  previous “Couldn't find matching GLX visual” failure and reached the
  separate `radeonsi` / `X_GLXCreateContext` failure.

## Remaining Scope / 风险

- Only the `steam` and `gldriverquery` basenames executing through a trusted
  i386 dynamic loader may invoke the fallback, and only for a read-only
  absolute `lib*.so*` open that missed the normal unprefixed path.
- A library absent beside the selected loader returns the original `ENOENT`.
- The fallback path is compiled out for x86_64; the shared loader identity
  helper remains available to its pre-existing x86_64 tunnel notification use.
- No negative test currently covers other executable basenames, an untrusted
  loader page, retry errno restoration, or `O_PATH`; the independent review
  accepted this as a narrow, Steam-only limitation rather than widening the
  change or adding an environment-specific fixture.
- This is a hack method specifically for Steam, not applicable to general scenarios.

## Checklist / 检查项

- [x] I have read `CONTRIBUTING.md`. / 我已阅读 `CONTRIBUTING.md`。
- [x] Every commit contains a DCO sign-off (`git commit -s`). /
      每个提交都包含 DCO 签署（`git commit -s`）。
- [x] I have included relevant build or test results, or explained why they
      are not applicable. / 我已提供相关构建或测试结果，或说明了不适用的原因。