### PR TITLE
linux-user, fix: Hide helper threads through saved procfs fds

### DIFF
--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -66,6 +66,7 @@
 #include <linux/in6.h>
 #include <linux/errqueue.h>
 #include <linux/random.h>
+#include <linux/magic.h>
 #include <linux/sctp.h>
 #ifdef CONFIG_TIMERFD
 #include <sys/timerfd.h>
@@ -12641,12 +12642,65 @@ static int is_proc_myself(const char *filename, const char *entry)
     return 0;
 }
 #ifdef CONFIG_LATX
+static bool latx_stat_same_object(const struct stat *a, const struct stat *b)
+{
+    return a->st_dev == b->st_dev && a->st_ino == b->st_ino;
+}
+
 static bool latx_stat_is_proc_self_task(const struct stat *st)
 {
     struct stat task_st;
 
     return stat("/proc/self/task", &task_st) == 0 &&
-           st->st_dev == task_st.st_dev && st->st_ino == task_st.st_ino;
+           latx_stat_same_object(st, &task_st);
+}
+
+static bool latx_stat_is_proc_self_task_fd(int fd, const struct stat *st)
+{
+    struct stat fd_st;
+    struct stat task_st;
+    struct statfs fs;
+
+    /*
+     * A saved /proc/self/task fd remains usable after a shared chroot makes
+     * the absolute procfs path unreachable.  Verify both the filesystem and
+     * the directory's identity: ../../self/task resolves to the current
+     * process task directory, while another process's task fd does not.
+     */
+    return fd >= 0 && fstatfs(fd, &fs) == 0 &&
+           fs.f_type == PROC_SUPER_MAGIC && fstat(fd, &fd_st) == 0 &&
+           latx_stat_same_object(st, &fd_st) &&
+           fstatat(fd, "../../self/task", &task_st, 0) == 0 &&
+           latx_stat_same_object(st, &task_st);
+}
+
+static bool latx_stat_is_proc_self_task_at(int dirfd, const char *pathname,
+                                           int flags,
+                                           const struct stat *st)
+{
+    struct stat task_st;
+    struct statfs fs;
+
+    if (latx_stat_is_proc_self_task(st)) {
+        return true;
+    }
+
+    if (pathname && pathname[0] == '\0') {
+        return (flags & AT_EMPTY_PATH) &&
+               latx_stat_is_proc_self_task_fd(dirfd, st);
+    }
+
+    /*
+     * Chromium keeps an fd for the procfs root before sharing a sandbox
+     * chroot with CLONE_FS.  At that point /proc/self/task is no longer
+     * reachable by an absolute path, but self/task remains reachable through
+     * the saved procfd.  Verify that the dirfd is procfs before using that
+     * relative reference so an ordinary self/task directory is not rewritten.
+     */
+    return pathname && pathname[0] != '/' && dirfd >= 0 &&
+           fstatfs(dirfd, &fs) == 0 && fs.f_type == PROC_SUPER_MAGIC &&
+           fstatat(dirfd, "self/task", &task_st, 0) == 0 &&
+           latx_stat_same_object(st, &task_st);
 }
 
 static bool latx_statx_is_proc_self_task(const struct target_statx *stx)
@@ -12659,9 +12713,58 @@ static bool latx_statx_is_proc_self_task(const struct target_statx *stx)
            stx->stx_ino == task_st.st_ino;
 }
 
