### PR TITLE
LATX, fix: Avoid LL/SC lowering for locked i386 operations

### DIFF
--- a/accel/tcg/cpu-exec-common.c
+++ b/accel/tcg/cpu-exec-common.c
@@ -22,6 +22,10 @@
 #include "sysemu/tcg.h"
 #include "exec/exec-all.h"
 
+#if defined(CONFIG_LATX) && !defined(TARGET_X86_64)
+#include "latx-lock.h"
+#endif
+
 bool tcg_allowed;
 
 /* exit the current TB, but without causing any exception to be raised */
@@ -65,6 +69,10 @@ void cpu_loop_exit(CPUState *cpu)
 {
     /* Undo the setting in cpu_tb_exec.  */
     cpu->can_do_io = 1;
+#if defined(CONFIG_LATX) && !defined(TARGET_X86_64)
+    /* A nonlocal CPU exit can leave a spinlock lowering via longjmp. */
+    latx_i386_unlock_owned_lock(cpu);
+#endif
 #ifdef CONFIG_LATX
     CPUArchState *env = cpu->env_ptr;
     env->fpu_clobber = true;

--- a/target/i386/latx/include/latx-lock-lowering.h
+++ b/target/i386/latx/include/latx-lock-lowering.h
@@ -1,0 +1,26 @@
+/*
+ * SPDX-FileCopyrightText: 2026 LAT Project Authors
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#ifndef LATX_LOCK_LOWERING_H
+#define LATX_LOCK_LOWERING_H
+
+/*
+ * x86 permits locked operands that cross an 8-byte host atomic boundary,
+ * but LoongArch LL/SC and AMO instructions require natural alignment.  The
+ * i386 LL/SC fallback handles that fault by relocating the guest host page,
+ * which makes guest-address syscalls observe a transient invalid address.
+ *
+ * The i386 translators use LATX-owned aligned storage to serialize ordinary
+ * loads and stores.  i386 selects one process-wide lock: a hashed lock is
+ * not sufficient because an x86 locked operand can overlap adjacent hash
+ * stripes.  This keeps the guest mapping at its original host address.
+ * x86-64 retains the existing LL/SC lowering.
+ */
+#if !defined(TARGET_X86_64)
+#undef CONFIG_LATX_LLSC
+#endif
+
+#endif /* LATX_LOCK_LOWERING_H */

--- a/target/i386/latx/include/latx-lock.h
+++ b/target/i386/latx/include/latx-lock.h
@@ -1,0 +1,14 @@
+/*
+ * SPDX-FileCopyrightText: 2026 LAT Project Authors
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#ifndef LATX_LOCK_H
+#define LATX_LOCK_H
+
+#include "qemu/typedefs.h"
+
+void latx_i386_unlock_owned_lock(CPUState *cpu);
+
+#endif /* LATX_LOCK_H */

--- a/target/i386/latx/translator/tr-arith.c
+++ b/target/i386/latx/translator/tr-arith.c
@@ -10,6 +10,7 @@
 #include "translate.h"
 #include "latx-options.h"
 #include "hbr.h"
+#include "latx-lock-lowering.h"
 
 bool translate_das(IR1_INST *pir1)
 {

--- a/target/i386/latx/translator/tr-btx.c
+++ b/target/i386/latx/translator/tr-btx.c
@@ -9,6 +9,7 @@
 #include "latx-options.h"
 #include "flag-lbt.h"
 #include "translate.h"
+#include "latx-lock-lowering.h"
 
 static void get_mem_bitbase(IR2_OPND mem_op, int *mem_off,
                             IR1_OPND *opnd0, IR1_OPND *opnd1,

--- a/target/i386/latx/translator/tr-logic.c
+++ b/target/i386/latx/translator/tr-logic.c
@@ -10,6 +10,7 @@
 #include "latx-options.h"
 #include "translate.h"
 #include "hbr.h"
+#include "latx-lock-lowering.h"
 
 static bool translate_shrd_imm(IR1_INST *pir1);
 static bool translate_shrd_cl(IR1_INST *pir1);

--- a/target/i386/latx/translator/tr-mov.c
+++ b/target/i386/latx/translator/tr-mov.c
@@ -12,6 +12,7 @@
 #include "translate.h"
 #include "hbr.h"
 #include "latx-smc.h"
+#include "latx-lock-lowering.h"
 bool translate_pop(IR1_INST *pir1)
 {
     IR2_OPND esp_opnd = ra_alloc_gpr(esp_index);
@@ -1455,6 +1456,9 @@ bool translate_xchg(IR1_INST *pir1)
     CPUState *cpu = env_cpu(env);
 
     opnd0_size = ir1_opnd_size(opnd0);
+#ifndef CONFIG_LATX_LLSC
+    (void)opnd0_size;
+#endif
 
     if ((ir1_opnd_is_gpr(opnd0) && ir1_opnd_is_gpr(opnd1))) {
         /* get src0 */
@@ -1713,9 +1717,6 @@ bool translate_cmpxchg(IR1_INST *pir1)
     return true;
 }
 
-/*
- * FIXME: This implementation is NOT thread safe.
- */
 bool translate_cmpxchg8b(IR1_INST *pir1)
 {
     IR1_OPND *reg_eax = &eax_ir1_opnd, *reg_edx = &edx_ir1_opnd;
@@ -1732,6 +1733,15 @@ bool translate_cmpxchg8b(IR1_INST *pir1)
         mem_opnd = convert_mem(opnd0, &imm);
     }
     ir2_set_opnd_type(&mem_opnd, IR2_OPND_GPR);
+
+    bool is_lock = ir1_is_prefix_lock(pir1);
+#ifndef CONFIG_LATX_LLSC
+    IR2_OPND lat_lock_addr;
+
+    if (is_lock) {
+        lat_lock_addr = tr_lat_spin_lock(mem_opnd, imm);
+    }
+#endif
 
     /*
      * There is only one parameter from IR1.
@@ -1765,10 +1775,11 @@ bool translate_cmpxchg8b(IR1_INST *pir1)
     la_slli_d(ecx_ebx_opnd, ecx_ebx_opnd, 32);
     la_bstrins_d(ecx_ebx_opnd, ebx_opnd, 31, 0);
 
-    IR2_OPND sc_opnd = ra_alloc_itemp();
-    IR2_OPND label_ll = ra_alloc_label();
+#ifdef CONFIG_LATX_LLSC
+    if (is_lock) {
+        IR2_OPND sc_opnd = ra_alloc_itemp();
+        IR2_OPND label_ll = ra_alloc_label();
 
-    if (ir1_is_prefix_lock(pir1)) {
         la_label(label_ll);
         la_or(sc_opnd, zero_ir2_opnd, ecx_ebx_opnd);
         la_ll_d(src_opnd_0, mem_opnd, imm);
@@ -1780,6 +1791,11 @@ bool translate_cmpxchg8b(IR1_INST *pir1)
         la_bne(src_opnd_0, edx_eax_opnd, label_unequal);
         la_st_d(ecx_ebx_opnd, mem_opnd, imm);
     }
+#else
+    la_ld_d(src_opnd_0, mem_opnd, imm);
+    la_bne(src_opnd_0, edx_eax_opnd, label_unequal);
+    la_st_d(ecx_ebx_opnd, mem_opnd, imm);
+#endif
     /* equal */
     generate_eflag_calculation(zero_ir2_opnd, zero_ir2_opnd, zero_ir2_opnd,
                                 pir1, true);
@@ -1796,6 +1812,11 @@ bool translate_cmpxchg8b(IR1_INST *pir1)
     store_ireg_to_ir1(src_opnd_0, reg_edx, false);
 
     la_label(label_exit);
+#ifndef CONFIG_LATX_LLSC
+    if (is_lock) {
+        tr_lat_spin_unlock(lat_lock_addr);
+    }
+#endif
     ra_free_temp(src_opnd_0);
 
     return true;

--- a/target/i386/latx/translator/tr-simd.c
+++ b/target/i386/latx/translator/tr-simd.c
@@ -11,6 +11,7 @@
 #include "hbr.h"
 #include "tr-vpaes.h"
 #include "pclmul.h"
+#include "latx-lock-lowering.h"
 
 bool translate_por(IR1_INST *pir1)
 {

--- a/target/i386/latx/translator/translate.c
+++ b/target/i386/latx/translator/translate.c
@@ -12,6 +12,7 @@
 #include "fpu/softfloat.h"
 #include "profile.h"
 #include "translate.h"
+#include "latx-lock.h"
 #include "runtime-trace.h"
 #include "exec/translate-all.h"
 #include "ir2-relocate.h"
@@ -95,6 +96,18 @@ int XMM_USEDEF_TO_SAVE = 0xffff;
 #endif
 
 struct lat_lock lat_lock[16];
+
+/* Release the i386 global lock when a fault leaves a lowered LOCK TB. */
+void latx_i386_unlock_owned_lock(CPUState *cpu)
+{
+#ifndef TARGET_X86_64
+    int owner = cpu->cpu_index + 1;
+
+    qatomic_cmpxchg(&lat_lock[0].lock, owner, 0);
+#else
+    (void)cpu;
+#endif
+}
 
 void tr_init(void *tb)
 {
@@ -4315,10 +4328,21 @@ IR2_OPND tr_lat_spin_lock(IR2_OPND mem_addr, int imm)
     IR2_OPND lat_lock_addr = ra_alloc_itemp();
     IR2_OPND lat_lock_val= ra_alloc_itemp();
     IR2_OPND cpu_index = ra_alloc_itemp();
-    /*compute lat_lock offset by add (mem_addr+imm)[9:6]*/
+
+#ifdef TARGET_X86_64
+    /* Compute lat_lock offset from (mem_addr + imm)[9:6]. */
     la_addi_w(lat_lock_addr, mem_addr, imm);
     la_bstrpick_d(lat_lock_val, lat_lock_addr, 9, 6);
     la_slli_w(lat_lock_val, lat_lock_val, 6);
+#else
+    /*
+     * An i386 LOCK operand may overlap any adjacent 64-byte stripes.  A
+     * stripe-selected lock would let two overlapping operations take
+     * different locks, so use one process-wide LATX lock for i386.
+     */
+    (void)mem_addr;
+    (void)imm;
+#endif
 
     TranslationBlock *tb __attribute__((unused)) = NULL;
     if (option_aot) {
@@ -4326,7 +4350,9 @@ IR2_OPND tr_lat_spin_lock(IR2_OPND mem_addr, int imm)
     }
     aot_load_host_addr(lat_lock_addr, (ADDR)lat_lock,
         LOAD_HOST_LATLOCK, 0);
+#ifdef TARGET_X86_64
     la_add_d(lat_lock_addr, lat_lock_addr, lat_lock_val);
+#endif
 
     la_ld_w(cpu_index, env_ir2_opnd,
                       lsenv_offset_of_cpu_index(lsenv));

--- a/tests/integration/futex-transient-wait-race-i386.S
+++ b/tests/integration/futex-transient-wait-race-i386.S
@@ -1,0 +1,415 @@
+/*
+ * Reproduce the race between i386 private futex waits and LATX locked
+ * instruction lowering.  Concurrent FUTEX_WAIT_PRIVATE and
+ * FUTEX_WAIT_BITSET_PRIVATE calls on the same page must not observe EFAULT,
+ * while unaligned and overlapping LOCK INC / LOCK CMPXCHG8B operations retain
+ * their exact counts.
+ */
+
+.equ __NR_clone, 120
+.equ __NR_exit, 1
+.equ __NR_exit_group, 252
+.equ __NR_futex, 240
+.equ __NR_mmap2, 192
+.equ __NR_clock_gettime, 265
+.equ __NR_rt_sigaction, 174
+
+.equ CLONE_VM, 0x00000100
+.equ CLONE_FS, 0x00000200
+.equ CLONE_FILES, 0x00000400
+.equ CLONE_SIGHAND, 0x00000800
+.equ CLONE_THREAD, 0x00010000
+.equ CLONE_SYSVSEM, 0x00040000
+.equ CLONE_FLAGS, (CLONE_VM | CLONE_FS | CLONE_FILES | CLONE_SIGHAND | CLONE_THREAD | CLONE_SYSVSEM)
+
+.equ PROT_NONE, 0
+.equ PROT_READ, 1
+.equ PROT_WRITE, 2
+.equ MAP_PRIVATE, 2
+.equ MAP_ANONYMOUS, 32
+
+.equ CLOCK_MONOTONIC, 1
+.equ FUTEX_WAIT_PRIVATE, 0x80
+.equ FUTEX_WAIT_BITSET_PRIVATE, 0x89
+.equ FUTEX_WAKE_PRIVATE, 0x81
+.equ FUTEX_BITSET_MATCH_ANY, -1
+.equ EFAULT, 14
+.equ SIGSEGV, 11
+.equ KERNEL_SIGSET_SIZE, 8
+
+.equ PAGE_SIZE, 4096
+.equ WAITER_COUNT, 12
+.equ INC_WORKER_COUNT, 4
+.equ CMPXCHG8B_WORKER_COUNT, 4
+.equ ATOMIC_WORKER_COUNT, (INC_WORKER_COUNT + CMPXCHG8B_WORKER_COUNT)
+.equ ATOMIC_ITERATIONS, 5000
+.equ STACK_SIZE, 32768
+
+.section .text
+.global _start
+.type _start, @function
+_start:
+    /* mmap2(NULL, PAGE_SIZE, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) */
+    mov $__NR_mmap2, %eax
+    xor %ebx, %ebx
+    mov $PAGE_SIZE, %ecx
+    mov $(PROT_READ | PROT_WRITE), %edx
+    mov $(MAP_PRIVATE | MAP_ANONYMOUS), %esi
+    mov $-1, %edi
+    xor %ebp, %ebp
+    int $0x80
+    test %eax, %eax
+    js exit_failure
+    mov %eax, shared_page
+    movl $0, 5(%eax)
+    movl $0, 9(%eax)
+    movl $0, 16(%eax)
+    movl $0, 60(%eax)
+    movl $0, 64(%eax)
+
+    /* Establish the futex page before any locked operation can migrate it. */
+    mov $__NR_futex, %eax
+    mov shared_page, %ebx
+    lea 16(%ebx), %ebx
+    mov $FUTEX_WAKE_PRIVATE, %ecx
+    xor %edx, %edx
+    xor %esi, %esi
+    xor %edi, %edi
+    xor %ebp, %ebp
+    int $0x80
+
+    movl $waiter_stacks_end, next_waiter_stack
+    movl $WAITER_COUNT, waiters_to_spawn
+    movl $atomic_stacks_end, next_atomic_stack
+    movl $ATOMIC_WORKER_COUNT, atomics_to_spawn
+
+spawn_atomic:
+    cmpl $0, atomics_to_spawn
+    je spawn_waiter
+    decl atomics_to_spawn
+    mov atomics_to_spawn, %edx
+    mov $__NR_clone, %eax
+    mov $CLONE_FLAGS, %ebx
+    mov next_atomic_stack, %ecx
+    subl $STACK_SIZE, next_atomic_stack
+    xor %esi, %esi
+    xor %edi, %edi
+    int $0x80
+    test %eax, %eax
+    js exit_failure
+    jz atomic_worker
+    jmp spawn_atomic
+
+spawn_waiter:
+    cmpl $0, waiters_to_spawn
+    je wait_for_workers
+    decl waiters_to_spawn
+    mov next_waiter_stack, %ecx
+    subl $STACK_SIZE, next_waiter_stack
+    mov waiters_to_spawn, %edx
+    mov $__NR_clone, %eax
+    mov $CLONE_FLAGS, %ebx
+    xor %esi, %esi
+    xor %edi, %edi
+    int $0x80
+    test %eax, %eax
+    js exit_failure
+    jz waiter
+    jmp spawn_waiter
+
+wait_for_workers:
+    cmpl $(WAITER_COUNT + ATOMIC_WORKER_COUNT), ready_workers
+    jne wait_for_workers
+    movl $1, start_waiters
+
+wait_for_waiters_to_enter:
+    cmpl $WAITER_COUNT, waiters_entered
+    jne wait_for_waiters_to_enter
+    movl $1, start_atomics
+
+wait_for_atomic_completion:
+    cmpl $ATOMIC_WORKER_COUNT, atomic_workers_done
+    jne wait_for_atomic_completion
+    mov shared_page, %eax
+    cmpl $(ATOMIC_WORKER_COUNT * ATOMIC_ITERATIONS), 5(%eax)
+    jne exit_primary_count_failure
+    cmpl $0, 9(%eax)
+    jne exit_primary_count_failure
+    cmpl $(CMPXCHG8B_WORKER_COUNT * ATOMIC_ITERATIONS), 60(%eax)
+    jne exit_crossing_low_count_failure
+    cmpl $(INC_WORKER_COUNT * ATOMIC_ITERATIONS), 64(%eax)
+    jne exit_crossing_high_count_failure
+    jmp start_fault_cleanup_test
+
+atomic_worker:
+    lock incl ready_workers
+wait_for_atomic_start:
+    cmpl $1, start_atomics
+    jne wait_for_atomic_start
+    test $1, %edx
+    jnz atomic_cmpxchg8b_worker
+
+atomic_inc_worker:
+    mov shared_page, %esi
+    push $ATOMIC_ITERATIONS
+atomic_inc_loop:
+    /* A 32-bit operand at +5 crosses a host 8-byte atomic boundary. */
+    lock incl 5(%esi)
+    /* This overlaps the high half of the CMPXCHG8B operand at +60. */
+    lock incl 64(%esi)
+    mov $__NR_futex, %eax
+    lea 16(%esi), %ebx
+    mov $FUTEX_WAKE_PRIVATE, %ecx
+    mov $0x7fffffff, %edx
+    xor %esi, %esi
+    xor %edi, %edi
+    xor %ebp, %ebp
+    int $0x80
+    mov shared_page, %esi
+    decl (%esp)
+    jne atomic_inc_loop
+    add $4, %esp
+    jmp atomic_done
+
+atomic_cmpxchg8b_worker:
+    mov shared_page, %esi
+    mov $ATOMIC_ITERATIONS, %edi
+atomic_cmpxchg8b_loop:
+    mov 5(%esi), %eax
+    mov 9(%esi), %edx
+cmpxchg8b_retry:
+    lea 1(%eax), %ebx
+    mov %edx, %ecx
+    /* A 64-bit operand at +5 crosses a host 8-byte atomic boundary. */
+    lock cmpxchg8b 5(%esi)
+    jnz cmpxchg8b_retry
+
+    /*
+     * +60 crosses a 64-byte lock stripe.  The increment at +64 overlaps its
+     * high 32 bits, so they must serialize even though their base addresses
+     * fall in adjacent stripes.
+     */
+    mov 60(%esi), %eax
+    mov 64(%esi), %edx
+cmpxchg8b_crossing_retry:
+    lea 1(%eax), %ebx
+    mov %edx, %ecx
+    lock cmpxchg8b 60(%esi)
+    jnz cmpxchg8b_crossing_retry
+
+    push %edi
+    mov $__NR_futex, %eax
+    lea 16(%esi), %ebx
+    mov $FUTEX_WAKE_PRIVATE, %ecx
+    mov $0x7fffffff, %edx
+    xor %esi, %esi
+    xor %edi, %edi
+    xor %ebp, %ebp
+    int $0x80
+    pop %edi
+    mov shared_page, %esi
+    decl %edi
+    jnz atomic_cmpxchg8b_loop
+
+atomic_done:
+    lock incl atomic_workers_done
+    mov $__NR_exit, %eax
+    xor %ebx, %ebx
+    int $0x80
+    ud2
+
+/*
+ * A fault in the load/store part of a spinlock-lowered LOCK instruction
+ * leaves the current TB through cpu_loop_exit().  The SIGSEGV handler waits
+ * for another guest thread to execute a valid LOCK INC.  If the faulting
+ * thread kept the internal lock, that worker cannot make progress and this
+ * test times out.
+ */
+start_fault_cleanup_test:
+    mov $__NR_mmap2, %eax
+    xor %ebx, %ebx
+    mov $PAGE_SIZE, %ecx
+    mov $PROT_NONE, %edx
+    mov $(MAP_PRIVATE | MAP_ANONYMOUS), %esi
+    mov $-1, %edi
+    xor %ebp, %ebp
+    int $0x80
+    test %eax, %eax
+    js exit_failure
+    mov %eax, fault_page
+
+    mov $__NR_rt_sigaction, %eax
+    mov $SIGSEGV, %ebx
+    mov $fault_sigaction, %ecx
+    xor %edx, %edx
+    mov $KERNEL_SIGSET_SIZE, %esi
+    int $0x80
+    test %eax, %eax
+    js exit_failure
+
+    mov $__NR_clone, %eax
+    mov $CLONE_FLAGS, %ebx
+    mov $fault_worker_stack_end, %ecx
+    xor %edx, %edx
+    xor %esi, %esi
+    xor %edi, %edi
+    int $0x80
+    test %eax, %eax
+    js exit_failure
+    jz fault_worker
+
+    mov fault_page, %esi
+    lock incl (%esi)
+    jmp exit_failure
+
+fault_worker:
+fault_worker_wait:
+    cmpl $1, fault_seen
+    jne fault_worker_wait
+    lock incl fault_worker_done
+    mov $__NR_exit, %eax
+    xor %ebx, %ebx
+    int $0x80
+    ud2
+
+fault_signal_handler:
+    movl $1, fault_seen
+fault_handler_wait:
+    cmpl $1, fault_worker_done
+    jne fault_handler_wait
+    xor %ebx, %ebx
+    jmp exit_group
+
+waiter:
+    sub $8, %esp
+    lock incl ready_workers
+wait_for_waiter_start:
+    cmpl $1, start_waiters
+    jne wait_for_waiter_start
+    test $1, %edx
+    jnz waiter_plain_enter
+waiter_bitset_enter:
+    mov $__NR_clock_gettime, %eax
+    mov $CLOCK_MONOTONIC, %ebx
+    mov %esp, %ecx
+    int $0x80
+    test %eax, %eax
+    js exit_failure
+    incl (%esp)
+    lock incl waiters_entered
+    jmp waiter_bitset_futex
+
+waiter_bitset_loop:
+    mov $__NR_clock_gettime, %eax
+    mov $CLOCK_MONOTONIC, %ebx
+    mov %esp, %ecx
+    int $0x80
+    test %eax, %eax
+    js exit_failure
+    incl (%esp)
+
+waiter_bitset_futex:
+    mov $__NR_futex, %eax
+    mov shared_page, %ebx
+    lea 16(%ebx), %ebx
+    mov $FUTEX_WAIT_BITSET_PRIVATE, %ecx
+    xor %edx, %edx
+    mov %esp, %esi
+    xor %edi, %edi
+    mov $FUTEX_BITSET_MATCH_ANY, %ebp
+    int $0x80
+    cmpl $-EFAULT, %eax
+    je exit_efault
+    jmp waiter_bitset_loop
+
+waiter_plain_enter:
+    lock incl waiters_entered
+waiter_plain_loop:
+    mov $__NR_futex, %eax
+    mov shared_page, %ebx
+    lea 16(%ebx), %ebx
+    mov $FUTEX_WAIT_PRIVATE, %ecx
+    xor %edx, %edx
+    xor %esi, %esi
+    xor %edi, %edi
+    xor %ebp, %ebp
+    int $0x80
+    cmpl $-EFAULT, %eax
+    je exit_efault
+    jmp waiter_plain_loop
+
+exit_efault:
+    mov $EFAULT, %ebx
+    jmp exit_group
+
+exit_primary_count_failure:
+    mov $2, %ebx
+    jmp exit_group
+
+exit_crossing_low_count_failure:
+    mov $3, %ebx
+    jmp exit_group
+
+exit_crossing_high_count_failure:
+    mov $4, %ebx
+    jmp exit_group
+
+exit_failure:
+    mov $1, %ebx
+exit_group:
+    mov $__NR_exit_group, %eax
+    int $0x80
+    ud2
+.size _start, .-_start
+
+.section .data
+.balign 4
+fault_sigaction:
+    .long fault_signal_handler
+    .long 0
+    .long 0
+    .long 0
+    .long 0
+
+.section .bss
+.balign 4
+shared_page:
+    .space 4
+ready_workers:
+    .space 4
+start_waiters:
+    .space 4
+start_atomics:
+    .space 4
+waiters_entered:
+    .space 4
+waiters_to_spawn:
+    .space 4
+next_waiter_stack:
+    .space 4
+atomic_workers_done:
+    .space 4
+fault_page:
+    .space 4
+fault_seen:
+    .space 4
+fault_worker_done:
+    .space 4
+.balign 16
+next_atomic_stack:
+    .space 4
+atomics_to_spawn:
+    .space 4
+atomic_stacks:
+    .space (ATOMIC_WORKER_COUNT * STACK_SIZE)
+atomic_stacks_end:
+.balign 16
+waiter_stacks:
+    .space (WAITER_COUNT * STACK_SIZE)
+waiter_stacks_end:
+.balign 16
+fault_worker_stack:
+    .space STACK_SIZE
+fault_worker_stack_end:
+
+.section .note.GNU-stack,"",@progbits

--- a/tests/integration/registrations/process/meson.build
+++ b/tests/integration/registrations/process/meson.build
@@ -40,3 +40,15 @@ if 'x86_64-linux-user' in target_dirs
     ],
   }]
 endif
+
+if 'i386-linux-user' in target_dirs
+  latx_integration_tests += [{
+    'name': 'test-futex-transient-wait-race-i386',
+    'runner': find_program('../../test-futex-transient-wait-race-i386.sh'),
+    'args': [
+      emulators['latx-i386'],
+      files('../../futex-transient-wait-race-i386.S'),
+    ],
+    'timeout': 90,
+  }]
+endif

--- a/tests/integration/test-futex-transient-wait-race-i386.sh
+++ b/tests/integration/test-futex-transient-wait-race-i386.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+set -eu
+
+emulator=$1
+source_file=$2
+workdir=$(mktemp -d)
+trap 'rm -rf "$workdir"' EXIT HUP INT TERM
+aot_home=$workdir/aot-home
+mkdir -p "$aot_home"
+
+if command -v clang-19 >/dev/null 2>&1; then
+    clang=clang-19
+elif command -v clang >/dev/null 2>&1; then
+    clang=clang
+else
+    echo "SKIP: clang is required to build the i386 guest"
+    exit 77
+fi
+
+"$clang" --target=i386-linux-gnu -fuse-ld=lld -nostdlib -static \
+    -Wl,--build-id=none "$source_file" \
+    -o "$workdir/futex-transient-wait-race-i386"
+
+for aot in 0 1; do
+    for kzt in 0 1; do
+        set +e
+        HOME="$aot_home" LATX_AOT="$aot" LATX_KZT="$kzt" timeout -s KILL 20 \
+            "$emulator" "$workdir/futex-transient-wait-race-i386"
+        ret=$?
+        set -e
+
+        case $ret in
+        0) echo "PASS: AOT=$aot KZT=$kzt i386 private futex waits survived concurrent unaligned and overlapping locked operations" ;;
+        14) echo "FAIL: AOT=$aot KZT=$kzt i386 private futex wait returned EFAULT" >&2 ;;
+        2) echo "FAIL: AOT=$aot KZT=$kzt primary locked counter lost updates" >&2 ;;
+        3) echo "FAIL: AOT=$aot KZT=$kzt overlapping CMPXCHG8B low counter lost updates" >&2 ;;
+        4) echo "FAIL: AOT=$aot KZT=$kzt overlapping CMPXCHG8B high counter lost updates" >&2 ;;
+        124) echo "FAIL: AOT=$aot KZT=$kzt i386 futex race test timed out" >&2 ;;
+        *) echo "FAIL: AOT=$aot KZT=$kzt unexpected i386 futex race status $ret" >&2 ;;
+        esac
+
+        test "$ret" -eq 0
+    done
+done


