### PR TITLE
LATX, fix: Translate legacy i386 AMDGPU GEM_VA ioctl

### DIFF
--- a/linux-user/ioctl/ioctl_def/def_amdgpu_drm.h
+++ b/linux-user/ioctl/ioctl_def/def_amdgpu_drm.h
@@ -16,6 +16,13 @@
     TARGET_IOWR('d', 0x47, union drm_amdgpu_gem_wait_idle)
 #define TARGET_DRM_IOCTL_AMDGPU_GEM_VA \
     TARGET_IOWR('d', 0x48, struct drm_amdgpu_gem_va)
+#if defined(TARGET_I386) && !defined(TARGET_X86_64) && \
+    !defined(CONFIG_AMDGPU_GEN_VA_OLD)
+/* Older libdrm clients pass this 40-byte pre-timeline request. */
+#define TARGET_DRM_IOCTL_AMDGPU_GEM_VA_OLD \
+    TARGET_IOWR('d', 0x48, struct target_drm_amdgpu_gem_va_old)
+#define DRM_IOCTL_AMDGPU_GEM_VA_OLD DRM_IOCTL_AMDGPU_GEM_VA
+#endif
 #define TARGET_DRM_IOCTL_AMDGPU_WAIT_CS \
     TARGET_IOWR('d', 0x49, union drm_amdgpu_wait_cs)
 #define TARGET_DRM_IOCTL_AMDGPU_GEM_OP \
@@ -88,3 +95,15 @@ struct target_drm_amdgpu_fence_to_handle_in {
     abi_uint pad;
 };
 
+#if defined(TARGET_I386) && !defined(TARGET_X86_64) && \
+    !defined(CONFIG_AMDGPU_GEN_VA_OLD)
+struct target_drm_amdgpu_gem_va_old {
+    abi_uint handle;
+    abi_uint _pad;
+    abi_uint operation;
+    abi_uint flags;
+    abi_ullong va_address;
+    abi_ullong offset_in_bo;
+    abi_ullong map_size;
+};
+#endif

--- a/linux-user/ioctl/ioctl_syscall/syscall_amdgpu_drm.c
+++ b/linux-user/ioctl/ioctl_syscall/syscall_amdgpu_drm.c
@@ -39,6 +39,24 @@ static inline abi_long target_to_host_drm_amdgpu_gem_metadata
     return 0;
 }
 
+#if defined(TARGET_I386) && !defined(TARGET_X86_64) && \
+    !defined(CONFIG_AMDGPU_GEN_VA_OLD)
+static inline abi_long target_to_host_drm_amdgpu_gem_va_old
+                        (struct drm_amdgpu_gem_va *host_ver,
+         struct target_drm_amdgpu_gem_va_old *target_ver)
+{
+    memset(host_ver, 0, sizeof(*host_ver));
+    __get_user(host_ver->handle, &target_ver->handle);
+    __get_user(host_ver->_pad, &target_ver->_pad);
+    __get_user(host_ver->operation, &target_ver->operation);
+    __get_user(host_ver->flags, &target_ver->flags);
+    __get_user(host_ver->va_address, &target_ver->va_address);
+    __get_user(host_ver->offset_in_bo, &target_ver->offset_in_bo);
+    __get_user(host_ver->map_size, &target_ver->map_size);
+    return 0;
+}
+#endif
+
 static inline void host_to_target_drm_amdgpu_gem_metadata
                         (struct target_drm_amdgpu_gem_metadata *target_ver,
          struct drm_amdgpu_gem_metadata *host_ver)