+static bool latx_statx_is_proc_self_task_at(int dirfd, const char *pathname,
+                                            int flags,
+                                            const struct target_statx *stx)
+{
+    struct stat task_st;
+    struct statfs fs;
+
+    if ((stx->stx_mask & STATX_TYPE) && !S_ISDIR(stx->stx_mode)) {
+        return false;
+    }
+
+    if (latx_statx_is_proc_self_task(stx)) {
+        return true;
+    }
+
+    if (pathname && pathname[0] == '\0') {
+        return (flags & AT_EMPTY_PATH) && fstat(dirfd, &task_st) == 0 &&
+               latx_stat_is_proc_self_task_fd(dirfd, &task_st) &&
+               stx->stx_dev_major == major(task_st.st_dev) &&
+               stx->stx_dev_minor == minor(task_st.st_dev) &&
+               stx->stx_ino == task_st.st_ino;
+    }
+
+    return pathname && pathname[0] != '/' && dirfd >= 0 &&
+           fstatfs(dirfd, &fs) == 0 && fs.f_type == PROC_SUPER_MAGIC &&
+           fstatat(dirfd, "self/task", &task_st, 0) == 0 &&
+           stx->stx_dev_major == major(task_st.st_dev) &&
+           stx->stx_dev_minor == minor(task_st.st_dev) &&
+           stx->stx_ino == task_st.st_ino;
+}
+
 static void latx_adjust_proc_self_task_stat(struct stat *st)
 {
-    if (latx_stat_is_proc_self_task(st)) {
+    if (S_ISDIR(st->st_mode) && latx_stat_is_proc_self_task(st)) {
+        st->st_nlink = latx_guest_thread_count() + 2;
+    }
+}
+static void latx_adjust_proc_self_task_fstat(int fd, struct stat *st)
+{
+    if (S_ISDIR(st->st_mode) &&
+        (latx_stat_is_proc_self_task(st) ||
+         latx_stat_is_proc_self_task_fd(fd, st))) {
+        st->st_nlink = latx_guest_thread_count() + 2;
+    }
+}
+
+static void latx_adjust_proc_self_task_stat_at(int dirfd, const char *pathname,
+                                               int flags,
+                                               struct stat *st)
+{
+    if (S_ISDIR(st->st_mode) &&
+        latx_stat_is_proc_self_task_at(dirfd, pathname, flags, st)) {
         st->st_nlink = latx_guest_thread_count() + 2;
     }
 }
@@ -16979,7 +17082,7 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
             }
 #ifdef CONFIG_LATX
             if (!is_error(ret)) {
-                latx_adjust_proc_self_task_stat(&st);
+                latx_adjust_proc_self_task_fstat(arg1, &st);
             }
 #endif
 #if defined(TARGET_NR_stat) || defined(TARGET_NR_lstat)
@@ -18531,7 +18634,7 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
         }
 #ifdef CONFIG_LATX
         if (!is_error(ret)) {
-            latx_adjust_proc_self_task_stat(&st);
+            latx_adjust_proc_self_task_fstat(arg1, &st);
         }
 #endif
         if (!is_error(ret))
