### PR TITLE
LATX KZT, fix: Preserve native FPRs across guest callbacks

### DIFF
--- a/target/i386/latx/context/callback-fpr.S
+++ b/target/i386/latx/context/callback-fpr.S
@@ -1,0 +1,52 @@
+/*
+ * SPDX-FileCopyrightText: 2026 LAT Project Authors
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+    .text
+    .align  2
+    .global latx_kzt_callback_cpu_loop
+    .type   latx_kzt_callback_cpu_loop, @function
+
+/*
+ * Run one complete native-to-guest callback while preserving the native
+ * caller's callee-saved floating-point registers.  Guest XMM8-XMM15 reuse
+ * f24-f31, so preserving them here keeps the cost off the normal TB dispatch
+ * path and pays it only when a KZT wrapper actually invokes guest code.
+ */
+latx_kzt_callback_cpu_loop:
+    .cfi_startproc
+    addi.d  $sp, $sp, -80
+    .cfi_def_cfa_offset 80
+    st.d    $ra, $sp, 64
+    .cfi_offset 1, -16
+
+    fst.d   $f24, $sp, 0
+    fst.d   $f25, $sp, 8
+    fst.d   $f26, $sp, 16
+    fst.d   $f27, $sp, 24
+    fst.d   $f28, $sp, 32
+    fst.d   $f29, $sp, 40
+    fst.d   $f30, $sp, 48
+    fst.d   $f31, $sp, 56
+
+    bl      cpu_loop
+
+    fld.d   $f24, $sp, 0
+    fld.d   $f25, $sp, 8
+    fld.d   $f26, $sp, 16
+    fld.d   $f27, $sp, 24
+    fld.d   $f28, $sp, 32
+    fld.d   $f29, $sp, 40
+    fld.d   $f30, $sp, 48
+    fld.d   $f31, $sp, 56
+
+    ld.d    $ra, $sp, 64
+    .cfi_restore 1
+    addi.d  $sp, $sp, 80
+    .cfi_def_cfa_offset 0
+    jirl    $zero, $ra, 0
+    .cfi_endproc
+
+    .size   latx_kzt_callback_cpu_loop, .-latx_kzt_callback_cpu_loop

--- a/target/i386/latx/context/callback.c
+++ b/target/i386/latx/context/callback.c
@@ -9,6 +9,7 @@
 #include <stdarg.h>
 
 #include "callback-args.h"
+#include "callback-fpr.h"
 #include "callback.h"
 #include "lsenv.h"
 #include "qemu.h"
@@ -88,7 +89,7 @@ static uint64_t callback_frame_run(CallbackFrame *frame, uintptr_t fnc)
     memcpy(&buf, &cs->jmp_env, sizeof(buf));
 
     old_running = qatomic_read(&cs->running);
-    cpu_loop(cpu);
+    latx_kzt_callback_cpu_loop(cpu);
     qatomic_set(&cs->running, old_running);
 
     memcpy(&cs->jmp_env, &buf, sizeof(buf));

