### PR TITLE
LATX, fix: Serialize fd transform table access

### DIFF
--- a/linux-user/fd-trans.c
+++ b/linux-user/fd-trans.c
@@ -295,8 +295,126 @@ enum {
     QEMU___RTA_MAX
 };
 
-TargetFdTrans **target_fd_trans;
-unsigned int target_fd_max;
+static TargetFdTrans **target_fd_trans;
+static unsigned int target_fd_max;
+/* Guest threads can grow this table while other threads query it. */
+static pthread_mutex_t target_fd_trans_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+static TargetFdTrans *fd_trans_lookup_locked(int fd)
+{
+    if (fd >= 0 && fd < target_fd_max) {
+        return target_fd_trans[fd];
+    }
+    return NULL;
+}
+
+static void fd_trans_register_locked(int fd, TargetFdTrans *trans)
+{
+    unsigned int oldmax;
+    unsigned int newmax;
+    TargetFdTrans **new_trans;
+
+    if (fd < 0) {
+        return;
+    }
+    if (fd >= target_fd_max) {
+        oldmax = target_fd_max;
+        newmax = ((fd >> 6) + 1) << 6;
+        new_trans = g_renew(TargetFdTrans *, target_fd_trans, newmax);
+        memset(new_trans + oldmax, 0,
+               (newmax - oldmax) * sizeof(*new_trans));
+        target_fd_trans = new_trans;
+        target_fd_max = newmax;
+    }
+    target_fd_trans[fd] = trans;
+}
+
+TargetFdDataFunc fd_trans_target_to_host_data(int fd)
+{
+    TargetFdTrans *trans;
+    TargetFdDataFunc func = NULL;
+
+    pthread_mutex_lock(&target_fd_trans_mutex);
+    trans = fd_trans_lookup_locked(fd);
+    if (trans) {
+        func = trans->target_to_host_data;
+    }
+    pthread_mutex_unlock(&target_fd_trans_mutex);
+    return func;
+}
+
+TargetFdDataFunc fd_trans_host_to_target_data(int fd)
+{
+    TargetFdTrans *trans;
+    TargetFdDataFunc func = NULL;
+
+    pthread_mutex_lock(&target_fd_trans_mutex);
+    trans = fd_trans_lookup_locked(fd);
+    if (trans) {
+        func = trans->host_to_target_data;
+    }
+    pthread_mutex_unlock(&target_fd_trans_mutex);
+    return func;
+}
+
+TargetFdAddrFunc fd_trans_target_to_host_addr(int fd)
+{
+    TargetFdTrans *trans;
+    TargetFdAddrFunc func = NULL;
+
+    pthread_mutex_lock(&target_fd_trans_mutex);
+    trans = fd_trans_lookup_locked(fd);
+    if (trans) {
+        func = trans->target_to_host_addr;
+    }
+    pthread_mutex_unlock(&target_fd_trans_mutex);
+    return func;
+}
+
+void fd_trans_register(int fd, TargetFdTrans *trans)
+{
+    pthread_mutex_lock(&target_fd_trans_mutex);
+    fd_trans_register_locked(fd, trans);
+    pthread_mutex_unlock(&target_fd_trans_mutex);
+}
+
+void fd_trans_unregister(int fd)
+{
+    pthread_mutex_lock(&target_fd_trans_mutex);
+    if (fd >= 0 && fd < target_fd_max) {
+        target_fd_trans[fd] = NULL;
+    }
+    pthread_mutex_unlock(&target_fd_trans_mutex);
+}
+
+void fd_trans_dup(int oldfd, int newfd)
+{
+    TargetFdTrans *trans;
+
+    if (oldfd == newfd) {
+        return;
+    }
+
+    pthread_mutex_lock(&target_fd_trans_mutex);
+    trans = fd_trans_lookup_locked(oldfd);
+    if (newfd >= 0 && newfd < target_fd_max) {
+        target_fd_trans[newfd] = NULL;
+    }
+    if (trans) {
+        fd_trans_register_locked(newfd, trans);
+    }
+    pthread_mutex_unlock(&target_fd_trans_mutex);
+}
+
+void fd_trans_fork_start(void)
+{
+    pthread_mutex_lock(&target_fd_trans_mutex);
+}
+
+void fd_trans_fork_end(void)
+{
+    pthread_mutex_unlock(&target_fd_trans_mutex);
+}
 
 static void tswap_nlmsghdr(struct nlmsghdr *nlh)
 {

--- a/linux-user/fd-trans.h
+++ b/linux-user/fd-trans.h
@@ -24,63 +24,12 @@ typedef struct TargetFdTrans {
     TargetFdAddrFunc target_to_host_addr;
 } TargetFdTrans;
 
-extern TargetFdTrans **target_fd_trans;
-
-extern unsigned int target_fd_max;
-
-static inline TargetFdDataFunc fd_trans_target_to_host_data(int fd)
-{
-    if (fd >= 0 && fd < target_fd_max && target_fd_trans[fd]) {
-        return target_fd_trans[fd]->target_to_host_data;
-    }
-    return NULL;
-}
-
-static inline TargetFdDataFunc fd_trans_host_to_target_data(int fd)
-{
-    if (fd >= 0 && fd < target_fd_max && target_fd_trans[fd]) {
-        return target_fd_trans[fd]->host_to_target_data;
-    }
-    return NULL;
-}
-
-static inline TargetFdAddrFunc fd_trans_target_to_host_addr(int fd)
-{
-    if (fd >= 0 && fd < target_fd_max && target_fd_trans[fd]) {
-        return target_fd_trans[fd]->target_to_host_addr;
-    }
-    return NULL;
-}
-
-static inline void fd_trans_register(int fd, TargetFdTrans *trans)
-{
-    unsigned int oldmax;
-
-    if (fd >= target_fd_max) {
-        oldmax = target_fd_max;
-        target_fd_max = ((fd >> 6) + 1) << 6; /* by slice of 64 entries */
-        target_fd_trans = g_renew(TargetFdTrans *,
-                                  target_fd_trans, target_fd_max);
-        memset((void *)(target_fd_trans + oldmax), 0,
-               (target_fd_max - oldmax) * sizeof(TargetFdTrans *));
-    }
-    target_fd_trans[fd] = trans;
-}
-
-static inline void fd_trans_unregister(int fd)
-{
-    if (fd >= 0 && fd < target_fd_max) {
-        target_fd_trans[fd] = NULL;
-    }
-}
-
-static inline void fd_trans_dup(int oldfd, int newfd)
-{
-    fd_trans_unregister(newfd);
-    if (oldfd < target_fd_max && target_fd_trans[oldfd]) {
-        fd_trans_register(newfd, target_fd_trans[oldfd]);
-    }
-}
+TargetFdDataFunc fd_trans_target_to_host_data(int fd);
+TargetFdDataFunc fd_trans_host_to_target_data(int fd);
+TargetFdAddrFunc fd_trans_target_to_host_addr(int fd);
+void fd_trans_register(int fd, TargetFdTrans *trans);
+void fd_trans_unregister(int fd);
+void fd_trans_dup(int oldfd, int newfd);
 
 extern TargetFdTrans target_packet_trans;
 #ifdef CONFIG_RTNETLINK

--- a/linux-user/main.c
+++ b/linux-user/main.c
@@ -216,6 +216,7 @@ void fork_start(void)
     mmap_fork_start();
     sigact_fork_start();
     path_fork_start();
+    fd_trans_fork_start();
     cpu_list_lock();
 }
 