@@ -18552,7 +18655,7 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
 
         if (!is_error(ret)) {
 #ifdef CONFIG_LATX
-            latx_adjust_proc_self_task_stat(&st);
+            latx_adjust_proc_self_task_stat_at(arg1, p, arg4, &st);
 #else
             if (rcu_call_thread_is_running() &&
                 (!strcmp((const char *)p, "self/task/") ||
@@ -18589,7 +18692,8 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
                 ret = get_errno(sys_statx(dirfd, p, flags, mask, &host_stx));
                 if (!is_error(ret)) {
 #ifdef CONFIG_LATX
-                    if (latx_statx_is_proc_self_task(&host_stx)) {
+                    if (latx_statx_is_proc_self_task_at(dirfd, p, flags,
+                                                        &host_stx)) {
                         host_stx.stx_nlink = latx_guest_thread_count() + 2;
                     }
 #endif
@@ -18609,7 +18713,7 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
 
 #ifdef CONFIG_LATX
             if (!is_error(ret)) {
-                latx_adjust_proc_self_task_stat(&st);
+                latx_adjust_proc_self_task_stat_at(dirfd, p, flags, &st);
             }
 #endif
             unlock_user(p, arg2, 0);

--- a/tests/integration/cef-procfs-chroot.S
+++ b/tests/integration/cef-procfs-chroot.S
@@ -1,0 +1,307 @@
+.equ __NR_close, 3
+.equ __NR_fstat, 5
+.equ __NR_exit, 60
+.equ __NR_chroot, 161
+.equ __NR_openat, 257
+.equ __NR_newfstatat, 262
+.equ __NR_unshare, 272
+.equ __NR_statx, 332
+.equ AT_FDCWD, -100
+.equ AT_EMPTY_PATH, 0x1000
+.equ O_RDONLY, 0
+.equ O_DIRECTORY, 0x10000
+.equ STATX_BASIC_STATS, 0x7ff
+.equ CLONE_NEWUSER, 0x10000000
+
+.section .rodata
+proc_root:
+    .asciz "/proc"
+chroot_path:
+    .asciz "/proc/self/fdinfo"
+relative_task:
+    .asciz "self/task"
+empty_path:
+    .asciz ""
+
+.section .bss
+.align 8
+statbuf:
+    .space 144
+.align 8
+statxbuf:
+    .space 256
+other_task_path:
+    .space 64
+
+.section .text
+.global _start
+.type _start, @function
+_start:
+    mov 16(%rsp), %rsi
+    lea other_task_path(%rip), %rdi
+.Lcopy_other_pid:
+    lodsb
+    test %al, %al
+    je .Lappend_task
+    stosb
+    jmp .Lcopy_other_pid
+.Lappend_task:
+    movb $'/', (%rdi)
+    movb $'t', 1(%rdi)
+    movb $'a', 2(%rdi)
+    movb $'s', 3(%rdi)
+    movb $'k', 4(%rdi)
+    movb $0, 5(%rdi)
+
+    xor %r15d, %r15d
+    mov 24(%rsp), %rsi
+.Lparse_other_nlink:
+    movzbl (%rsi), %eax
+    test %al, %al
+    je .Lother_nlink_ready
+    sub $'0', %eax
+    imul $10, %r15
+    add %rax, %r15
+    inc %rsi
+    jmp .Lparse_other_nlink
+.Lother_nlink_ready:
+    cmp $4, %r15
+    jb other_task_initial_count_failed
+
+    mov $__NR_openat, %eax
+    mov $AT_FDCWD, %edi
+    lea proc_root(%rip), %rsi
+    mov $(O_RDONLY | O_DIRECTORY), %edx
+    xor %r10d, %r10d
+    syscall
+    test %rax, %rax
+    js open_proc_failed
+    mov %eax, %r12d
+
+    mov $__NR_openat, %eax
+    mov %r12d, %edi
+    lea relative_task(%rip), %rsi
+    mov $(O_RDONLY | O_DIRECTORY), %edx
+    xor %r10d, %r10d
+    syscall
+    test %rax, %rax
+    js open_task_failed
+    mov %eax, %r13d
+
+    mov $__NR_openat, %eax
+    mov %r12d, %edi
+    lea other_task_path(%rip), %rsi
+    mov $(O_RDONLY | O_DIRECTORY), %edx
+    xor %r10d, %r10d
+    syscall
+    test %rax, %rax
+    js open_other_task_failed
+    mov %eax, %r14d
+
+    /* Starting the namespace sandbox also starts LATX's host RCU helper. */
+    mov $__NR_unshare, %eax
+    mov $CLONE_NEWUSER, %edi
+    syscall
+    test %rax, %rax
+    js unshare_failed
+
+    /* Chromium shares this chroot through CLONE_FS before probing procfd. */
+    mov $__NR_chroot, %eax
+    lea chroot_path(%rip), %rdi
+    syscall
+    test %rax, %rax
+    js chroot_failed
+
+    mov $__NR_newfstatat, %eax
+    mov %r12d, %edi
+    lea relative_task(%rip), %rsi
+    lea statbuf(%rip), %rdx
+    xor %r10d, %r10d
+    syscall
+    test %rax, %rax
+    js task_stat_failed
+
+    /* One guest thread must be reported as '.' + '..' + one task. */
+    cmpq $3, statbuf+16(%rip)
+    jne task_count_failed
+
+    mov $__NR_fstat, %eax
+    mov %r13d, %edi
+    lea statbuf(%rip), %rsi
+    syscall
+    test %rax, %rax
+    js task_fstat_failed
+    cmpq $3, statbuf+16(%rip)
+    jne task_fstat_count_failed
+
+    mov $__NR_newfstatat, %eax
+    mov %r13d, %edi
+    lea empty_path(%rip), %rsi
+    lea statbuf(%rip), %rdx
+    mov $AT_EMPTY_PATH, %r10d
+    syscall
+    test %rax, %rax
+    js task_empty_fstatat_failed
+    cmpq $3, statbuf+16(%rip)
+    jne task_empty_fstatat_count_failed
+
+    mov $__NR_statx, %eax
+    mov %r13d, %edi
+    lea empty_path(%rip), %rsi
+    mov $AT_EMPTY_PATH, %edx
+    mov $STATX_BASIC_STATS, %r10d
+    lea statxbuf(%rip), %r8
+    syscall
+    test %rax, %rax
+    js task_empty_statx_failed
+    cmpl $3, statxbuf+16(%rip)
+    jne task_empty_statx_count_failed
+
+    mov $__NR_statx, %eax
+    mov %r12d, %edi
+    lea relative_task(%rip), %rsi
+    xor %edx, %edx
+    mov $STATX_BASIC_STATS, %r10d
+    lea statxbuf(%rip), %r8
+    syscall
+    test %rax, %rax
+    js task_relative_statx_failed
+    cmpl $3, statxbuf+16(%rip)
+    jne task_relative_statx_count_failed
+
+    mov $__NR_fstat, %eax
+    mov %r14d, %edi
+    lea statbuf(%rip), %rsi
+    syscall
+    test %rax, %rax
+    js other_task_fstat_failed
+    cmp statbuf+16(%rip), %r15
+    jne other_task_fstat_rewritten
+
+    mov $__NR_newfstatat, %eax
+    mov %r14d, %edi
+    lea empty_path(%rip), %rsi
+    lea statbuf(%rip), %rdx
+    mov $AT_EMPTY_PATH, %r10d
+    syscall
+    test %rax, %rax
+    js other_task_empty_fstatat_failed
+    cmp statbuf+16(%rip), %r15
+    jne other_task_empty_fstatat_rewritten
+
+    mov $__NR_statx, %eax
+    mov %r14d, %edi
+    lea empty_path(%rip), %rsi
+    mov $AT_EMPTY_PATH, %edx
+    mov $STATX_BASIC_STATS, %r10d
+    lea statxbuf(%rip), %r8
+    syscall
+    test %rax, %rax
+    js other_task_empty_statx_failed
+    cmp statxbuf+16(%rip), %r15d
+    jne other_task_empty_statx_rewritten
+
+    mov $__NR_statx, %eax
+    mov %r12d, %edi
+    lea other_task_path(%rip), %rsi
+    xor %edx, %edx
+    mov $STATX_BASIC_STATS, %r10d
+    lea statxbuf(%rip), %r8
+    syscall
+    test %rax, %rax
+    js other_task_relative_statx_failed
+    cmp statxbuf+16(%rip), %r15d
+    jne other_task_relative_statx_rewritten
+
+    mov $__NR_close, %eax
+    mov %r14d, %edi
+    syscall
+
+    mov $__NR_close, %eax
+    mov %r13d, %edi
+    syscall
+
+    mov $__NR_close, %eax
+    mov %r12d, %edi
+    syscall
+    xor %edi, %edi
+    jmp exit
+
+open_proc_failed:
+    mov $30, %edi
+    jmp exit
+unshare_failed:
+    mov $31, %edi
+    jmp exit
+chroot_failed:
+    mov $32, %edi
+    jmp exit
+task_stat_failed:
+    mov $33, %edi
+    jmp exit
+task_count_failed:
+    mov $34, %edi
+    jmp exit
+open_task_failed:
+    mov $35, %edi
+    jmp exit
+task_fstat_failed:
+    mov $36, %edi
+    jmp exit
+task_fstat_count_failed:
+    mov $37, %edi
+    jmp exit
+task_empty_fstatat_failed:
+    mov $38, %edi
+    jmp exit
+task_empty_fstatat_count_failed:
+    mov $39, %edi
+    jmp exit
+task_empty_statx_failed:
+    mov $40, %edi
+    jmp exit
+task_empty_statx_count_failed:
+    mov $41, %edi
+    jmp exit
+open_other_task_failed:
+    mov $42, %edi
+    jmp exit
+other_task_initial_count_failed:
+    mov $44, %edi
+    jmp exit
+other_task_fstat_failed:
+    mov $45, %edi
+    jmp exit
+other_task_fstat_rewritten:
+    mov $46, %edi
+    jmp exit
+other_task_empty_fstatat_failed:
+    mov $47, %edi
+    jmp exit
+other_task_empty_fstatat_rewritten:
+    mov $48, %edi
+    jmp exit
+other_task_empty_statx_failed:
+    mov $49, %edi
+    jmp exit
+other_task_empty_statx_rewritten:
+    mov $50, %edi
+    jmp exit
+task_relative_statx_failed:
+    mov $51, %edi
+    jmp exit
+task_relative_statx_count_failed:
+    mov $52, %edi
+    jmp exit
+other_task_relative_statx_failed:
+    mov $53, %edi
+    jmp exit
+other_task_relative_statx_rewritten:
+    mov $54, %edi
+
+exit:
+    mov $__NR_exit, %eax
+    syscall
+.size _start, .-_start
+
+.section .note.GNU-stack,"",@progbits

--- a/tests/integration/cef-procfs-other-task.c
+++ b/tests/integration/cef-procfs-other-task.c
@@ -1,0 +1,24 @@
+#include <pthread.h>
+#include <signal.h>
+#include <unistd.h>
+
+static void *wait_forever(void *opaque)
+{
+    (void)opaque;
+    for (;;) {
+        pause();
+    }
+    return NULL;
+}
+
+int main(void)
+{
+    pthread_t thread;
+
+    if (pthread_create(&thread, NULL, wait_forever, NULL) != 0) {
+        return 1;
+    }
+
+    raise(SIGSTOP);
+    return 1;
+}

--- a/tests/integration/registrations/sandbox/meson.build
+++ b/tests/integration/registrations/sandbox/meson.build
@@ -1,5 +1,14 @@
 if 'x86_64-linux-user' in target_dirs
   latx_integration_tests += [{
+    'name': 'test-cef-procfs-chroot',
+    'runner': find_program('../../test-cef-procfs-chroot.sh'),
+    'args': [
+      emulators['latx-x86_64'],
+      files('../../cef-procfs-chroot.S'),
+      files('../../cef-procfs-other-task.c'),
+    ],
+  }]
+  latx_integration_tests += [{
     'name': 'test-cef-userns-nested',
     'runner': find_program('../../test-cef-userns-nested.sh'),
     'args': [

--- a/tests/integration/test-cef-procfs-chroot.sh
+++ b/tests/integration/test-cef-procfs-chroot.sh
@@ -1,0 +1,141 @@
+#!/bin/sh
+set -eu
+
+emulator=$1
+source_file=$2
+helper_source=$3
+workdir=$(mktemp -d)
+helper_pid=
+helper_nlink=
+
+cleanup()
+{
+    if [ -n "$helper_pid" ]; then
+        kill -KILL "$helper_pid" 2>/dev/null || true
+        wait "$helper_pid" 2>/dev/null || true
+    fi
+    rm -rf "$workdir"
+}
+trap cleanup EXIT HUP INT TERM
+
+if ! command -v unshare >/dev/null 2>&1 || ! unshare -Ur true 2>/dev/null; then
+    echo "SKIP: unprivileged user namespaces are unavailable"
+    exit 77
+fi
+
+if command -v clang-19 >/dev/null 2>&1; then
+    clang=clang-19
+elif command -v clang >/dev/null 2>&1; then
+    clang=clang
+else
+    echo "SKIP: clang is required to build the x86_64 guest"
+    exit 77
+fi
+
+"$clang" --target=x86_64-linux-gnu -fuse-ld=lld -nostdlib -static \
+    -Wl,--build-id=none "$source_file" -o "$workdir/cef-procfs-chroot"
+
+"${CC:-cc}" -Wall -Wextra -Werror -pthread "$helper_source" \
+    -o "$workdir/cef-procfs-other-task"
+"$workdir/cef-procfs-other-task" &
+helper_pid=$!
+
+i=0
+while [ "$(stat -c %h "/proc/$helper_pid/task")" -lt 4 ]; do
+    if ! kill -0 "$helper_pid" 2>/dev/null || [ "$i" -ge 100 ]; then
+        echo "FAIL: native helper did not start two threads" >&2
+        exit 1
+    fi
+    i=$((i + 1))
+    sleep 0.05
+done
+helper_nlink=$(stat -c %h "/proc/$helper_pid/task")
+
+set +e
+SBX_USER_NS=1 LATX_AOT=0 LATX_KZT=0 \
+    "$emulator" "$workdir/cef-procfs-chroot" "$helper_pid" "$helper_nlink"
+ret=$?
+set -e
+
+case $ret in
+0)
+    echo "PASS: procfd hides translator threads after sandbox chroot"
+    ;;
+30)
+    echo "FAIL: opening /proc failed" >&2
+    ;;
+31)
+    echo "FAIL: unshare(CLONE_NEWUSER) failed" >&2
+    ;;
+32)
+    echo "FAIL: sandbox chroot failed" >&2
+    ;;
+33)
+    echo "FAIL: fstatat relative to the saved procfd failed" >&2
+    ;;
+34)
+    echo "FAIL: procfd exposed translator-only threads after chroot" >&2
+    ;;
+35)
+    echo "FAIL: opening /proc/self/task relative to the saved procfd failed" >&2
+    ;;
+36)
+    echo "FAIL: fstat on the saved task fd failed after chroot" >&2
+    ;;
+37)
+    echo "FAIL: fstat on the saved task fd exposed translator-only threads" >&2
+    ;;
+38)
+    echo "FAIL: fstatat(AT_EMPTY_PATH) on the saved task fd failed" >&2
+    ;;
+39)
+    echo "FAIL: fstatat(AT_EMPTY_PATH) exposed translator-only threads" >&2
+    ;;
+40)
+    echo "FAIL: statx(AT_EMPTY_PATH) on the saved task fd failed" >&2
+    ;;
+41)
+    echo "FAIL: statx(AT_EMPTY_PATH) exposed translator-only threads" >&2
+    ;;
+42)
+    echo "FAIL: opening another process task directory failed" >&2
+    ;;
+44)
+    echo "FAIL: invalid native helper task link count" >&2
+    ;;
+45)
+    echo "FAIL: fstat on another process task fd failed after chroot" >&2
+    ;;
+46)
+    echo "FAIL: fstat rewrote another process task count" >&2
+    ;;
+47)
+    echo "FAIL: fstatat(AT_EMPTY_PATH) on another task fd failed" >&2
+    ;;
+48)
+    echo "FAIL: fstatat(AT_EMPTY_PATH) rewrote another task count" >&2
+    ;;
+49)
+    echo "FAIL: statx(AT_EMPTY_PATH) on another task fd failed" >&2
+    ;;
+50)
+    echo "FAIL: statx(AT_EMPTY_PATH) rewrote another task count" >&2
+    ;;
+51)
+    echo "FAIL: statx relative to the saved procfd failed" >&2
+    ;;
+52)
+    echo "FAIL: relative statx exposed translator-only threads" >&2
+    ;;
+53)
+    echo "FAIL: relative statx on another task directory failed" >&2
+    ;;
+54)
+    echo "FAIL: relative statx rewrote another task count" >&2
+    ;;
+*)
+    echo "FAIL: unexpected guest exit status $ret" >&2
+    ;;
+esac
+
+exit "$ret"