### PR DESCRIPTION
## Summary / 变更说明

- Steam's i386 runtime on LoongArch received `EFAULT` from a private
  `FUTEX_WAIT` even though the guest futex word remained mapped.  The root
  cause is not the futex syscall itself: an unaligned i386 `LOCK` operand can
  enter the LL/SC interpreter fallback, which temporarily `mremap`s the host
  page.  A concurrent host futex wait can observe that short-lived unmapped
  window.
- Use software-lock lowering for all locked i386 instruction translators,
  including the previously separate `LOCK CMPXCHG8B` path.  i386 uses one
  process-local lock rather than a 64-byte hash, because overlapping x86
  operands can start in different hash stripes.  x86-64 keeps its existing
  lowering.
- Release the current i386 lock owner on every nonlocal CPU-loop exit, so a
  guest page fault cannot strand the lock.  This is a root-cause repair: it
  removes the temporary page migration instead of retrying a failed futex.
- The single i386 regression combines unaligned `LOCK INC`, `LOCK CMPXCHG8B`,
  private `FUTEX_WAIT` and `FUTEX_WAIT_BITSET`, a cross-stripe overlap check,
  and a `PROT_NONE` fault-cleanup check.  It runs the complete
  `LATX_AOT=0/1 × LATX_KZT=0/1` matrix with an isolated temporary `HOME` for
  AOT cache files.
