### PR TITLE
linux-user, fix: Preserve x87 state in signal frames

### DIFF
--- a/linux-user/i386/signal.c
+++ b/linux-user/i386/signal.c
@@ -471,15 +471,21 @@ cs->previous_exception_index = -1;
     __put_user(env->regs[R_ESP], &sc->esp_at_signal);
     __put_user(env->segs[R_SS].selector, (unsigned int *)&sc->ss);
 
-    cpu_x86_fsave(env, fpstate_addr, 1);
-    fpstate->status = fpstate->sw;
     if (!(env->features[FEAT_1_EDX] & CPUID_FXSR)) {
         magic = 0xffff;
     } else {
+        /*
+         * cpu_x86_fsave() has FSAVE semantics and resets the x87 state.
+         * Capture the non-destructive extended state first, then let FSAVE
+         * fill the legacy area and initialize the state used by the handler.
+         * Sigreturn restores the interrupted state from the signal frame.
+         */
         xsave_sigcontext(env, &fpstate->fxsave,
                           fpstate_addr + TARGET_FPSTATE_FXSAVE_OFFSET);
         magic = 0;
     }
+    cpu_x86_fsave(env, fpstate_addr, 1);
+    fpstate->status = fpstate->sw;
     __put_user(magic, &fpstate->magic);
 #else
     __put_user(env->regs[R_EDI], &sc->rdi);


### PR DESCRIPTION
## Motivation

An x87 value could be lost or restored into the wrong logical stack slot after a guest signal because the i386 signal frame did not preserve the complete x87 state used by LATX.

## Changes

- Preserve the missing x87 state when constructing and restoring i386 guest signal frames.
- Keep the change limited to `linux-user/i386/signal.c`.

## Validation

- `ninja -C build32 latx-i386`
- `LATX_SOFTFPU=2 build32/latx-i386 latx-x87-signal-stack-test-one`
- Result: `signals=1 failures=0`.

## Scope

This PR contains one correctness fix. LBT TOP cleanup is submitted separately.