@@ -224,6 +225,7 @@ void fork_end(int child)
     mmap_fork_end(child);
     sigact_fork_end(child);
     path_fork_end(child);
+    fd_trans_fork_end();
     if (child) {
         CPUState *cpu, *next_cpu;
         /* Child processes created by fork() only have a single thread.

--- a/linux-user/qemu.h
+++ b/linux-user/qemu.h
@@ -374,6 +374,8 @@ int get_osversion(void);
 void init_qemu_uname_release(void);
 void fork_start(void);
 void fork_end(int child);
+void fd_trans_fork_start(void);
+void fd_trans_fork_end(void);
 
 /**
  * probe_guest_base:

--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -2501,9 +2501,11 @@ static inline abi_long target_to_host_sockaddr(int fd, struct sockaddr *addr,
     const socklen_t unix_maxlen = sizeof (struct sockaddr_un);
     sa_family_t sa_family;
     struct target_sockaddr *target_saddr;
+    TargetFdAddrFunc trans;
 
-    if (fd_trans_target_to_host_addr(fd)) {
-        return fd_trans_target_to_host_addr(fd)(addr, target_addr, len);
+    trans = fd_trans_target_to_host_addr(fd);
+    if (trans) {
+        return trans(addr, target_addr, len);
     }
 
     target_saddr = lock_user(VERIFY_READ, target_addr, len, 1);
@@ -4629,6 +4631,7 @@ static abi_long do_sendrecvmsg_locked(int fd, struct target_msghdr *msgp,
     abi_ulong count;
     struct iovec *vec;
     abi_ulong target_vec;
+    TargetFdDataFunc trans;
 
     if (msgp->msg_name) {
         msg.msg_namelen = tswap32(msgp->msg_namelen);
@@ -4673,13 +4676,13 @@ static abi_long do_sendrecvmsg_locked(int fd, struct target_msghdr *msgp,
     msg.msg_iov = vec;
 
     if (send) {
-        if (fd_trans_target_to_host_data(fd)) {
+        trans = fd_trans_target_to_host_data(fd);
+        if (trans) {
             void *host_msg;
 
             host_msg = g_malloc(msg.msg_iov->iov_len);
             memcpy(host_msg, msg.msg_iov->iov_base, msg.msg_iov->iov_len);
-            ret = fd_trans_target_to_host_data(fd)(host_msg,
-                                                   msg.msg_iov->iov_len);
+            ret = trans(host_msg, msg.msg_iov->iov_len);
             if (ret >= 0) {
                 msg.msg_iov->iov_base = host_msg;
                 ret = get_errno(safe_sendmsg(fd, &msg, flags));
@@ -4714,9 +4717,10 @@ static abi_long do_sendrecvmsg_locked(int fd, struct target_msghdr *msgp,
 
         if (!is_error(ret)) {
             len = ret;
-            if (fd_trans_host_to_target_data(fd)) {
-                ret = fd_trans_host_to_target_data(fd)(msg.msg_iov->iov_base,
-                                               MIN(msg.msg_iov->iov_len, len));
+            trans = fd_trans_host_to_target_data(fd);
+            if (trans) {
+                ret = trans(msg.msg_iov->iov_base,
+                            MIN(msg.msg_iov->iov_len, len));
             }
             if (!is_error(ret)) {
                 ret = host_to_target_cmsg(msgp, &msg);
@@ -4961,6 +4965,7 @@ static abi_long do_sendto(int fd, abi_ulong msg, size_t len, int flags,
     void *host_msg;
     void *copy_msg = NULL;
     abi_long ret;
+    TargetFdDataFunc trans;
 
     if ((int)addrlen < 0) {
         return -TARGET_EINVAL;
@@ -4969,11 +4974,12 @@ static abi_long do_sendto(int fd, abi_ulong msg, size_t len, int flags,
     host_msg = lock_user(VERIFY_READ, msg, len, 1);
     if (!host_msg)
         return -TARGET_EFAULT;
-    if (fd_trans_target_to_host_data(fd)) {
+    trans = fd_trans_target_to_host_data(fd);
+    if (trans) {
         copy_msg = host_msg;
         host_msg = g_malloc(len);
         memcpy(host_msg, copy_msg, len);
-        ret = fd_trans_target_to_host_data(fd)(host_msg, len);
+        ret = trans(host_msg, len);
         if (ret < 0) {
             goto fail;
         }
@@ -5006,6 +5012,7 @@ static abi_long do_recvfrom(int fd, abi_ulong msg, size_t len, int flags,
     void *addr;
     void *host_msg;
     abi_long ret;
+    TargetFdDataFunc trans;
 
     if (!msg) {
         host_msg = NULL;
@@ -5034,11 +5041,11 @@ static abi_long do_recvfrom(int fd, abi_ulong msg, size_t len, int flags,
         ret = get_errno(safe_recvfrom(fd, host_msg, len, flags, NULL, 0));
     }
     if (!is_error(ret)) {
-        if (fd_trans_host_to_target_data(fd)) {
-            abi_long trans;
-            trans = fd_trans_host_to_target_data(fd)(host_msg, MIN(ret, len));
-            if (is_error(trans)) {
-                ret = trans;
+        trans = fd_trans_host_to_target_data(fd);
+        if (trans) {
+            abi_long trans_ret = trans(host_msg, MIN(ret, len));
+            if (is_error(trans_ret)) {
+                ret = trans_ret;
                 goto fail;
             }
         }
@@ -14336,6 +14343,7 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
     struct statfs stfs;
 #endif
     void *p;
+    TargetFdDataFunc fd_data_trans;
 
     switch(num) {
     case TARGET_NR_ioperm:
@@ -14391,9 +14399,9 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
             if (!(p = lock_user(VERIFY_WRITE, arg2, arg3, 0)))
                 return -TARGET_EFAULT;
             ret = get_errno(safe_read(arg1, p, arg3));
-            if (ret >= 0 &&
-                fd_trans_host_to_target_data(arg1)) {
-                ret = fd_trans_host_to_target_data(arg1)(p, ret);
+            fd_data_trans = fd_trans_host_to_target_data(arg1);
+            if (ret >= 0 && fd_data_trans) {
+                ret = fd_data_trans(p, ret);
             }
             unlock_user(p, arg2, ret);
         }
@@ -14404,10 +14412,11 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
         }
         if (!(p = lock_user(VERIFY_READ, arg2, arg3, 1)))
             return -TARGET_EFAULT;
-        if (fd_trans_target_to_host_data(arg1)) {
+        fd_data_trans = fd_trans_target_to_host_data(arg1);
+        if (fd_data_trans) {
             void *copy = g_malloc(arg3);
             memcpy(copy, p, arg3);
-            ret = fd_trans_target_to_host_data(arg1)(copy, arg3);
+            ret = fd_data_trans(copy, arg3);
             if (ret >= 0) {
                 ret = get_errno(safe_write(arg1, copy, ret));
             }

--- a/tests/integration/fd-transform-race-i386.S
+++ b/tests/integration/fd-transform-race-i386.S
@@ -1,0 +1,274 @@
+.equ __NR_exit, 1
+.equ __NR_fork, 2
+.equ __NR_read, 3
+.equ __NR_close, 6
+.equ __NR_waitpid, 7
+.equ __NR_dup2, 63
+.equ __NR_getrlimit, 76
+.equ __NR_clone, 120
+.equ __NR_eventfd2, 328
+.equ __NR_sched_yield, 158
+
+.equ RLIMIT_NOFILE, 7
+.equ EFD_SEMAPHORE, 1
+
+.equ CLONE_VM, 0x00000100
+.equ CLONE_FS, 0x00000200
+.equ CLONE_FILES, 0x00000400
+.equ CLONE_SIGHAND, 0x00000800
+.equ CLONE_THREAD, 0x00010000
+.equ CLONE_SYSVSEM, 0x00040000
+.equ CLONE_FLAGS, (CLONE_VM | CLONE_FS | CLONE_FILES | CLONE_SIGHAND)
+.equ CLONE_THREAD_FLAGS, (CLONE_THREAD | CLONE_SYSVSEM)
+
+.equ READER_COUNT, 4
+.equ STACK_SHIFT, 16
+
+.section .text
+.global _start
+.type _start, @function
+_start:
+    mov $__NR_getrlimit, %eax
+    mov $RLIMIT_NOFILE, %ebx
+    mov $fd_limit, %ecx
+    int $0x80
+    test %eax, %eax
+    js fail_limit
+
+    mov $__NR_eventfd2, %eax
+    mov $0x7fffffff, %ebx
+    mov $EFD_SEMAPHORE, %ecx
+    int $0x80
+    test %eax, %eax
+    js fail_eventfd
+    mov %eax, eventfd
+
+    /* Cross the next 64-descriptor table boundary. */
+    mov %eax, %ecx
+    shr $6, %ecx
+    inc %ecx
+    shl $6, %ecx
+    cmpl fd_limit, %ecx
+    jae skip_limit
+    mov %ecx, grow_fd
+
+spawn_reader:
+    mov reader_spawned, %ecx
+    cmp $READER_COUNT, %ecx
+    je spawn_churner
+    inc %ecx
+    shl $STACK_SHIFT, %ecx
+    add $reader_stacks, %ecx
+    mov $__NR_clone, %eax
+    mov $(CLONE_FLAGS | CLONE_THREAD_FLAGS), %ebx
+    xor %edx, %edx
+    xor %esi, %esi
+    xor %edi, %edi
+    int $0x80
+    test %eax, %eax
+    js fail_reader_clone
+    jz reader
+    incl reader_spawned
+    jmp spawn_reader
+
+spawn_churner:
+    mov $__NR_clone, %eax
+    mov $(CLONE_FLAGS | CLONE_THREAD_FLAGS), %ebx
+    mov $churner_stack_end, %ecx
+    xor %edx, %edx
+    xor %esi, %esi
+    xor %edi, %edi
+    int $0x80
+    test %eax, %eax
+    js fail_churner_clone
+    jz churner
+
+wait_readers:
+    cmpl $READER_COUNT, reader_ready
+    jne wait_readers
+wait_churner:
+    cmpl $1, churner_ready
+    jne wait_churner
+    movl $1, start_workers
+
+wait_churner_started:
+    cmpl $1, churner_started
+    jne wait_churner_started
+    mov $__NR_sched_yield, %eax
+    int $0x80
+
+    /* Exercise the fd-transform prefork/postfork lock handoff. */
+    mov $__NR_fork, %eax
+    int $0x80
+    test %eax, %eax
+    js fail_fork
+    jz fork_child
+    mov %eax, fork_child_pid
+
+    mov $__NR_waitpid, %eax
+    mov fork_child_pid, %ebx
+    mov $fork_child_status, %ecx
+    xor %edx, %edx
+    int $0x80
+    cmp fork_child_pid, %eax
+    jne fail_fork_wait
+    cmpl $0, fork_child_status
+    jne fail_fork_child
+    jmp wait_churner_done
+
+fork_child:
+    mov $__NR_dup2, %eax
+    mov eventfd, %ebx
+    mov grow_fd, %ecx
+    int $0x80
+    cmp grow_fd, %eax
+    jne fork_child_failed
+    mov $__NR_close, %eax
+    mov grow_fd, %ebx
+    int $0x80
+    test %eax, %eax
+    js fork_child_failed
+    xor %ebx, %ebx
+    jmp exit_now
+
+fork_child_failed:
+    mov $19, %ebx
+    jmp exit_now
+
+wait_churner_done:
+    cmpl $1, churner_done
+    jne wait_churner_done
+wait_readers_done:
+    cmpl $READER_COUNT, reader_done
+    jne wait_readers_done
+    cmpl $0, reader_error
+    jne fail_reader_read
+    cmpl $0, churner_error
+    jne fail_churner_dup
+
+    xor %ebx, %ebx
+    jmp exit_now
+
+reader:
+    sub $16, %esp
+    lock incl reader_ready
+wait_reader_start:
+    cmpl $1, start_workers
+    jne wait_reader_start
+reader_loop:
+    mov $__NR_read, %eax
+    mov eventfd, %ebx
+    mov %esp, %ecx
+    mov $8, %edx
+    int $0x80
+    cmp $8, %eax
+    jne reader_read_failed
+    cmpl $1, churner_done
+    jne reader_loop
+    lock incl reader_done
+    xor %ebx, %ebx
+    jmp exit_now
+
+reader_read_failed:
+    movl $1, reader_error
+    lock incl reader_done
+    xor %ebx, %ebx
+    jmp exit_now
+
+churner:
+    lock incl churner_ready
+wait_churner_start:
+    cmpl $1, start_workers
+    jne wait_churner_start
+    movl $1, churner_started
+
+    /* Grow the table while the readers are in read(2). */
+    mov $__NR_dup2, %eax
+    mov eventfd, %ebx
+    mov grow_fd, %ecx
+    int $0x80
+    cmp grow_fd, %eax
+    jne churner_dup_failed
+    movl $1, churner_done
+    xor %ebx, %ebx
+    jmp exit_now
+
+churner_dup_failed:
+    movl $1, churner_error
+    movl $1, churner_done
+    xor %ebx, %ebx
+    jmp exit_now
+
+skip_limit:
+    mov $77, %ebx
+    jmp exit_now
+fail_limit:
+    mov $10, %ebx
+    jmp exit_now
+fail_eventfd:
+    mov $11, %ebx
+    jmp exit_now
+fail_reader_clone:
+    mov $13, %ebx
+    jmp exit_now
+fail_churner_clone:
+    mov $14, %ebx
+    jmp exit_now
+fail_churner_dup:
+    mov $15, %ebx
+    jmp exit_now
+fail_reader_read:
+    mov $16, %ebx
+    jmp exit_now
+fail_fork:
+    mov $17, %ebx
+    jmp exit_now
+fail_fork_wait:
+    mov $18, %ebx
+    jmp exit_now
+fail_fork_child:
+    mov $19, %ebx
+
+exit_now:
+    mov $__NR_exit, %eax
+    int $0x80
+.size _start, .-_start
+
+.section .bss
+.balign 4
+fd_limit:
+    .space 8
+eventfd:
+    .space 4
+grow_fd:
+    .space 4
+reader_spawned:
+    .space 4
+reader_ready:
+    .space 4
+reader_done:
+    .space 4
+reader_error:
+    .space 4
+churner_ready:
+    .space 4
+churner_started:
+    .space 4
+churner_done:
+    .space 4
+churner_error:
+    .space 4
+start_workers:
+    .space 4
+fork_child_pid:
+    .space 4
+fork_child_status:
+    .space 4
+.balign 16
+reader_stacks:
+    .space 262144
+churner_stack:
+    .space 65536
+churner_stack_end:
+
+.section .note.GNU-stack,"",@progbits

--- a/tests/integration/fd-transform-race-shim.c
+++ b/tests/integration/fd-transform-race-shim.c
@@ -1,0 +1,121 @@
+#define _GNU_SOURCE
+
+#include <dlfcn.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/eventfd.h>
+#include <sys/mman.h>
+#include <time.h>
+#include <unistd.h>
+
+typedef void *(*GReallocNFunc)(void *, size_t, size_t);
+typedef int (*EventfdFunc)(unsigned int, int);
+
+static GReallocNFunc real_g_realloc_n;
+static EventfdFunc real_eventfd;
+static pthread_once_t init_once = PTHREAD_ONCE_INIT;
+static void *fd_table;
+static size_t fd_table_blocks;
+static int injected;
+static int enabled;
+static const char *marker;
+static __thread int expect_fd_table;
+
+static void init_symbols(void)
+{
+    real_g_realloc_n = dlsym(RTLD_NEXT, "g_realloc_n");
+    real_eventfd = dlsym(RTLD_NEXT, "eventfd");
+    marker = getenv("LATX_TEST_FD_TRANS_RACE_MARKER");
+    enabled = getenv("LATX_TEST_FD_TRANS_RACE") != NULL && marker;
+    if (!real_g_realloc_n || !real_eventfd) {
+        abort();
+    }
+}
+
+static void *allocate_table(size_t n_blocks, size_t n_block_bytes)
+{
+    size_t size;
+    void *table;
+
+    if (!n_blocks || n_blocks > SIZE_MAX / n_block_bytes) {
+        return NULL;
+    }
+    size = n_blocks * n_block_bytes;
+    table = mmap(NULL, size, PROT_READ | PROT_WRITE,
+                 MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    return table == MAP_FAILED ? NULL : table;
+}
+
+static void mark_injected(void)
+{
+    int fd;
+
+    fd = open(marker, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+    if (fd >= 0) {
+        write(fd, "1", 1);
+        close(fd);
+    }
+}
+
+int eventfd(unsigned int initval, int flags)
+{
+    int ret;
+
+    pthread_once(&init_once, init_symbols);
+    ret = real_eventfd(initval, flags);
+    if (enabled && initval == 0x7fffffff && flags == EFD_SEMAPHORE &&
+        ret >= 0) {
+        expect_fd_table = 1;
+    }
+    return ret;
+}
+
+void *g_realloc_n(void *mem, size_t n_blocks, size_t n_block_bytes)
+{
+    struct timespec delay = { .tv_sec = 0, .tv_nsec = 250000000 };
+    size_t old_blocks;
+    size_t old_size;
+    void *old_table;
+    void *new_mem;
+
+    pthread_once(&init_once, init_symbols);
+
+    if (!enabled || n_block_bytes != sizeof(void *)) {
+        return real_g_realloc_n(mem, n_blocks, n_block_bytes);
+    }
+
+    if (expect_fd_table) {
+        expect_fd_table = 0;
+        if (!mem) {
+            new_mem = allocate_table(n_blocks, n_block_bytes);
+            if (!new_mem) {
+                abort();
+            }
+            __atomic_store_n(&fd_table_blocks, n_blocks, __ATOMIC_RELAXED);
+            __atomic_store_n(&fd_table, new_mem, __ATOMIC_RELEASE);
+            return new_mem;
+        }
+    }
+
+    old_table = __atomic_load_n(&fd_table, __ATOMIC_ACQUIRE);
+    old_blocks = __atomic_load_n(&fd_table_blocks, __ATOMIC_RELAXED);
+    if (mem != old_table || old_blocks > SIZE_MAX - 64 ||
+        n_blocks != old_blocks + 64 || !old_blocks ||
+        !__sync_bool_compare_and_swap(&injected, 0, 1)) {
+        return real_g_realloc_n(mem, n_blocks, n_block_bytes);
+    }
+
+    new_mem = allocate_table(n_blocks, n_block_bytes);
+    if (!new_mem) {
+        abort();
+    }
+    old_size = old_blocks * n_block_bytes;
+    memcpy(new_mem, mem, old_size);
+    munmap(mem, old_size);
+    mark_injected();
+    nanosleep(&delay, NULL);
+    return new_mem;
+}

--- a/tests/integration/registrations/process/meson.build
+++ b/tests/integration/registrations/process/meson.build
@@ -40,3 +40,15 @@ if 'x86_64-linux-user' in target_dirs
     ],
   }]
 endif