### PR DESCRIPTION
## Summary / 变更说明

- Keep Chromium's saved procfs descriptors recognizable after a shared
  sandbox chroot makes the absolute `/proc` path unreachable.
- Hide LATX-only RCU/helper threads from `fstat`, relative `fstatat`/`statx`,
  and `AT_EMPTY_PATH` results for the current process's `/proc/self/task`
  directory.
- Identify the current process through `../../self/task` device/inode matching
  so another PID's task directory is never rewritten.
- Skip procfs identity probes for results known to be non-directories, avoiding
  an extra host `fstatfs()` on ordinary `fstat` paths.
- Add a focused x86_64 guest regression and a native two-thread helper covering
  saved proc-root/task descriptors, relative and empty-path operations, and
  the other-PID negative cases.

This fixes ChatGPT 42.3.0 / Chromium 151 zygote startup under the default
sandbox. Before the fix, LATX exposed a host-only helper as `st_nlink=4` while
Chromium expected `3`, causing an `INT3`; `--no-sandbox` avoided that path.

## Validation / 验证

- Rebased onto `011a7497`.
- `./latxbuild/build64.sh -c` — passed.
- `./latxbuild/build32.sh -c` — passed.
- `test-cef-procfs-chroot.sh` — passed; covers relative `fstatat`/`statx`,
  saved task-fd operations, and the self/other-PID cases.
