### PR TITLE
LATX, opt: Skip low-value AOT generation

### DIFF
--- a/accel/tcg/tb-flush.c
+++ b/accel/tcg/tb-flush.c
@@ -92,6 +92,9 @@ void do_tb_flush(CPUState *cpu, run_on_cpu_data tb_flush_count)
 
     qht_reset_size(&tb_ctx.htable, CODE_GEN_HTABLE_SIZE);
     tb_flush_remove_all();
+#ifdef CONFIG_LATX_AOT
+    aot_reset_tb_stats();
+#endif
 
     tcg_region_reset_all();
     /*

--- a/accel/tcg/translate-all.c
+++ b/accel/tcg/translate-all.c
@@ -1729,6 +1729,10 @@ static void do_tb_phys_invalidate(TranslationBlock *tb, bool rm_from_page_list)
     qatomic_set(&tb->cflags, tb->cflags | CF_INVALID);
     qemu_spin_unlock(&tb->jmp_lock);
 
+#ifdef CONFIG_LATX_AOT
+    aot_unmark_tb(tb);
+#endif
+
     /* remove the TB from the hash list */
     phys_pc = tb_page_addr0(tb);
 
@@ -2332,6 +2336,9 @@ TranslationBlock *tb_gen_code(CPUState *cpu,
         tcg_tb_remove(tb);
         return existing_tb;
     }
+#ifdef CONFIG_LATX_AOT
+    aot_mark_dynamic_tb(tb);
+#endif
     return tb;
 }
 
@@ -2363,6 +2370,7 @@ void aot_tb_register(TranslationBlock *tb)
 #endif
     }
     tcg_tb_insert(tb);
+    aot_mark_recovered_tb(tb);
 }
 
 #endif

--- a/accel/tcg/translate-all.c
+++ b/accel/tcg/translate-all.c
@@ -2343,7 +2343,7 @@ TranslationBlock *tb_gen_code(CPUState *cpu,
 }
 
 #ifdef CONFIG_LATX_AOT
-void aot_tb_register(TranslationBlock *tb)
+void aot_tb_register(TranslationBlock *tb, AOTTBOrigin origin)
 {
     TranslationBlock *existing_tb;
     tb_page_addr_t phys_pc, phys_page2;
@@ -2370,7 +2370,12 @@ void aot_tb_register(TranslationBlock *tb)
 #endif
     }
     tcg_tb_insert(tb);
-    aot_mark_recovered_tb(tb);
+    if (origin == AOT_TB_RECOVERED) {
+        aot_mark_recovered_tb(tb);
+    } else {
+        g_assert(origin == AOT_TB_DYNAMIC);
+        aot_mark_dynamic_tb(tb);
+    }
 }
 
 #endif

--- a/include/exec/exec-all.h
+++ b/include/exec/exec-all.h
@@ -651,6 +651,7 @@ struct TranslationBlock {
 #define IS_CODE64         0x1000
 #define IS_TU_SPLIT       0x2000
 #define TBSMC_OPTED       0x4000
+#define AOT_STATS_COUNTED 0x8000
     uint16_t bool_flags;
     uint8_t  eflag_use;
 #ifdef CONFIG_LATX_INSTS_PATTERN

--- a/linux-user/main.c
+++ b/linux-user/main.c
@@ -839,6 +839,17 @@ static void handle_arg_latx_aot(const char *arg)
     }
 }
 