+
+if 'i386-linux-user' in target_dirs
+  latx_integration_tests += [{
+    'name': 'test-fd-transform-race-i386',
+    'runner': find_program('../../test-fd-transform-race-i386.sh'),
+    'args': [
+      emulators['latx-i386'],
+      files('../../fd-transform-race-i386.S'),
+      files('../../fd-transform-race-shim.c'),
+    ],
+  }]
+endif

--- a/tests/integration/test-fd-transform-race-i386.sh
+++ b/tests/integration/test-fd-transform-race-i386.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+set -eu
+
+emulator=$1
+source_file=$2
+shim_source=$3
+workdir=$(mktemp -d)
+marker=$workdir/fd-transform-race-injected
+trap 'rm -rf "$workdir"' EXIT HUP INT TERM
+
+if command -v clang-19 >/dev/null 2>&1; then
+    clang=clang-19
+elif command -v clang >/dev/null 2>&1; then
+    clang=clang
+else
+    echo "SKIP: clang is required to build the i386 guest"
+    exit 77
+fi
+
+"$clang" --target=i386-linux-gnu -fuse-ld=lld -nostdlib -static -no-pie \
+    -Wl,--build-id=none "$source_file" -o "$workdir/fd-transform-race-i386"
+"${CC:-cc}" -shared -fPIC -O2 -Wall -Wextra "$shim_source" \
+    -ldl -pthread -o "$workdir/fd-transform-race-shim.so"
+
+set +e
+LATX_AOT=0 LATX_KZT=0 LATX_TEST_FD_TRANS_RACE=1 \
+    LATX_TEST_FD_TRANS_RACE_MARKER="$marker" \
+    LD_PRELOAD="$workdir/fd-transform-race-shim.so" \
+    timeout -s KILL 15 "$emulator" "$workdir/fd-transform-race-i386"
+ret=$?
+set -e
+
+if test "$ret" -eq 0 && test ! -f "$marker"; then
+    echo "FAIL: fd-transform race injection did not run" >&2
+    exit 1
+fi
+
+case $ret in
+0) echo "PASS: i386 fd-transform table synchronization" ;;
+77) echo "SKIP: RLIMIT_NOFILE cannot cross a table boundary"; exit 77 ;;
+10) echo "FAIL: getrlimit(RLIMIT_NOFILE) failed" >&2 ;;
+11) echo "FAIL: eventfd2 failed" >&2 ;;
+13) echo "FAIL: reader clone failed" >&2 ;;
+14) echo "FAIL: transform-table churner clone failed" >&2 ;;
+15) echo "FAIL: concurrent transform-table growth failed" >&2 ;;
+16) echo "FAIL: eventfd reader failed during transform-table growth" >&2 ;;
+17) echo "FAIL: guest fork failed during fd-transform activity" >&2 ;;
+18) echo "FAIL: waitpid failed for fd-transform fork child" >&2 ;;
+19) echo "FAIL: fd-transform fork child did not complete table access" >&2 ;;
+124) echo "FAIL: fd-transform race test timed out" >&2 ;;
+*) echo "FAIL: unexpected fd-transform race status $ret" >&2 ;;
+esac
+
+test "$ret" -eq 0


