### PR TITLE
LATX, fix: Resolve Guest dlfcn from live objects

### DIFF
--- a/target/i386/latx/context/kzt_public_loader_observer.c
+++ b/target/i386/latx/context/kzt_public_loader_observer.c
@@ -27,6 +27,15 @@ _Static_assert(sizeof(kzt_x86_64_link_map_prefix_t) == 40,
 #define KZT_X86_64_ELFDATA2LSB 1
 #define KZT_X86_64_EV_CURRENT 1
 #define KZT_X86_64_PT_GNU_RELRO UINT32_C(0x6474e552)
+#define KZT_X86_64_DT_HASH 4
+#define KZT_X86_64_DT_STRTAB 5
+#define KZT_X86_64_DT_SYMTAB 6
+#define KZT_X86_64_DT_STRSZ 10
+#define KZT_X86_64_DT_SYMENT 11
+#define KZT_X86_64_DT_GNU_HASH INT64_C(0x6ffffef5)
+#define KZT_PUBLIC_LOADER_MAX_DYNAMIC_ENTRIES 4096
+#define KZT_PUBLIC_LOADER_MAX_SYMBOLS (1024 * 1024)
+#define KZT_PUBLIC_LOADER_MAX_SYMBOL_NAME 512
 
 typedef struct kzt_x86_64_elf_header {
     uint8_t ident[16];
@@ -56,10 +65,21 @@ typedef struct kzt_x86_64_program_header {
     uint64_t align;
 } kzt_x86_64_program_header_t;
 
+typedef struct kzt_x86_64_symbol {
+    uint32_t name;
+    uint8_t info;
+    uint8_t other;
+    uint16_t section_index;
+    uint64_t value;
+    uint64_t size;
+} kzt_x86_64_symbol_t;
+
 _Static_assert(sizeof(kzt_x86_64_elf_header_t) == 64,
                "unexpected x86_64 ELF header layout");
 _Static_assert(sizeof(kzt_x86_64_program_header_t) == 56,
                "unexpected x86_64 program header layout");
+_Static_assert(sizeof(kzt_x86_64_symbol_t) == 24,
+               "unexpected x86_64 symbol layout");
 
 static int kzt_public_loader_read(
     const kzt_public_loader_reader_t *reader,
@@ -91,6 +111,282 @@ static int kzt_public_loader_add_offset(uintptr_t base,
     }
     *result = base + offset;
     return 0;
+}
+
+static int kzt_public_loader_dynamic_pointer(
+    const kzt_public_loader_object_t *object,
+    uint64_t value,
+    uintptr_t *result)
+{
+    if (!object || !value || !result) {
+        return -1;
+    }
+    if (value >= object->load_bias) {
+        *result = (uintptr_t)value;
+        return 0;
+    }
+    if (value > UINTPTR_MAX - object->load_bias) {
+        return -1;
+    }
+    *result = object->load_bias + (uintptr_t)value;
+    return 0;
+}
+
+static kzt_public_loader_result_t kzt_public_loader_gnu_symbol_count(
+    const kzt_public_loader_reader_t *reader,
+    uintptr_t hash_addr,
+    size_t *symbol_count)
+{
+    uint32_t header[4];
+    uintptr_t buckets_addr;
+    uintptr_t chains_addr;
+    size_t maximum = 0;
+    size_t bucket_index;
+
+    if (kzt_public_loader_read(reader, hash_addr,
+                               header, sizeof(header)) != 0) {
+        return KZT_PUBLIC_LOADER_READ_ERROR;
+    }
+    if (!header[0] || !header[2] ||
+        header[0] > KZT_PUBLIC_LOADER_MAX_SYMBOLS ||
+        header[1] > KZT_PUBLIC_LOADER_MAX_SYMBOLS ||
+        header[2] > KZT_PUBLIC_LOADER_MAX_SYMBOLS) {
+        return KZT_PUBLIC_LOADER_LIMIT;
+    }
+    if (hash_addr > UINTPTR_MAX - sizeof(header) ||
+        header[2] > (UINTPTR_MAX - hash_addr - sizeof(header)) /
+                        sizeof(uint64_t)) {
+        return KZT_PUBLIC_LOADER_OVERFLOW;
+    }
+    buckets_addr = hash_addr + sizeof(header) +
+                   (uintptr_t)header[2] * sizeof(uint64_t);
+    if (header[0] > (UINTPTR_MAX - buckets_addr) / sizeof(uint32_t)) {
+        return KZT_PUBLIC_LOADER_OVERFLOW;
+    }
+    chains_addr = buckets_addr +
+                  (uintptr_t)header[0] * sizeof(uint32_t);
+
+    for (bucket_index = 0; bucket_index < header[0]; ++bucket_index) {
+        uintptr_t entry_addr;
+        uint32_t symbol_index;
+        size_t chain_steps = 0;
+
+        if (kzt_public_loader_add_offset(
+                buckets_addr, bucket_index, sizeof(symbol_index),
+                &entry_addr) != 0) {
+            return KZT_PUBLIC_LOADER_OVERFLOW;
+        }
+        if (kzt_public_loader_read(reader, entry_addr,
+                                   &symbol_index,
+                                   sizeof(symbol_index)) != 0) {
+            return KZT_PUBLIC_LOADER_READ_ERROR;
+        }
+        if (!symbol_index) {
+            continue;
+        }
+        if (symbol_index < header[1] ||
+            symbol_index > KZT_PUBLIC_LOADER_MAX_SYMBOLS) {
+            return KZT_PUBLIC_LOADER_INVALID_STATE;
+        }
+        while (1) {
+            uint32_t chain;
+
+            if (kzt_public_loader_add_offset(
+                    chains_addr, symbol_index - header[1],
+                    sizeof(chain), &entry_addr) != 0) {
+                return KZT_PUBLIC_LOADER_OVERFLOW;
+            }
+            if (kzt_public_loader_read(reader, entry_addr,
+                                       &chain, sizeof(chain)) != 0) {
+                return KZT_PUBLIC_LOADER_READ_ERROR;
+            }
+            if (symbol_index > maximum) {
+                maximum = symbol_index;
+            }
+            if (chain & 1) {
+                break;
+            }
+            if (++chain_steps == KZT_PUBLIC_LOADER_MAX_SYMBOLS ||
+                ++symbol_index > KZT_PUBLIC_LOADER_MAX_SYMBOLS) {
+                return KZT_PUBLIC_LOADER_LIMIT;
+            }
+        }
+    }
+    *symbol_count = maximum ? maximum + 1 : header[1];
+    return KZT_PUBLIC_LOADER_OK;
+}
+
+static int kzt_public_loader_symbol_name_matches(
+    const kzt_public_loader_reader_t *reader,
+    uintptr_t string_addr,
+    size_t available,
+    const char *symbol_name,
+    size_t symbol_name_size)
+{
+    size_t index;
+
+    if (symbol_name_size + 1 > available) {
+        return 0;
+    }
+    for (index = 0; index <= symbol_name_size; ++index) {
+        char byte;
+
+        if (string_addr > UINTPTR_MAX - index ||
+            kzt_public_loader_read(reader, string_addr + index,
+                                   &byte, sizeof(byte)) != 0) {
+            return -1;
+        }
+        if (byte != symbol_name[index]) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+static kzt_public_loader_result_t kzt_public_loader_find_object_symbol(
+    const kzt_public_loader_object_t *object,
+    const kzt_public_loader_reader_t *reader,
+    const char *symbol_name,
+    size_t symbol_name_size,
+    uintptr_t *symbol_addr)
+{
+    uintptr_t hash_addr = 0;
+    uintptr_t string_table_addr = 0;
+    uintptr_t symbol_table_addr = 0;
+    uint64_t string_table_value = 0;
+    uint64_t symbol_table_value = 0;
+    uint64_t hash_value = 0;
+    uint64_t gnu_hash_value = 0;
+    uint64_t string_table_size = 0;
+    uint64_t symbol_entry_size = 0;
+    uint32_t hash_header[2];
+    size_t symbol_count;
+    size_t index;
+    int terminated = 0;
+
+    if (!object->dynamic_addr) {
+        return KZT_PUBLIC_LOADER_NOT_FOUND;
+    }
+    for (index = 0; index < KZT_PUBLIC_LOADER_MAX_DYNAMIC_ENTRIES;
+         ++index) {
+        kzt_x86_64_dynamic_entry_t entry;
+        uintptr_t entry_addr;
+
+        if (kzt_public_loader_add_offset(
+                object->dynamic_addr, index, sizeof(entry),
+                &entry_addr) != 0) {
+            return KZT_PUBLIC_LOADER_OVERFLOW;
+        }
+        if (kzt_public_loader_read(reader, entry_addr,
+                                   &entry, sizeof(entry)) != 0) {
+            return KZT_PUBLIC_LOADER_READ_ERROR;
+        }
+        if (entry.tag == KZT_X86_64_DT_NULL) {
+            terminated = 1;
+            break;
+        }
+        switch (entry.tag) {
+        case KZT_X86_64_DT_HASH:
+            hash_value = entry.value;
+            break;
+        case KZT_X86_64_DT_GNU_HASH:
+            gnu_hash_value = entry.value;
+            break;
+        case KZT_X86_64_DT_STRTAB:
+            string_table_value = entry.value;
+            break;
+        case KZT_X86_64_DT_SYMTAB:
+            symbol_table_value = entry.value;
+            break;
+        case KZT_X86_64_DT_STRSZ:
+            string_table_size = entry.value;
+            break;
+        case KZT_X86_64_DT_SYMENT:
+            symbol_entry_size = entry.value;
+            break;
+        default:
+            break;
+        }
+    }
+    if (!terminated) {
+        return KZT_PUBLIC_LOADER_LIMIT;
+    }
+    if ((!hash_value && !gnu_hash_value) ||
+        !string_table_value || !symbol_table_value ||
+        !string_table_size ||
+        symbol_entry_size != sizeof(kzt_x86_64_symbol_t)) {
+        return KZT_PUBLIC_LOADER_NOT_FOUND;
+    }
+    if (kzt_public_loader_dynamic_pointer(
+            object, hash_value ? hash_value : gnu_hash_value,
+            &hash_addr) != 0 ||
+        kzt_public_loader_dynamic_pointer(
+            object, string_table_value, &string_table_addr) != 0 ||
+        kzt_public_loader_dynamic_pointer(
+            object, symbol_table_value, &symbol_table_addr) != 0) {
+        return KZT_PUBLIC_LOADER_OVERFLOW;
+    }
+    if (hash_value) {
+        if (kzt_public_loader_read(reader, hash_addr,
+                                   hash_header, sizeof(hash_header)) != 0) {
+            return KZT_PUBLIC_LOADER_READ_ERROR;
+        }
+        if (!hash_header[1]) {
+            return KZT_PUBLIC_LOADER_NOT_FOUND;
+        }
+        if (hash_header[1] > KZT_PUBLIC_LOADER_MAX_SYMBOLS) {
+            return KZT_PUBLIC_LOADER_LIMIT;
+        }
+        symbol_count = hash_header[1];
+    } else {
+        kzt_public_loader_result_t result =
+            kzt_public_loader_gnu_symbol_count(
+                reader, hash_addr, &symbol_count);
+
+        if (result != KZT_PUBLIC_LOADER_OK) {
+            return result;
+        }
+    }
+
+    for (index = 0; index < symbol_count; ++index) {
+        kzt_x86_64_symbol_t symbol;
+        uintptr_t entry_addr;
+        uintptr_t name_addr;
+        int matches;
+
+        if (kzt_public_loader_add_offset(
+                symbol_table_addr, index, sizeof(symbol),
+                &entry_addr) != 0) {
+            return KZT_PUBLIC_LOADER_OVERFLOW;
+        }
+        if (kzt_public_loader_read(reader, entry_addr,
+                                   &symbol, sizeof(symbol)) != 0) {
+            return KZT_PUBLIC_LOADER_READ_ERROR;
+        }
+        if (!symbol.name || symbol.name >= string_table_size ||
+            !symbol.section_index || !symbol.value) {
+            continue;
+        }
+        if (string_table_addr > UINTPTR_MAX - symbol.name) {
+            return KZT_PUBLIC_LOADER_OVERFLOW;
+        }
+        name_addr = string_table_addr + symbol.name;
+        matches = kzt_public_loader_symbol_name_matches(
+            reader, name_addr, string_table_size - symbol.name,
+            symbol_name, symbol_name_size);
+        if (matches < 0) {
+            return KZT_PUBLIC_LOADER_READ_ERROR;
+        }
+        if (!matches) {
+            continue;
+        }
+        if (symbol.value > UINTPTR_MAX - object->load_bias) {
+            return KZT_PUBLIC_LOADER_OVERFLOW;
+        }
+        *symbol_addr = object->load_bias + (uintptr_t)symbol.value;
+        return KZT_PUBLIC_LOADER_OK;
+    }
+    return KZT_PUBLIC_LOADER_NOT_FOUND;
 }
 
 static kzt_public_loader_result_t kzt_public_loader_find_r_debug(
@@ -628,6 +924,65 @@ kzt_public_loader_result_t kzt_public_loader_observer_refresh(
         return KZT_PUBLIC_LOADER_INVALID_STATE;
     }
     return result;
+}
+
+kzt_public_loader_result_t kzt_public_loader_find_symbol(
+    const kzt_public_loader_observer_t *observer,
+    const kzt_public_loader_reader_t *reader,
+    const char *symbol_name,
+    uintptr_t *symbol_addr)
+{
+    uintptr_t found_addr = 0;
+    size_t symbol_name_size;
+    size_t index;
+
+    if (!observer || !observer->active || !reader ||
+        !reader->read_memory || !symbol_name || !symbol_addr) {
+        return KZT_PUBLIC_LOADER_INVALID_INPUT;
+    }
+    symbol_name_size = strlen(symbol_name);
+    if (!symbol_name_size ||
+        symbol_name_size > KZT_PUBLIC_LOADER_MAX_SYMBOL_NAME) {
+        return KZT_PUBLIC_LOADER_INVALID_INPUT;
+    }
+    *symbol_addr = 0;
+
+    for (index = 0; index < observer->live_map_count; ++index) {
+        kzt_x86_64_link_map_prefix_t map;
+        kzt_public_loader_object_t object;
+        uintptr_t candidate = 0;
+        kzt_public_loader_result_t result;
+
+        if (kzt_public_loader_read(reader, observer->live_maps[index],
+                                   &map, sizeof(map)) != 0) {
+            return KZT_PUBLIC_LOADER_READ_ERROR;
+        }
+        object = (kzt_public_loader_object_t) {
+            .link_map_addr = observer->live_maps[index],
+            .load_bias = (uintptr_t)map.load_bias,
+            .name_addr = (uintptr_t)map.name,
+            .dynamic_addr = (uintptr_t)map.dynamic_addr,
+            .next_addr = (uintptr_t)map.next,
+            .previous_addr = (uintptr_t)map.previous,
+        };
+        result = kzt_public_loader_find_object_symbol(
+            &object, reader, symbol_name, symbol_name_size, &candidate);
+        if (result == KZT_PUBLIC_LOADER_NOT_FOUND) {
+            continue;
+        }
+        if (result != KZT_PUBLIC_LOADER_OK) {
+            return result;
+        }
+        if (found_addr && found_addr != candidate) {
+            return KZT_PUBLIC_LOADER_INVALID_STATE;
+        }
+        found_addr = candidate;
+    }
+    if (!found_addr) {
+        return KZT_PUBLIC_LOADER_NOT_FOUND;
+    }
+    *symbol_addr = found_addr;
+    return KZT_PUBLIC_LOADER_OK;
 }
 
 const char *kzt_public_loader_result_name(

--- a/target/i386/latx/context/myalign.c
+++ b/target/i386/latx/context/myalign.c
@@ -2356,6 +2356,48 @@ static int kzt_find_main_dynamic_table(const elfheader_t *head,
     return -1;
 }
 
+static int kzt_loader_snapshot_visit(
+    const kzt_public_loader_object_t *object,
+    void *opaque)
+{
+    (void)object;
+    (void)opaque;
+    return 0;
+}
+
+uintptr_t kzt_resolve_guest_symbol(const char *name)
+{
+    kzt_public_loader_observer_t snapshot;
+    kzt_public_loader_result_t result;
+    uintptr_t address = 0;
+    uintptr_t dynamic_addr = 0;
+    size_t dynamic_count = 0;
+
+    if (!name || !elf_header) {
+        return 0;
+    }
+    mmap_lock();
+    snapshot = kzt_public_loader_observer;
+    if (snapshot.active) {
+        result = kzt_public_loader_observer_refresh(
+            &snapshot, &kzt_public_loader_reader,
+            kzt_loader_snapshot_visit, NULL);
+    } else if (kzt_find_main_dynamic_table(
+                   elf_header, &dynamic_addr, &dynamic_count) == 0) {
+        result = kzt_public_loader_observer_activate(
+            &snapshot, dynamic_addr, dynamic_count,
+            &kzt_public_loader_reader, kzt_loader_snapshot_visit, NULL);
+    } else {
+        result = KZT_PUBLIC_LOADER_NOT_FOUND;
+    }
+    if (result == KZT_PUBLIC_LOADER_OK) {
+        result = kzt_public_loader_find_symbol(
+            &snapshot, &kzt_public_loader_reader, name, &address);
+    }
+    mmap_unlock();
+    return result == KZT_PUBLIC_LOADER_OK ? address : 0;
+}
+
 static int kzt_main_relro_matches(const elfheader_t *head,
                                   uintptr_t protect_start,
                                   size_t protect_size)

--- a/target/i386/latx/context/wrappedlibdl.c
+++ b/target/i386/latx/context/wrappedlibdl.c
@@ -150,7 +150,9 @@ void kzt_wine_init_x86(void);
 static int init_x86dlfun(void)
 {
 #ifdef CONFIG_LOONGARCH_NEW_WORLD
-    init_x86dlfun_from("libc.so.6", "libdl.so.2");
+    if (init_x86dlfun_from("libc.so.6", "libdl.so.2") != 0) {
+        return -1;
+    }
     kzt_wine_init_x86();
     return 0;
 #else
@@ -196,8 +198,10 @@ EXPORT void* my_dlopen(void *filename, int flag){
     int is_local = (flag&0x100)?0:1;  // if not global, then local, and that means symbols are not put in the global "pot" for other libs
     CLEARERR
     if (!dl->x86dlopen) {
-        init_x86dlfun();
-        lsassert(dl->x86dlopen);
+        if (init_x86dlfun() != 0 || !dl->x86dlopen) {
+            set_dl_error(dl, "Cannot resolve guest dlfcn entry points");
+            return NULL;
+        }
     }
     if(filename) {
         char* rfilename = expand_dlopen_path((char*)filename);
@@ -420,8 +424,10 @@ EXPORT void* my_dlsym(void *handle, void *symbol){
     char* rsymbol = (char*)symbol;
     CLEARERR
     if (!dl->x86dlsym) {
-        init_x86dlfun();
-        lsassert(dl->x86dlsym);
+        if (init_x86dlfun() != 0 || !dl->x86dlsym) {
+            set_dl_error(dl, "Cannot resolve guest dlfcn entry points");
+            return NULL;
+        }
     }
     printf_dlsym(LOG_DEBUG, "Call to dlsym(%p, \"%s\")%s\n", handle, rsymbol, dlsym_error?"":"\n");
     if (handle && handle != (void*)~0LL) {
@@ -615,8 +621,10 @@ EXPORT int my_dlclose(void *handle)
     dlprivate_t *dl = my_context->dlprivate;
     CLEARERR
     if (!dl->x86dlclose) {
-        init_x86dlfun();
-        lsassert(dl->x86dlclose);
+        if (init_x86dlfun() != 0 || !dl->x86dlclose) {
+            set_dl_error(dl, "Cannot resolve guest dlfcn entry points");
+            return -1;
+        }
     }
     size_t nlib = (size_t)handle;
     if(nlib > dl->lib_sz) {
@@ -686,8 +694,10 @@ EXPORT int my_dladdr1(void *addr, void *i, void** extra_info, int flags)
     dlprivate_t *dl = my_context->dlprivate;
     CLEARERR
     if (!dl->x86dladdr1) {
-        init_x86dlfun();
-        lsassert(dl->x86dladdr1);
+        if (init_x86dlfun() != 0 || !dl->x86dladdr1) {
+            set_dl_error(dl, "Cannot resolve guest dlfcn entry points");
+            return 0;
+        }
     }
     Dl_info *info = (Dl_info*)i;
     printf_dlsym(LOG_DEBUG, "Warning: partially unimplement call to dladdr/dladdr1(%p, %p, %p, %d)\n", addr, info, extra_info, flags);
@@ -721,8 +731,10 @@ EXPORT int my_dladdr(void *addr, void *i)
     dlprivate_t *dl = my_context->dlprivate;
     CLEARERR
     if (!dl->x86dladdr) {
-        init_x86dlfun();
-        lsassert(dl->x86dladdr);
+        if (init_x86dlfun() != 0 || !dl->x86dladdr) {
+            set_dl_error(dl, "Cannot resolve guest dlfcn entry points");
+            return 0;
+        }
     }
 #ifdef CONFIG_LATX_DEBUG
     Dl_info *info = (Dl_info*)i;
@@ -791,8 +803,10 @@ EXPORT int my_dlinfo(void* handle, int request, void* info)
     dlprivate_t *dl = my_context->dlprivate;
     CLEARERR
     if (!dl->x86dlinfo) {
-        init_x86dlfun();
-        lsassert(dl->x86dlinfo);
+        if (init_x86dlfun() != 0 || !dl->x86dlinfo) {
+            set_dl_error(dl, "Cannot resolve guest dlfcn entry points");
+            return -1;
+        }
     }
     size_t nlib;
     void *guest_handle = handle;

--- a/target/i386/latx/context/x86dlfun.c
+++ b/target/i386/latx/context/x86dlfun.c
@@ -7,10 +7,24 @@
  */
 
 #include "box64context.h"
+#include "config-host.h"
 #include "debug.h"
 #include "elfloader.h"
+#include "latx-options.h"
 #include "myalign.h"
 #include "x86dlfun.h"
+
+static void set_x86dlfun(void *const *resolved)
+{
+    my_context->dlprivate->x86dlopen = resolved[0];
+    my_context->dlprivate->x86dlsym = resolved[1];
+    my_context->dlprivate->x86dlclose = resolved[2];
+    my_context->dlprivate->x86dladdr = resolved[3];
+    my_context->dlprivate->x86dladdr1 = resolved[4];
+    my_context->dlprivate->x86dlinfo = resolved[5];
+    my_context->dlprivate->x86dlvsym = resolved[6];
+    my_context->dlprivate->x86dlerror = resolved[7];
+}
 
 int init_x86dlfun_from(const char *primary, const char *fallback)
 {
@@ -20,26 +34,39 @@ int init_x86dlfun_from(const char *primary, const char *fallback)
         "dladdr1", "dlinfo", "dlvsym", "dlerror",
     };
     void *resolved[X86_DL_SYMBOL_COUNT] = {0};
-    elfheader_t *header = loadElfFromFile(primary);
+    elfheader_t *header;
     int resolved_count = 0;
 
-    lsassert(header);
+#if defined(CONFIG_LOONGARCH_NEW_WORLD) && defined(CONFIG_LATX_KZT)
+    if (latx_kzt_runtime_enabled()) {
+        for (int index = 0; index < X86_DL_SYMBOL_COUNT; ++index) {
+            resolved[index] =
+                (void *)kzt_resolve_guest_symbol(symbols[index]);
+            if (!resolved[index]) {
+                return -1;
+            }
+        }
+        set_x86dlfun(resolved);
+        return 0;
+    }
+#endif
+
+    header = loadElfFromFile(primary);
+    if (!header) {
+        return -1;
+    }
     ResetSpecialCaseElf(header, symbols, X86_DL_SYMBOL_COUNT,
                         resolved, &resolved_count);
     if (resolved_count != X86_DL_SYMBOL_COUNT) {
         header = loadElfFromFile(fallback);
-        ResetSpecialCaseElf(header, symbols, X86_DL_SYMBOL_COUNT,
-                            resolved, &resolved_count);
+        if (header) {
+            ResetSpecialCaseElf(header, symbols, X86_DL_SYMBOL_COUNT,
+                                resolved, &resolved_count);
+        }
     }
-    lsassert(resolved_count == X86_DL_SYMBOL_COUNT);
-
-    my_context->dlprivate->x86dlopen = resolved[0];
-    my_context->dlprivate->x86dlsym = resolved[1];
-    my_context->dlprivate->x86dlclose = resolved[2];
-    my_context->dlprivate->x86dladdr = resolved[3];
-    my_context->dlprivate->x86dladdr1 = resolved[4];
-    my_context->dlprivate->x86dlinfo = resolved[5];
-    my_context->dlprivate->x86dlvsym = resolved[6];
-    my_context->dlprivate->x86dlerror = resolved[7];
+    if (resolved_count != X86_DL_SYMBOL_COUNT) {
+        return -1;
+    }
+    set_x86dlfun(resolved);
     return 0;
 }

--- a/target/i386/latx/include/kzt_public_loader_observer.h
+++ b/target/i386/latx/include/kzt_public_loader_observer.h
@@ -178,6 +178,13 @@ kzt_public_loader_result_t kzt_public_loader_observer_refresh(
     kzt_public_loader_visit_fn visit,
     void *visit_opaque);
 
+/* Resolve one unique defined symbol from the live in-memory link_map set. */
+kzt_public_loader_result_t kzt_public_loader_find_symbol(
+    const kzt_public_loader_observer_t *observer,
+    const kzt_public_loader_reader_t *reader,
+    const char *symbol_name,
+    uintptr_t *symbol_addr);
+
 const char *kzt_public_loader_result_name(
     kzt_public_loader_result_t result);
 

--- a/target/i386/latx/include/myalign.h
+++ b/target/i386/latx/include/myalign.h
@@ -159,5 +159,6 @@ TranslationBlock * kzt_tb_find_exp(
 void kzt_bridge_init(void);
 void kzt_wine_bridge(abi_ulong start, int fd);
 int latx_dpy_xcb_sync(void *v1);
+uintptr_t kzt_resolve_guest_symbol(const char *name);
 elfheader_t* loadElfFromFile(const char* name);
 #endif  //__MY_ALIGN__H_

--- a/tests/unit/kzt/test_kzt_public_loader_observer.c
+++ b/tests/unit/kzt/test_kzt_public_loader_observer.c
@@ -23,6 +23,11 @@
 #define NAME3_ADDR (FIXTURE_BASE + 0x4200)
 #define ELF1_BASE (FIXTURE_BASE + 0x6000)
 #define ELF2_BASE (FIXTURE_BASE + 0xb000)
+#define SYMBOL_ELF_BASE (FIXTURE_BASE + 0x8000)
+#define SYMBOL_DYNAMIC_ADDR (SYMBOL_ELF_BASE + 0x100)
+#define SYMBOL_HASH_ADDR (SYMBOL_ELF_BASE + 0x200)
+#define SYMBOL_TABLE_ADDR (SYMBOL_ELF_BASE + 0x300)
+#define SYMBOL_STRING_ADDR (SYMBOL_ELF_BASE + 0x400)
 #define TEST_PAGE_SIZE 0x1000
 #define KZT_TEST_PT_GNU_RELRO UINT32_C(0x6474e552)
 
@@ -53,6 +58,15 @@ typedef struct test_x86_64_program_header {
     uint64_t memsz;
     uint64_t align;
 } test_x86_64_program_header_t;
+
+typedef struct test_x86_64_symbol {
+    uint32_t name;
+    uint8_t info;
+    uint8_t other;
+    uint16_t section_index;
+    uint64_t value;
+    uint64_t size;
+} test_x86_64_symbol_t;
 
 #define CHECK(condition)                                                     \
     do {                                                                     \
@@ -215,6 +229,52 @@ static void write_elf_without_relro(fixture_t *fixture,
     header.phnum = 1;
     fixture_write(fixture, load_bias, &header, sizeof(header));
     fixture_write(fixture, load_bias + header.phoff, &phdr, sizeof(phdr));
+}
+
+static void write_gnu_hash_dlopen_object(fixture_t *fixture)
+{
+    const kzt_x86_64_dynamic_entry_t dynamic[] = {
+        { .tag = INT64_C(0x6ffffef5),
+          .value = SYMBOL_HASH_ADDR - SYMBOL_ELF_BASE },
+        { .tag = 5, .value = SYMBOL_STRING_ADDR - SYMBOL_ELF_BASE },
+        { .tag = 6, .value = SYMBOL_TABLE_ADDR - SYMBOL_ELF_BASE },
+        { .tag = 10, .value = sizeof("\0dlopen") },
+        { .tag = 11, .value = sizeof(test_x86_64_symbol_t) },
+        { .tag = KZT_X86_64_DT_NULL, .value = 0 },
+    };
+    const struct {
+        uint32_t bucket_count;
+        uint32_t symbol_offset;
+        uint32_t bloom_size;
+        uint32_t bloom_shift;
+        uint64_t bloom;
+        uint32_t bucket;
+        uint32_t chain;
+    } hash = {
+        .bucket_count = 1,
+        .symbol_offset = 1,
+        .bloom_size = 1,
+        .bucket = 1,
+        .chain = 1,
+    };
+    const test_x86_64_symbol_t symbols[] = {
+        { 0 },
+        {
+            .name = 1,
+            .info = 0x12,
+            .section_index = 1,
+            .value = 0x905d0,
+        },
+    };
+    static const char strings[] = "\0dlopen";
+
+    fixture_write(fixture, SYMBOL_DYNAMIC_ADDR,
+                  dynamic, sizeof(dynamic));
+    fixture_write(fixture, SYMBOL_HASH_ADDR, &hash, sizeof(hash));
+    fixture_write(fixture, SYMBOL_TABLE_ADDR,
+                  symbols, sizeof(symbols));
+    fixture_write(fixture, SYMBOL_STRING_ADDR,
+                  strings, sizeof(strings));
 }
 
 static void setup_two_maps(fixture_t *fixture)
@@ -546,6 +606,37 @@ static void test_object_relro_classification_uses_guest_memory(void)
     CHECK(has_relro == 0);
 }
 
+static void test_symbol_lookup_uses_live_gnu_hash_object(void)
+{
+    fixture_t fixture;
+    visit_log_t log = { 0 };
+    kzt_public_loader_observer_t observer;
+    const kzt_public_loader_reader_t reader = {
+        .read_memory = fixture_read,
+        .opaque = &fixture,
+    };
+    uintptr_t symbol_addr = 0;
+
+    memset(&fixture, 0, sizeof(fixture));
+    write_dynamic(&fixture, R_DEBUG_ADDR);
+    write_debug(&fixture, KZT_LOADER_DEBUG_CONSISTENT, MAP1_ADDR);
+    write_map(&fixture, MAP1_ADDR, SYMBOL_ELF_BASE, NAME1_ADDR,
+              SYMBOL_DYNAMIC_ADDR, 0, 0);
+    write_gnu_hash_dlopen_object(&fixture);
+    kzt_public_loader_observer_reset(&observer);
+    CHECK(kzt_public_loader_observer_activate(
+              &observer, DYNAMIC_ADDR, 16, &reader,
+              record_visit, &log) == KZT_PUBLIC_LOADER_OK);
+
+    CHECK(kzt_public_loader_find_symbol(
+              &observer, &reader, "dlopen", &symbol_addr) ==
+          KZT_PUBLIC_LOADER_OK);
+    CHECK(symbol_addr == SYMBOL_ELF_BASE + 0x905d0);
+    CHECK(kzt_public_loader_find_symbol(
+              &observer, &reader, "missing", &symbol_addr) ==
+          KZT_PUBLIC_LOADER_NOT_FOUND);
+}
+
 int main(void)
 {
     test_activate_reads_public_loader_state();
@@ -557,6 +648,7 @@ int main(void)
     test_relro_lookup_matches_one_object_before_protection();
     test_observed_processed_and_reported_states_are_distinct();
     test_object_relro_classification_uses_guest_memory();
+    test_symbol_lookup_uses_live_gnu_hash_object();
     puts("kzt public loader observer tests: PASS");
     return 0;
 }


### PR DESCRIPTION
## Cause

KZT initialized Guest dlfcn entry points by reopening `libc.so.6` through its
own search path. When the Guest loader selected a glibc-hwcaps variant, that
lookup could inspect a different ELF file and lose the loaded object's bias,
leaving a raw symbol value to be used as a Guest function address.

## Fix

Resolve dlfcn symbols from the live `r_debug`/`link_map` objects and their
in-memory SysV or GNU hash tables. Reject incomplete resolution instead of
publishing partial or unrelocated entry points.

## Validation

- `test-kzt-public-loader-observer`
- LoongArch incremental `latx-x86_64` build
- `LATX_KZT=1` Wine 11.9 `--version` with the AOSC rootfs, without a library-path override
- GDB confirmed `dlopen` resolves inside the loaded x86-64-v2 libc mapping