- `test-proc-thread-count.sh` — passed.
- `test-cef-userns-exec.sh` — passed.
- Ordinary-file `fstat` trace — host `fstatfs()` count reduced from 1 to 0.
- Guest assembly compiled as a static x86_64 ELF; the native helper compiled
  with `-Wall -Wextra -Werror`.
- `test-cef-userns-nested.sh` — currently exits 12 with
  `longjmp causes uninitialized stack frame`; the rebased PR baseline fails
  identically with the follow-up changes removed, so this is not introduced by
  the changes above.
- `scripts/checkpatch.pl` — 0 errors; one generic new-file MAINTAINERS reminder.
- Initial ChatGPT default-sandbox validation — 3/3 observed runs reached
  `Launching app`, started `NetworkService`, and did not trigger the original
  `INT3`.

## Checklist / 检查项

- [x] I have read `CONTRIBUTING.md`. / 我已阅读 `CONTRIBUTING.md`。
- [x] Every commit contains a DCO sign-off (`git commit -s`). /
      每个提交都包含 DCO 签署（`git commit -s`）。
- [x] I have included relevant build or test results, or explained why they
      are not applicable. /
      我已提供相关构建或测试结果，或说明了不适用的原因。

## Follow-up

`AT_FDCWD`-based `fstatat()` and `statx()` calls remain unsupported when the
current working directory refers to procfs across the shared chroot. This is a
pre-existing limitation and is not part of Chromium's saved-procfd path fixed
by this PR.

A follow-up patch will cover both relative-path and `AT_EMPTY_PATH` uses of
`AT_FDCWD`.