### PR DESCRIPTION
## Summary / 变更说明

- Serialize lookup, register, unregister, duplication, and guest-fork access
  to the table with one mutex.  Lookup copies the static callback pointer
  while holding the mutex, then performs data conversion after unlocking.
- The review found that child-side `pthread_mutex_init()` was being called on
  an already initialized and locked mutex after guest `fork()`, which is
  undefined behavior.  The revised code follows the upstream QEMU pattern:
  `fork_start()` acquires the mutex in the forking vCPU, and
  `fd_trans_fork_end()` unconditionally unlocks it in both the parent and the
  child.  The now-unused child argument was removed.
- The existing i386 regression still forces table growth with concurrent
  eventfd readers.  Its preload shim unmaps the old table and writes a marker,
  so an uninjected run cannot pass.  It now also executes a real guest
  `fork()`; the child performs `dup2()` and `close()` on the transformed
  eventfd, while the parent verifies `waitpid()` and the child status.

## Validation / 验证

- `ninja -C build32 latx-i386`: passed on LoongArch64.
- `ninja -C build64 latx-x86_64`: passed on LoongArch64.
- Focused product regression: 20 consecutive runs passed, and every run
  completed the required fd-table-growth injection marker.
- `meson test -C build32-tests --suite latx-integration --print-errorlogs`:
  passed on the PR branch (5/5) and again after integration (6/6).
- `git diff --check`: passed.  `checkpatch.pl --no-signoff` reported zero
  errors and zero warnings for the patch; the full new-file check emits only
  its generic `MAINTAINERS` reminder.
- A dedicated read-only agent review found no blocking issue.  It confirmed
  the prefork/postfork ownership argument, full prototype/call-site coverage,
  real guest-fork coverage, and correct `waitpid()` status handling.  Its
  one cleanup suggestion—an unreachable child exit-code branch—was applied.
- No new Steam session or performance claim is made for this follow-up;
  validation is limited to the builds and deterministic regression above.

## Checklist / 检查项

- [x] I have read `CONTRIBUTING.md`. / 我已阅读 `CONTRIBUTING.md`。
- [x] Every commit contains a DCO sign-off (`git commit -s`). /
      每个提交都包含 DCO 签署（`git commit -s`）。
- [x] I have included relevant build or test results, or explained why they
      are not applicable. /
      我已提供相关构建或测试结果，或说明了不适用的原因。