+static void handle_arg_latx_aot_generate(const char *arg)
+{
+    long value;
+
+    if (qemu_strtol(arg, NULL, 0, &value) < 0 || value < -1 || value > 1) {
+        fprintf(stderr, "LATX_AOT_GENERATE must be -1, 0, or 1\n");
+        exit(EXIT_FAILURE);
+    }
+    option_aot_generate = value;
+}
+
 static void handle_arg_latx_aot_pe_profile(const char *arg)
 {
     option_aot_pe_profile = strtol(arg, NULL, 0);
@@ -964,6 +975,9 @@ static const struct qemu_argument arg_table[] = {
 #ifdef CONFIG_LATX_AOT
     {"latx-aot",    "LATX_AOT",     true,  handle_arg_latx_aot,
     "",           "enable aot"},
+    {"latx-aot-generate", "LATX_AOT_GENERATE", true,
+    handle_arg_latx_aot_generate, "",
+    "AOT generation: auto (-1), off (0), or force (1)"},
     {"latx-aot-pe-profile", "LATX_AOT_PE_PROFILE", true,
     handle_arg_latx_aot_pe_profile, "", "split libcef PE AOT by process role"},
     {"latx-aot-file-size", "LAT_AOT_FILE_SIZE", false,

--- a/target/i386/latx/include/aot.h
+++ b/target/i386/latx/include/aot.h
@@ -297,6 +297,10 @@ void dump_seg(aot_segment *p_segment, aot_header *p_header);
 lib_info *aot_load(char *lib_name, char *aot_file_name,
                    void **curr_aot_buffer);
 void aot_tb_register(TranslationBlock *tb);
+void aot_mark_dynamic_tb(TranslationBlock *tb);
+void aot_mark_recovered_tb(TranslationBlock *tb);
+void aot_unmark_tb(TranslationBlock *tb);
+void aot_reset_tb_stats(void);
 void aot_do_tb_reloc(TranslationBlock *tb, struct aot_tb *stb,
     target_ulong seg_begin, target_ulong seg_end);
 int aot_get_file_name(char *aot_file, char *buff, int index);

--- a/target/i386/latx/include/aot.h
+++ b/target/i386/latx/include/aot.h
@@ -290,13 +290,18 @@ typedef struct aot_rel {
 
 extern aot_rel *rel_table;
 extern seg_info **seg_info_vector;
+typedef enum AOTTBOrigin {
+    AOT_TB_DYNAMIC,
+    AOT_TB_RECOVERED,
+} AOTTBOrigin;
+
 void mk_aot_dir(char * pathname);
 void aot_set_process_profile(int argc, char **argv);
 void dump_aot_buffer(aot_header *p_header);
 void dump_seg(aot_segment *p_segment, aot_header *p_header);
 lib_info *aot_load(char *lib_name, char *aot_file_name,
                    void **curr_aot_buffer);
-void aot_tb_register(TranslationBlock *tb);
+void aot_tb_register(TranslationBlock *tb, AOTTBOrigin origin);
 void aot_mark_dynamic_tb(TranslationBlock *tb);
 void aot_mark_recovered_tb(TranslationBlock *tb);
 void aot_unmark_tb(TranslationBlock *tb);

--- a/target/i386/latx/include/latx-options.h
+++ b/target/i386/latx/include/latx-options.h
@@ -68,6 +68,8 @@ extern int option_tunnel_lib;
 extern uint64_t option_end_trace_addr;
 extern uint64_t option_begin_trace_addr;
 extern int option_aot;
+/* -1 selects automatic generation, 0 disables it, 1 forces it. */
+extern int option_aot_generate;
 extern int option_smc_reload;
 extern int option_aot_wine;
 extern int option_load_aot;

--- a/target/i386/latx/latx-options.c
+++ b/target/i386/latx/latx-options.c
@@ -76,6 +76,7 @@ int option_latx_disassemble_trace_cmp;
 int option_debug_lative;
 int option_aot;
 int option_load_aot;
+int option_aot_generate;
 int option_aot_wine;
 int option_smc_reload;
 int option_debug_aot;
@@ -250,6 +251,7 @@ void options_init(void)
 #ifdef CONFIG_LATX_AOT
     option_aot = 1;
     option_load_aot = 1;
+    option_aot_generate = -1;
     option_aot_wine = 0;
     option_debug_aot = 0;
 #endif

--- a/target/i386/latx/optimization/tu.c
+++ b/target/i386/latx/optimization/tu.c
@@ -22,6 +22,9 @@
 #include "reg-alloc.h"
 #include "latx-options.h"
 #include "aot_page.h"
+#ifdef CONFIG_LATX_AOT
+#include "aot.h"
+#endif
 
 void get_last_info(TranslationBlock *tb, IR1_INST* pir1)
 {
@@ -1106,6 +1109,9 @@ static void register_tu(uint32 tb_num_in_tu, TranslationBlock **tb_list,
             }
             tb_link_page(tb, phys_pc, phys_page2);
             tcg_tb_insert(tb);
+#ifdef CONFIG_LATX_AOT
+            aot_mark_dynamic_tb(tb);
+#endif
         }
     }
 

--- a/target/i386/latx/sbt/aot.c
+++ b/target/i386/latx/sbt/aot.c
@@ -36,6 +36,9 @@
 static TranslationBlock **tb_vector;
 static int tb_num;
 static int curr_lib_tb_num;
+/* TB insertion/recovery is serialized; flush resets under exclusive. */
+static uint64_t aot_dynamic_tb_count;
+static uint64_t aot_total_tb_count;
 /* Compare function used to sort tb_vector. */
 static int tb_cmp(const void *a, const void *b)
 {
@@ -404,7 +407,9 @@ static inline int create_aot_tb(aot_tb *curr_aot_tb, TranslationBlock *tb,
     curr_aot_tb->rel_end_index = tb->s_data->rel_end;
     curr_aot_tb->first_jmp_align = tb->first_jmp_align;
     curr_aot_tb->last_ir1_type = tb->s_data->last_ir1_type;
-    curr_aot_tb->bool_flags = tb->bool_flags | IS_AOT_TB;
+    /* AOT_STATS_COUNTED is runtime-only state. */
+    curr_aot_tb->bool_flags =
+        (tb->bool_flags & ~AOT_STATS_COUNTED) | IS_AOT_TB;
     curr_aot_tb->eflag_use = tb->eflag_use;
     #ifdef CONFIG_LATX_INSTS_PATTERN
     curr_aot_tb->eflags_target_arg[0] = tb->eflags_target_arg[0];
@@ -1661,6 +1666,22 @@ static void creat_daemon(bool is_end)
 
 #define AOT_EXIT_EXCLUSIVE_TIMEOUT_MS 1000
 
+#define AOT_GENERATION_RATIO_DENOMINATOR 20
+
+static bool aot_should_generate(void)
+{
+    uint64_t dynamic_tbs = aot_dynamic_tb_count;
+    uint64_t total_tbs = aot_total_tb_count;
+    uint64_t threshold;
+
+    if (dynamic_tbs == 0 || total_tbs == 0) {
+        return false;
+    }
+    threshold = total_tbs / AOT_GENERATION_RATIO_DENOMINATOR;
+    threshold += total_tbs % AOT_GENERATION_RATIO_DENOMINATOR != 0;
+    return dynamic_tbs >= threshold;
+}
+
 void aot_exit_entry(CPUState *cpu, AOTExitReason reason)
 {
     TaskState *ts = cpu->opaque;
@@ -1668,6 +1689,12 @@ void aot_exit_entry(CPUState *cpu, AOTExitReason reason)
         ts && ts->ipc_namespace_isolated);
 
     if (!option_aot) {
+        return;
+    }
+    if (option_aot_generate == 0) {
+        return;
+    }
+    if (option_aot_generate < 0 && !aot_should_generate()) {
         return;
     }
     if (in_pre_translate) {
@@ -1758,6 +1785,54 @@ parent_exit:
 
     aot_generate(cpu);
     _exit(EXIT_SUCCESS);
+}
+
+void aot_mark_dynamic_tb(TranslationBlock *tb)
+{
+    if (!option_aot || option_aot_generate >= 0 || in_pre_translate ||
+        (tb->bool_flags & IS_TUNNEL_LIB) ||
+        page_get_page_state(tb->pc) == PAGE_SMC) {
+        return;
+    }
+    if (tb->bool_flags & AOT_STATS_COUNTED) {
+        return;
+    }
+    tb->bool_flags |= AOT_STATS_COUNTED;
+    aot_dynamic_tb_count++;
+    aot_total_tb_count++;
+}
+
+void aot_mark_recovered_tb(TranslationBlock *tb)
+{
+    (void)tb;
+    if (!option_aot || option_aot_generate >= 0 || in_pre_translate) {
+        return;
+    }
+    if (tb->bool_flags & AOT_STATS_COUNTED) {
+        return;
+    }
+    tb->bool_flags |= AOT_STATS_COUNTED;
+    aot_total_tb_count++;
+}
+
+void aot_unmark_tb(TranslationBlock *tb)
+{
+    if (!(tb->bool_flags & AOT_STATS_COUNTED)) {
+        return;
+    }
+    tb->bool_flags &= ~AOT_STATS_COUNTED;
+    assert(aot_total_tb_count > 0);
+    aot_total_tb_count--;
+    if (!(tb->bool_flags & IS_AOT_TB)) {
+        assert(aot_dynamic_tb_count > 0);
+        aot_dynamic_tb_count--;
+    }
+}
+
+void aot_reset_tb_stats(void)
+{
+    aot_dynamic_tb_count = 0;
+    aot_total_tb_count = 0;
 }
 
 void aot_init(void)

--- a/target/i386/latx/sbt/aot_recover_tb.c
+++ b/target/i386/latx/sbt/aot_recover_tb.c
@@ -158,7 +158,7 @@ static void recover_tb_range(target_ulong page, struct aot_tb *p_aot_tbs,
 #ifdef CONFIG_LATX_PROFILER
         CLN_TB_PROFILE(tb);
 #endif
-        aot_tb_register(tb);
+        aot_tb_register(tb, AOT_TB_RECOVERED);
 
 #ifdef CONFIG_LATX_DEBUG
         assert((tb->pc & TARGET_PAGE_MASK) == page);
@@ -263,7 +263,7 @@ static void recover_tb_range(target_ulong page, struct aot_tb *p_aot_tbs,
                 aot_link_tree_insert(tb, 0, 0);
             }
 #endif
-            aot_tb_register(tb);
+            aot_tb_register(tb, AOT_TB_RECOVERED);
         }
         i = j;
     }

--- a/target/i386/latx/sbt/aot_smc_reload.c
+++ b/target/i386/latx/sbt/aot_smc_reload.c
@@ -68,7 +68,7 @@ int smc_page_reload(target_ulong page_addr, uint32_t cflags)
             tb->jmp_list_next[1] = 0;
             tb->jmp_dest[0] = 0;
             tb->jmp_dest[1] = 0;
-            aot_tb_register(tb);
+            aot_tb_register(tb, AOT_TB_DYNAMIC);
         }
         ir1_offset += tb->size;
     }

--- a/target/i386/latx/sbt/tests/smc-reload-guest-base-test.c
+++ b/target/i386/latx/sbt/tests/smc-reload-guest-base-test.c
@@ -8,6 +8,7 @@
 #include "smc-reload-guest-base-test.h"
 
 static unsigned int aot_register_count;
+static AOTTBOrigin aot_register_origin;
 static void *reload_mprotect_addr;
 static int reload_mprotect_prot;
 static bool capture_reload_mprotect;
@@ -53,10 +54,11 @@ void tb_target_set_nop(uintptr_t tc_ptr G_GNUC_UNUSED,
     g_assert_not_reached();
 }
 
-void aot_tb_register(TranslationBlock *tb)
+void aot_tb_register(TranslationBlock *tb, AOTTBOrigin origin)
 {
     assert(tb != NULL);
     aot_register_count++;
+    aot_register_origin = origin;
 }
 
 int page_get_flags(target_ulong address G_GNUC_UNUSED)
@@ -113,6 +115,7 @@ int main(void)
     g_assert(reload_mprotect_addr == host_page);
     g_assert(reload_mprotect_prot == PROT_READ);
     g_assert(aot_register_count == 1);
+    g_assert(aot_register_origin == AOT_TB_DYNAMIC);
     g_assert(smc_reload_tree_get_node_count() == 0);
     qemu_spin_destroy(&tb.jmp_lock);
     g_assert(munmap(mapping, mapping_size) == 0);

--- a/target/i386/latx/sbt/tests/smc-reload-tu-test.c
+++ b/target/i386/latx/sbt/tests/smc-reload-tu-test.c
@@ -7,6 +7,7 @@
 #include "exec/translate-all.h"
 
 static unsigned int aot_register_count;
+static AOTTBOrigin aot_register_origin;
 static int test_page_flags;
 
 __thread TCGContext *tcg_ctx;
@@ -42,10 +43,11 @@ void tb_target_set_nop(uintptr_t tc_ptr G_GNUC_UNUSED,
     g_assert_not_reached();
 }
 
-void aot_tb_register(TranslationBlock *tb)
+void aot_tb_register(TranslationBlock *tb, AOTTBOrigin origin)
 {
     assert(tb != NULL);
     aot_register_count++;
+    aot_register_origin = origin;
 }
 
 int page_get_flags(target_ulong address G_GNUC_UNUSED)
@@ -96,6 +98,7 @@ int main(void)
     smc_reload_tree_insert(reload);
     g_assert(smc_page_reload(reload->page_addr, 0) == 1);
     g_assert(aot_register_count == 1);
+    g_assert(aot_register_origin == AOT_TB_DYNAMIC);
     g_assert(tb.tu_jmp[TU_TB_INDEX_NEXT] == 4);
     g_assert(smc_reload_tree_get_node_count() == 0);
     tb.cflags = CF_INVALID;
@@ -111,6 +114,7 @@ int main(void)
     smc_reload_tree_insert(reload);
     g_assert(smc_page_reload(reload->page_addr, 0) == 1);
     g_assert(aot_register_count == 2);
+    g_assert(aot_register_origin == AOT_TB_DYNAMIC);
     g_assert(tb.tu_jmp[TU_TB_INDEX_NEXT] == 4);
     g_assert(smc_reload_tree_get_node_count() == 0);
     return 0;

--- a/target/i386/latx/sbt/tests/tb-flush-smc-reload-async-test.c
+++ b/target/i386/latx/sbt/tests/tb-flush-smc-reload-async-test.c
@@ -16,6 +16,7 @@
 static run_on_cpu_func queued_func;
 static run_on_cpu_data queued_data;
 static bool mmap_locked;
+static unsigned int aot_reset_count;
 
 TBContext tb_ctx;
 CPUTailQ cpus = QTAILQ_HEAD_INITIALIZER(cpus);
@@ -37,6 +38,12 @@ int qemu_log(const char *fmt G_GNUC_UNUSED, ...)
 void aot_exit_entry(CPUState *cpu G_GNUC_UNUSED,
                     AOTExitReason reason G_GNUC_UNUSED)
 {
+}
+
+void aot_reset_tb_stats(void)
+{
+    g_assert(mmap_locked);
+    aot_reset_count++;
 }
 
 #ifdef CONFIG_PLUGIN
@@ -126,6 +133,7 @@ int main(void)
     smc_reload_tree_insert(new_reload_node(0x1000));
     run_queued_flush(&cpu);
     g_assert(smc_reload_tree_get_node_count() == 0);
+    g_assert_cmpuint(aot_reset_count, ==, 1);
 
     smc_reload_tree_insert(new_reload_node(0x2000));
     tb_flush(&cpu);
@@ -133,6 +141,7 @@ int main(void)
     tb_ctx.tb_flush_count++;
     run_queued_flush(&cpu);
     g_assert(smc_reload_tree_get_node_count() == 1);
+    g_assert_cmpuint(aot_reset_count, ==, 1);
     smc_reload_tree_clear();
     return 0;
 }


### PR DESCRIPTION
## Motivation

Avoid spending AOT generation time and cache space on translation blocks that are unlikely to provide useful reuse.

## Changes

- Skip low-value AOT generation according to the existing generation heuristics.
- Keep the change limited to AOT generation policy.

## Validation

- `ninja -C build32 latx-i386`
- `ninja -C build64 latx-x86_64`
- Both targets built successfully from `upstream/master` plus this commit.

## Scope

This PR contains one optimization commit and no local build output or test artifacts.