--- a/target/i386/latx/context/meson.build
+++ b/target/i386/latx/context/meson.build
@@ -78,6 +78,7 @@ my_file = files(
   'globalsymbols.c',
   'callback-args.c',
   'callback.c',
+  'callback-fpr.S',
   'kzt_public_loader_observer.c',
   'kzt_relocation_transaction.c',
   'wrappedlibdl.c',

--- a/target/i386/latx/include/callback-fpr.h
+++ b/target/i386/latx/include/callback-fpr.h
@@ -1,0 +1,12 @@
+/*
+ * SPDX-FileCopyrightText: 2026 LAT Project Authors
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#ifndef LATX_CALLBACK_FPR_H
+#define LATX_CALLBACK_FPR_H
+
+void latx_kzt_callback_cpu_loop(void *cpu);
+
+#endif

--- a/tests/unit/meson.build
+++ b/tests/unit/meson.build
@@ -58,6 +58,25 @@ if 'CONFIG_LATX' in config_host
   )
 endif
 
+if 'CONFIG_LATX' in config_host and host_machine.cpu_family() == 'loongarch64'
+  test_kzt_callback_fpr = executable(
+    'test-kzt-callback-fpr',
+    files(
+      'test-kzt-callback-fpr.c',
+      '../../target/i386/latx/context/callback-fpr.S',
+    ),
+    include_directories: include_directories('../..'),
+    dependencies: glib,
+    build_by_default: false,
+  )
+
+  test(
+    'test-kzt-callback-fpr',
+    test_kzt_callback_fpr,
+    suite: 'lat-pr-fast',
+  )
+endif
+
 test(
   'test-x11-synchronize-callback',
   python,

--- a/tests/unit/test-kzt-callback-fpr.c
+++ b/tests/unit/test-kzt-callback-fpr.c
@@ -1,0 +1,80 @@
+/*
+ * SPDX-FileCopyrightText: 2026 LAT Project Authors
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "qemu/osdep.h"
+#include "target/i386/latx/include/callback-fpr.h"
+#include "test-kzt-callback-fpr.h"
+
+static const uint64_t native_values[8] = {
+    UINT64_C(0x3ff0000000000000), UINT64_C(0x4000000000000000),
+    UINT64_C(0x4008000000000000), UINT64_C(0x4010000000000000),
+    UINT64_C(0x4014000000000000), UINT64_C(0x4018000000000000),
+    UINT64_C(0x401c000000000000), UINT64_C(0x4020000000000000),
+};
+
+static const uint64_t guest_values[8] = {
+    UINT64_C(0xdeadbeef00000018), UINT64_C(0xdeadbeef00000019),
+    UINT64_C(0xdeadbeef0000001a), UINT64_C(0xdeadbeef0000001b),
+    UINT64_C(0xdeadbeef0000001c), UINT64_C(0xdeadbeef0000001d),
+    UINT64_C(0xdeadbeef0000001e), UINT64_C(0xdeadbeef0000001f),
+};
+
+static bool callback_ran;
+
+static void load_f24_f31(const uint64_t values[8])
+{
+    __asm__ volatile(
+        "fld.d $f24, %0\n\t"
+        "fld.d $f25, %1\n\t"
+        "fld.d $f26, %2\n\t"
+        "fld.d $f27, %3\n\t"
+        "fld.d $f28, %4\n\t"
+        "fld.d $f29, %5\n\t"
+        "fld.d $f30, %6\n\t"
+        "fld.d $f31, %7\n\t"
+        :
+        : "m"(values[0]), "m"(values[1]), "m"(values[2]), "m"(values[3]),
+          "m"(values[4]), "m"(values[5]), "m"(values[6]), "m"(values[7])
+        : "memory");
+}
+
+static void store_f24_f31(uint64_t values[8])
+{
+    __asm__ volatile(
+        "fst.d $f24, %0\n\t"
+        "fst.d $f25, %1\n\t"
+        "fst.d $f26, %2\n\t"
+        "fst.d $f27, %3\n\t"
+        "fst.d $f28, %4\n\t"
+        "fst.d $f29, %5\n\t"
+        "fst.d $f30, %6\n\t"
+        "fst.d $f31, %7\n\t"
+        : "=m"(values[0]), "=m"(values[1]), "=m"(values[2]), "=m"(values[3]),
+          "=m"(values[4]), "=m"(values[5]), "=m"(values[6]), "=m"(values[7])
+        :
+        : "memory");
+}
+
+void cpu_loop(void *cpu)
+{
+    g_assert_null(cpu);
+    callback_ran = true;
+    load_f24_f31(guest_values);
+}
+
+int main(void)
+{
+    uint64_t actual[8];
+
+    load_f24_f31(native_values);
+    latx_kzt_callback_cpu_loop(NULL);
+    store_f24_f31(actual);
+
+    g_assert_true(callback_ran);
+    g_assert_cmpmem(actual, sizeof(actual), native_values,
+                    sizeof(native_values));
+    return 0;
+}

--- a/tests/unit/test-kzt-callback-fpr.h
+++ b/tests/unit/test-kzt-callback-fpr.h
@@ -1,0 +1,12 @@
+/*
+ * SPDX-FileCopyrightText: 2026 LAT Project Authors
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#ifndef TEST_KZT_CALLBACK_FPR_H
+#define TEST_KZT_CALLBACK_FPR_H
+
+void cpu_loop(void *cpu);
+
+#endif


### PR DESCRIPTION
## 问题

KZT 的宿主原生库在调用 x86 callback 时，可能把仍然存活的浮点状态保存在 LoongArch `fs0–fs7`（`f24–f31`）中。LATX 执行 callback 时会把 guest XMM8–XMM15 加载到同一组寄存器；如果 callback 返回前不恢复宿主值，原生库会继续使用被破坏的数据。

gtkperf 的 Cairo 路径稳定暴露了该问题：host Cairo 保存的 device-scale 矩阵在 guest callback 往返后损坏，最终触发 `cairo_surface_set_device_scale()` 断言。

## 修改

- 在 KZT 的统一 callback 路径 `RunFunctionWithState/RunFunctionFmt → callback_frame_run` 中加入专用 LoongArch gateway。
- gateway 在进入完整的 guest `cpu_loop()` 前保存 `fs0–fs7`，callback 完成后恢复。
- 每个 KZT callback 只保存、恢复一次；普通 TB context switch、无 callback 的 KZT 直通和 KZT-off 路径不增加 FPR 保存开销。
- 新增仅由显式测试命令构建的 LoongArch 回归测试，不把测试可执行文件加入正常产品构建。

## 验证

- 回归测试 RED：临时移除 gateway 保存后，8 个 FPR 对比失败并 `SIGABRT`。
- 回归测试 GREEN：`test-kzt-callback-fpr` 为 `1/1 OK`。
- LoongArch x86_64 产品构建通过；正常产品构建不依赖测试目标。
- GDB 确认真实 gtkperf 路径命中 `RunFunctionWithState → callback_frame_run → latx_kzt_callback_cpu_loop`。
- Cairo KZT 路径命中 `libcairo.so.2` wrapper，退出 0，无 device-scale assertion，并运行到 `Total time`、`Quitting..`。
- KZT-off 对照退出 0。
- checkpatch：0 errors。

## 范围

本修复聚焦已确认的 x86_64 KZT native→guest callback→native 边界。i386 行为不变，普通 LATX TB dispatch 不增加每次切换的保存/恢复成本。

---

## Problem

A KZT host library may keep live floating-point state in LoongArch `fs0–fs7` (`f24–f31`) while invoking an x86 callback. LATX reuses the same registers for guest XMM8–XMM15, so returning without restoring the host values corrupts the native caller's state.

gtkperf exposed this through native Cairo: a live device-scale matrix was damaged across guest callback execution and later triggered the `cairo_surface_set_device_scale()` assertion.

## Change

- Add a dedicated LoongArch gateway to the shared KZT callback path used by `RunFunctionWithState` and `RunFunctionFmt`.
- Save `fs0–fs7` once before the complete guest `cpu_loop()` and restore them when the callback returns.
- Keep the normal TB context-switch path unchanged, so KZT-off execution and KZT calls without guest callbacks pay no additional FPR save/restore cost.
- Add an explicit LoongArch regression-test target without adding the test executable to the normal product build.

## Validation

- RED: removing the gateway preservation made the focused test abort on the FPR comparison.
- GREEN: `test-kzt-callback-fpr` passed (`1/1 OK`).
- The LoongArch x86_64 product build passed, and the normal build does not depend on the test target.
- GDB confirmed the real gtkperf route reaches `RunFunctionWithState → callback_frame_run → latx_kzt_callback_cpu_loop`.
- The Cairo KZT route selected the `libcairo.so.2` wrapper, exited 0, and completed without the device-scale assertion.
- The KZT-off control also exited 0.
- checkpatch: 0 errors.

## Scope

This fix is limited to the confirmed x86_64 KZT native→guest callback→native boundary. The i386 behavior and normal LATX TB dispatch remain unchanged.