@@ -90,6 +108,11 @@ static abi_long do_ioctl_amdgpu_drm(const IOCTLEntry *ie,
     struct drm_amdgpu_gem_metadata *drm_amdgpu_gem_metadata;
     struct target_drm_amdgpu_fence_to_handle_in *target_drm_amdgpu_fence_to_handle_in;
     union drm_amdgpu_fence_to_handle *drm_amdgpu_fence_to_handle;
+#if defined(TARGET_I386) && !defined(TARGET_X86_64) && \
+    !defined(CONFIG_AMDGPU_GEN_VA_OLD)
+    struct target_drm_amdgpu_gem_va_old *target_drm_amdgpu_gem_va_old;
+    struct drm_amdgpu_gem_va *drm_amdgpu_gem_va;
+#endif
     switch (ie->host_cmd) {
     case DRM_IOCTL_AMDGPU_INFO:
         if (!lock_user_struct(VERIFY_READ, target_drm_amdgpu_info, arg, 0)) {
@@ -125,6 +148,23 @@ static abi_long do_ioctl_amdgpu_drm(const IOCTLEntry *ie,
         }
         unlock_user_struct(target_drm_amdgpu_gem_metadata, arg, 0);
         return ret;
+#if defined(TARGET_I386) && !defined(TARGET_X86_64) && \
+    !defined(CONFIG_AMDGPU_GEN_VA_OLD)
+    case DRM_IOCTL_AMDGPU_GEM_VA:
+        if (!lock_user_struct(VERIFY_READ,
+                              target_drm_amdgpu_gem_va_old, arg, 0)) {
+            return -TARGET_EFAULT;
+        }
+        drm_amdgpu_gem_va = (struct drm_amdgpu_gem_va *)buf_temp;
+        ret = target_to_host_drm_amdgpu_gem_va_old(
+                    drm_amdgpu_gem_va, target_drm_amdgpu_gem_va_old);
+        if (!is_error(ret)) {
+            ret = get_errno(safe_ioctl(fd, ie->host_cmd,
+                                       drm_amdgpu_gem_va));
+        }
+        unlock_user_struct(target_drm_amdgpu_gem_va_old, arg, 0);
+        return ret;
+#endif
     case DRM_IOCTL_AMDGPU_FENCE_TO_HANDLE:
         if (!lock_user_struct(VERIFY_READ,
                     target_drm_amdgpu_fence_to_handle_in, arg, 0)) {
@@ -147,4 +187,3 @@ static abi_long do_ioctl_amdgpu_drm(const IOCTLEntry *ie,
     }
     return -TARGET_ENOSYS;
 }
-

--- a/linux-user/ioctl/ioctl_type/type_amdgpu_drm.h
+++ b/linux-user/ioctl/ioctl_type/type_amdgpu_drm.h
@@ -41,6 +41,17 @@ STRUCT(drm_amdgpu_gem_wait_idle_in,
     TYPE_INT,
     TYPE_INT,
     TYPE_ULONGLONG)
+#if defined(TARGET_I386) && !defined(TARGET_X86_64) && \
+    !defined(CONFIG_AMDGPU_GEN_VA_OLD)
+STRUCT(drm_amdgpu_gem_va_old,
+    TYPE_INT,
+    TYPE_INT,
+    TYPE_INT,
+    TYPE_INT,
+    TYPE_ULONGLONG,
+    TYPE_ULONGLONG,
+    TYPE_ULONGLONG)
+#endif
 #ifdef CONFIG_AMDGPU_GEN_VA_OLD
 STRUCT(drm_amdgpu_gem_va,
     TYPE_INT,

--- a/linux-user/ioctl/ioctls/ioctl_amdgpu_drm.h
+++ b/linux-user/ioctl/ioctls/ioctl_amdgpu_drm.h
@@ -14,6 +14,11 @@ IOCTL_SPECIAL(DRM_IOCTL_AMDGPU_GEM_METADATA, IOC_RW, do_ioctl_amdgpu_drm,
       MK_PTR(MK_STRUCT(STRUCT_drm_amdgpu_gem_metadata)))
 IOCTL(DRM_IOCTL_AMDGPU_GEM_WAIT_IDLE, IOC_RW,
       MK_PTR(MK_STRUCT(STRUCT_drm_amdgpu_gem_wait_idle_in)))
+#if defined(TARGET_I386) && !defined(TARGET_X86_64) && \
+    !defined(CONFIG_AMDGPU_GEN_VA_OLD)
+IOCTL_SPECIAL(DRM_IOCTL_AMDGPU_GEM_VA_OLD, IOC_W, do_ioctl_amdgpu_drm,
+      MK_PTR(MK_STRUCT(STRUCT_drm_amdgpu_gem_va_old)))
+#endif
 IOCTL(DRM_IOCTL_AMDGPU_GEM_VA, IOC_RW,
       MK_PTR(MK_STRUCT(STRUCT_drm_amdgpu_gem_va)))
 IOCTL(DRM_IOCTL_AMDGPU_WAIT_CS, IOC_RW,


### PR DESCRIPTION
## Summary / 变更说明

- Steam Runtime's i386 libdrm sends the 40-byte pre-timeline GEM_VA request
  through the same command number used by the current 64-byte host ABI.  The
  size encoded in the guest request therefore misses the generic current-ABI
  ioctl entry.
- Register the legacy request only for i386 builds using current host DRM
  headers, then copy its seven common fields into a zero-initialized current
  host structure before issuing the host ioctl.  x86_64 and hosts whose headers
  still use the 40-byte layout retain their existing paths.
- An independent read-only review found no remaining code-level blockers.  It
  verified the 40-byte layout, guest command encoding, host alias, locking and
  error paths, and the `CONFIG_AMDGPU_GEN_VA_OLD` exclusion.
- No automated test was added.  This is a small ABI marshalling fix, and a
  faithful fixture would require an i386 guest, the Steam runtime's old libdrm,
  and a real DRM device; the Steam Runtime `gldriverquery` regression directly
  exercises the affected path.

## Validation / 验证

- `ninja -C build32 latx-i386` — passed.
- `ninja -C build64 latx-x86_64` — passed.
- `git diff --check` — passed; the final patch check reported 0 errors and 0
  warnings.
- The final i386 and x86_64 binaries were rebuilt after the temporary combined
  validation was reverted, so the PR branch remains independent of PR1.
- Combined validation temporarily merged PR1 without committing, then ran
  `ubuntu12_32/steam-runtime/run.sh ubuntu12_32/gldriverquery`; it exited 0.
  The direct `/usr/bin/steam` run used no custom launcher or injected
  environment.  It reached GPU topology (`AMD RADV OLAND`) and Web/UI
  initialization; the previous GLX/radeonsi context failure did not recur, but
  the main client still segfaulted during later Web/UI startup.  Login/main UI
  acceptance therefore remains pending the next independent fix.

## Checklist / 检查项

- [x] I have read `CONTRIBUTING.md`. / 我已阅读 `CONTRIBUTING.md`。
- [x] Every commit contains a DCO sign-off (`git commit -s`). /
      每个提交都包含 DCO 签署（`git commit -s`）。
- [x] I have included relevant build or test results, or explained why they
      are not applicable. /
      我已提供相关构建或测试结果，或说明了不适用的原因。