- The process-local lock covers the Steam/private-mapping case.  Cross-process
  `MAP_SHARED` x86 `LOCK` atomicity needs a separate shared-lock design.

## Validation / 验证

- `ninja -C build32 latx-i386`: passed on LoongArch64.
- `ninja -C build64 latx-x86_64`: passed on LoongArch64.
- Focused product test: all four `LATX_AOT=0/1 × LATX_KZT=0/1` combinations
  passed.  The AOT=1 passes share the temporary cache directory after its
  first creation.
- Product `strace` of the focused test observed roughly 100,000 futex calls
  for each KZT mode, with zero futex `EFAULT` results and zero `mremap` calls.
- `meson test -C build32-tests --suite latx-integration --print-errorlogs`:
  passed on the PR branch (5/5) and again after integration (6/6).
- `git diff --check`: passed.  Independent review found no blocking issue;
  it verified the i386 LOCK paths, `CMPXCHG8B`, cross-stripe overlap, and
  nonlocal-exit cleanup.
- No performance result is claimed.  The change addresses an exceptional
  correctness path rather than a throughput optimization.

## Checklist / 检查项

- [x] I have read `CONTRIBUTING.md`. / 我已阅读 `CONTRIBUTING.md`。
- [x] Every commit contains a DCO sign-off (`git commit -s`). /
      每个提交都包含 DCO 签署（`git commit -s`）。
- [x] I have included relevant build or test results, or explained why they
      are not applicable. /
      我已提供相关构建或测试结果，或说明了不适用的原因。
