### PR TITLE
LATX, fix: update mapped EAX/EDX after softfpu XGETBV

### DIFF
--- a/target/i386/latx/translator/tr-softfpu.c
+++ b/target/i386/latx/translator/tr-softfpu.c
@@ -3089,12 +3089,12 @@ static bool translate_xgetbv_softfpu(IR1_INST *pir1)
 {
     IR2_OPND ecx_opnd = ra_alloc_gpr(ecx_index);
     gen_softfpu_helper2m_ptr((ADDR)helper_xgetbv, ecx_opnd);
-    IR2_OPND temp_low = ra_alloc_itemp();
-    IR2_OPND temp_high = ra_alloc_itemp();
-    la_bstrpick_d(temp_low, a0_ir2_opnd, 31, 0);
-    la_bstrpick_d(temp_high, a0_ir2_opnd, 63, 32);
-    la_st_d(temp_low, env_ir2_opnd, lsenv_offset_of_gpr(lsenv, R_EAX));
-    la_st_d(temp_high, env_ir2_opnd, lsenv_offset_of_gpr(lsenv, R_EDX));
+    
+    IR2_OPND eax_opnd = ra_alloc_gpr(eax_index);
+    IR2_OPND edx_opnd = ra_alloc_gpr(edx_index);
+
+    la_bstrpick_d(eax_opnd, a0_ir2_opnd, 31, 0);
+    la_bstrpick_d(edx_opnd, a0_ir2_opnd, 63, 32);
     return true;
 }
 


### PR DESCRIPTION
The softfpu XGETBV translator split the helper return value and stored it only in the EAX and EDX slots in CPUX86State. During translated execution, however, guest GPRs are held in fixed mapped LoongArch registers. Subsequent guest instructions therefore continued to read stale EAX and EDX values from s0 and s2.

This could cause guest AVX availability checks to fail even when XCR0 had both the SSE and AVX state components enabled.

Write the low and high 32-bit halves of the helper return value directly to the mapped EAX and EDX operands, matching the non-softfpu XGETBV path. The values will be saved to CPUX86State at the normal explicit state synchronization points.

Fixes: fe5993f639f6 ("Add avx support")

## Summary / 变更说明

<!-- What does this change do and why? / 这项变更做了什么，为什么需要？ -->

修复XGETBV翻译时问题

## Validation / 验证

<!-- List the builds and tests you ran, or explain why they are not applicable.
请列出执行过的构建和测试；如不适用，请说明原因。 -->

## Checklist / 检查项

- [ ] I have read `CONTRIBUTING.md`. / 我已阅读 `CONTRIBUTING.md`。
- [ ] Every commit contains a DCO sign-off (`git commit -s`). /
      每个提交都包含 DCO 签署（`git commit -s`）。
- [x] I have included relevant build or test results, or explained why they
      are not applicable. /
      我已提供相关构建或测试结果，或说明了不适用的原因。
