### PR TITLE
LATX, fix: Preserve 16K permission checks with a cached fast path

### DIFF
--- a/accel/tcg/translate-all.c
+++ b/accel/tcg/translate-all.c
@@ -3118,6 +3118,47 @@ void latx_init_16k_page_checks(void)
         g_new0(uint8_t, LATX_HOST_16K_PAGE_COUNT);
 }
 
+#define LATX_MINKE_WINE_HELPER_PC       UINT32_C(0x7b71d000)
+#define LATX_MINKE_MAX_JIT_MAPPING_SIZE (64 * KiB)
+
+static uint8_t *latx_minke_16k_write_tb_pages;
+
+void latx_enable_minke_16k_write_checks(void)
+{
+    latx_init_16k_page_checks();
+    if (!latx_4k_page_flags || latx_minke_16k_write_tb_pages) {
+        return;
+    }
+
+    latx_minke_16k_write_tb_pages =
+        g_new0(uint8_t, LATX_GUEST_PAGE_COUNT);
+    qatomic_set(&latx_minke_16k_write_tb_pages[
+                LATX_MINKE_WINE_HELPER_PC >> TARGET_PAGE_BITS], 1);
+}
+
+bool latx_minke_16k_write_check_pc(target_ulong pc)
+{
+    return latx_minke_16k_write_tb_pages &&
+        qatomic_read(&latx_minke_16k_write_tb_pages[
+                     pc >> TARGET_PAGE_BITS]);
+}
+
+void latx_minke_register_16k_tb_range(abi_ulong start, abi_ulong end)
+{
+    uint32_t first, last, i;
+
+    if (!latx_minke_16k_write_tb_pages || start >= end ||
+        end - start > LATX_MINKE_MAX_JIT_MAPPING_SIZE) {
+        return;
+    }
+
+    first = start >> TARGET_PAGE_BITS;
+    last = (end - 1) >> TARGET_PAGE_BITS;
+    for (i = first; i <= last; i++) {
+        qatomic_set(&latx_minke_16k_write_tb_pages[i], 1);
+    }
+}
+
 static void latx_update_page_permissions(target_ulong start, target_ulong end)
 {
     target_ulong addr, host_addr;

--- a/accel/tcg/translate-all.c
+++ b/accel/tcg/translate-all.c
@@ -7071,8 +7071,11 @@ static int interpret_xchg(ucontext_t *uc, uint32_t* inst,
         return LOCKINT_SEGV; /* send segv to guest */
     }
 
-    int opnd0_size = (inst[-1] & 0xffc003ff) == 0x03400000 ?
-                ((inst[-1] << 10)) >> 20 : size;
+    int encoded_size = (inst[-1] << 10) >> 20;
+    bool narrow_swap = (inst[0] & 0xffff8000) == 0x38608000 &&
+                       (inst[-1] & 0xffc003ff) == 0x03400000 &&
+                       (encoded_size == 16 || encoded_size == 32);
+    int opnd0_size = narrow_swap ? encoded_size : size;
     if (page_addr != ((siaddr + (opnd0_size >> 3)) & qemu_host_page_mask)) {
         page_num = 2;
     } else {
@@ -7092,9 +7095,8 @@ static int interpret_xchg(ucontext_t *uc, uint32_t* inst,
     /*
      * amswap.d
      */
-    if ((inst[-1] & 0xffc003ff) == 0x03400000) {
+    if (narrow_swap) {
         /* andi 0, 0, opnd0_size */
-        int opnd0_size = (inst[-1] << 10) >> 20;
         qemu_log_mask(LAT_LOG_MEM, "[LATX_LOCK] %s opnd0_size %d\n",
                     __func__, opnd0_size);
         if (opnd0_size == 32) {

--- a/accel/tcg/translate-all.c
+++ b/accel/tcg/translate-all.c
@@ -3102,6 +3102,54 @@ typedef struct PageFlagsNode {
 } PageFlagsNode;
 
 IntervalTreeRoot pageflags_root;
+#if defined(CONFIG_LATX) && defined(TARGET_I386) && TARGET_ABI_BITS == 32
+uint8_t *latx_4k_page_flags;
+uint8_t *latx_16k_page_mixed;
+
+void latx_init_16k_page_checks(void)
+{
+    if (qemu_real_host_page_size != LATX_HOST_16K_PAGE_SIZE ||
+        latx_4k_page_flags) {
+        return;
+    }
+
+    latx_4k_page_flags = g_new0(uint8_t, LATX_GUEST_PAGE_COUNT);
+    latx_16k_page_mixed =
+        g_new0(uint8_t, LATX_HOST_16K_PAGE_COUNT);
+}
+
+static void latx_update_page_permissions(target_ulong start, target_ulong end)
+{
+    target_ulong addr, host_addr;
+
+    if (!latx_4k_page_flags ||
+        qemu_host_page_size != LATX_HOST_16K_PAGE_SIZE) {
+        return;
+    }
+
+    for (addr = start; addr < end; addr += TARGET_PAGE_SIZE) {
+        qatomic_set(&latx_4k_page_flags[addr >> TARGET_PAGE_BITS],
+                    page_get_flags(addr) & PAGE_BITS);
+    }
+
+    start &= ~(target_ulong)(LATX_HOST_16K_PAGE_SIZE - 1);
+    end = ROUND_UP(end, LATX_HOST_16K_PAGE_SIZE);
+    for (host_addr = start; host_addr < end;
+         host_addr += LATX_HOST_16K_PAGE_SIZE) {
+        int flags = page_get_flags(host_addr) & PAGE_BITS;
+        int mixed = 0;
+
+        for (addr = host_addr + TARGET_PAGE_SIZE;
+             addr < host_addr + LATX_HOST_16K_PAGE_SIZE;
+             addr += TARGET_PAGE_SIZE) {
+            mixed |= flags ^ (page_get_flags(addr) & PAGE_BITS);
+        }
+        qatomic_set(&latx_16k_page_mixed[
+                    host_addr >> LATX_HOST_16K_PAGE_BITS],
+                    mixed & PAGE_BITS);
+    }
+}
+#endif
 
 static PageFlagsNode *pageflags_find(target_ulong start, target_ulong last)
 {
@@ -3686,6 +3734,12 @@ void page_set_flags_tb_reload(target_ulong start, target_ulong end,
         inval_tb |= pageflags_set_clear(start, last, flags,
             ~(reset ? 0 : PAGE_ANON | PAGE_OVERFLOW | PAGE_MEMSHARE));
     }
+
+#if defined(CONFIG_LATX) && defined(TARGET_I386) && TARGET_ABI_BITS == 32
+    if (latx_4k_page_flags) {
+        latx_update_page_permissions(start, end);
+    }
+#endif
 
     if (inval_tb) {
 #ifdef CONFIG_LATX_AOT

--- a/include/exec/cpu-all.h
+++ b/include/exec/cpu-all.h
@@ -240,6 +240,19 @@ extern const TargetPageBits target_page;
  */
 extern uintptr_t qemu_host_page_size;
 extern intptr_t qemu_host_page_mask;
+#if defined(CONFIG_LATX) && defined(TARGET_I386)
+#define LATX_HOST_16K_PAGE_BITS 14
+#define LATX_HOST_16K_PAGE_SIZE (1UL << LATX_HOST_16K_PAGE_BITS)
+#if TARGET_ABI_BITS == 32
+#define LATX_GUEST_PAGE_COUNT   \
+    (1U << (TARGET_ABI_BITS - TARGET_PAGE_BITS))
+#define LATX_HOST_16K_PAGE_COUNT \
+    (1U << (TARGET_ABI_BITS - LATX_HOST_16K_PAGE_BITS))
+extern uint8_t *latx_4k_page_flags;
+extern uint8_t *latx_16k_page_mixed;
+void latx_init_16k_page_checks(void);
+#endif
+#endif
 
 #define HOST_PAGE_ALIGN(addr) ROUND_UP((addr), qemu_host_page_size)
 #define REAL_HOST_PAGE_ALIGN(addr) ROUND_UP((addr), qemu_real_host_page_size)

--- a/include/exec/cpu-all.h
+++ b/include/exec/cpu-all.h
@@ -251,6 +251,9 @@ extern intptr_t qemu_host_page_mask;
 extern uint8_t *latx_4k_page_flags;
 extern uint8_t *latx_16k_page_mixed;
 void latx_init_16k_page_checks(void);
+void latx_enable_minke_16k_write_checks(void);
+bool latx_minke_16k_write_check_pc(target_ulong pc);
+void latx_minke_register_16k_tb_range(abi_ulong start, abi_ulong end);
 #endif
 #endif
 

--- a/linux-user/main.c
+++ b/linux-user/main.c
@@ -789,6 +789,27 @@ static void handle_arg_latx_mem_test(const char *arg)
     }
 }
 
+#define LATX_MINKE_PROGRAM_NAME "Minke.MI.Organ.exe"
+
+static void handle_arg_latx_minke_16k_page_check(const char *arg)
+{
+    long value;
+
+    if (qemu_strtol(arg, NULL, 0, &value)) {
+        value = 0;
+    }
+    option_minke_16k_page_check = value != 0;
+    if (option_minke_16k_page_check) {
+#if TARGET_ABI_BITS == 32
+        if (qemu_real_host_page_size != LATX_HOST_16K_PAGE_SIZE) {
+            option_minke_16k_page_check = 0;
+        }
+#else
+        option_minke_16k_page_check = 0;
+#endif
+    }
+}
+
 static void handle_arg_latx_real_maps(const char *arg)
 {
     option_real_maps = strtol(arg, NULL, 0);
@@ -958,6 +979,9 @@ static const struct qemu_argument arg_table[] = {
     "",           "enable imm reg optimization"},
     {"latx-mem-test",    "LATX_MT",     true,  handle_arg_latx_mem_test,
     "",           "test memory right when memory access"},
+    {"latx-minke-16k-page-check", "LATX_MINKE_16K_PAGE_CHECK", true,
+    handle_arg_latx_minke_16k_page_check, "0|1",
+    "enable Minke-specific mixed 16K write checks"},
     {"latx-real-maps",    "LATX_REAL_MAPS",     true,  handle_arg_latx_real_maps,
     "",           "enable get real self maps"},
     {"latx-monitor-shared-mem",    "LATX_MONITOR_SHARED_MEM",     true,  handle_arg_latx_monitor_shared_mem,
@@ -1468,6 +1492,19 @@ int main(int argc, char **argv, char **envp)
 #if defined(CONFIG_LATX) && defined(TARGET_I386) && TARGET_ABI_BITS == 32
     if (option_mem_test) {
         latx_init_16k_page_checks();
+    }
+    if (option_minke_16k_page_check) {
+        const char *program = guest_program(target_argv);
+        bool enable_minke_checks = program &&
+            !strcasecmp(program, LATX_MINKE_PROGRAM_NAME);
+
+        option_minke_16k_page_check = enable_minke_checks;
+        if (enable_minke_checks) {
+#ifdef CONFIG_LATX_AOT
+            option_aot = 0;
+#endif
+            latx_enable_minke_16k_write_checks();
+        }
     }
 #endif
 

--- a/linux-user/main.c
+++ b/linux-user/main.c
@@ -779,7 +779,13 @@ static void handle_arg_latx_unimp_dump(const char *arg)
 
 static void handle_arg_latx_mem_test(const char *arg)
 {
-    option_mem_test = strtol(arg, NULL, 0);
+    long value;
+
+    if (qemu_strtol(arg, NULL, 0, &value) || value < 0 || value > 2) {
+        option_mem_test = 0;
+    } else {
+        option_mem_test = value;
+    }
     if (option_mem_test) {
         if (qemu_real_host_page_size != LATX_HOST_16K_PAGE_SIZE) {
             option_mem_test = 0;
@@ -978,7 +984,7 @@ static const struct qemu_argument arg_table[] = {
     {"latx-imm-reg",    "LATX_IMM_REG",     true,  handle_arg_latx_imm_reg,
     "",           "enable imm reg optimization"},
     {"latx-mem-test",    "LATX_MT",     true,  handle_arg_latx_mem_test,
-    "",           "test memory right when memory access"},
+    "0|1|2",      "16K checks: sparse fast or strict fast"},
     {"latx-minke-16k-page-check", "LATX_MINKE_16K_PAGE_CHECK", true,
     handle_arg_latx_minke_16k_page_check, "0|1",
     "enable Minke-specific mixed 16K write checks"},

--- a/linux-user/main.c
+++ b/linux-user/main.c
@@ -781,7 +781,7 @@ static void handle_arg_latx_mem_test(const char *arg)
 {
     option_mem_test = strtol(arg, NULL, 0);
     if (option_mem_test) {
-        if (sysconf(_SC_PAGESIZE) != 16384) {
+        if (qemu_real_host_page_size != LATX_HOST_16K_PAGE_SIZE) {
             option_mem_test = 0;
         } else {
             option_aot = 0;
@@ -1464,6 +1464,12 @@ int main(int argc, char **argv, char **envp)
 
     /* set environment variables */
     options_set(target_argv);
+
+#if defined(CONFIG_LATX) && defined(TARGET_I386) && TARGET_ABI_BITS == 32
+    if (option_mem_test) {
+        latx_init_16k_page_checks();
+    }
+#endif
 
     if (!latx_options_finalize()) {
 #if defined(CONFIG_LATX_KZT)

--- a/linux-user/mmap.c
+++ b/linux-user/mmap.c
@@ -27,6 +27,7 @@
 #endif
 #ifdef CONFIG_LATX
 #include "latx-config.h"
+#include "latx-options.h"
 #endif
 #if defined(CONFIG_LATX_KZT) && defined(TARGET_X86_64)
 #include "kzt_relro_preprotect.h"
@@ -39,7 +40,6 @@
 #include "aot.h"
 #include "aot_smc.h"
 #include "aot_page.h"
-#include "latx-options.h"
 #endif
 #include <sys/resource.h>
 
@@ -280,6 +280,12 @@ static int target_mprotect_internal(abi_ulong start, abi_ulong len,
     }
 
     page_set_flags_tb_reload(start, start + len, page_flags, true);
+
+#if defined(CONFIG_LATX) && defined(TARGET_I386) && TARGET_ABI_BITS == 32
+    if (option_minke_16k_page_check && (target_prot & PROT_EXEC)) {
+        latx_minke_register_16k_tb_range(start, start + len);
+    }
+#endif
 
     if (target_prot == PROT_NONE) {
 #ifdef CONFIG_LATX_AOT
@@ -1163,6 +1169,11 @@ abi_long target_mmap(abi_ulong start, abi_ulong len, int target_prot,
     if (fd > 2 && (target_prot & PROT_EXEC)) {
         ht_pc_thunk_invalidate(start, start + len);
     }
+#if TARGET_ABI_BITS == 32
+    if (option_minke_16k_page_check && (target_prot & PROT_EXEC)) {
+        latx_minke_register_16k_tb_range(start, start + len);
+    }
+#endif
 #endif
 #endif
 

--- a/target/i386/latx/include/latx-options.h
+++ b/target/i386/latx/include/latx-options.h
@@ -124,6 +124,7 @@ extern int option_imm_complex;
 extern int option_debug_imm_reg;
 extern uint64_t imm_skip_pc;
 extern int option_mem_test;
+extern int option_minke_16k_page_check;
 extern int option_real_maps;
 extern int option_monitor_shared_mem;
 extern int option_private_mmap_shadow;
@@ -163,6 +164,8 @@ extern unsigned long long counter_mips_tr;
     ENVFUN(LATX_JRRA, handle_arg_latx_jrra) \
     ENVFUN(LATX_IMM_REG, handle_arg_latx_imm_reg) \
     ENVFUN(LATX_MT, handle_arg_latx_mem_test) \
+    ENVFUN(LATX_MINKE_16K_PAGE_CHECK, \
+           handle_arg_latx_minke_16k_page_check) \
     ENVFUN(LATX_REAL_MAPS, handle_arg_latx_real_maps) \
     ENVFUN(LATX_MONITOR_SHARED_MEM, handle_arg_latx_monitor_shared_mem) \
     ENVFUN(LATX_PRIVATE_MMAP_SHADOW, handle_arg_latx_private_mmap_shadow) \

--- a/target/i386/latx/include/translate.h
+++ b/target/i386/latx/include/translate.h
@@ -1734,7 +1734,8 @@ void update_fcsr_rm(IR2_OPND control_word, IR2_OPND fcsr);
 bool ir1_need_reserve_h128(IR1_INST *ir1);
 IR2_OPND save_h128_of_ymm(IR1_INST *ir1);
 void restore_h128_of_ymm(IR1_INST *ir1, IR2_OPND temp);
-void gen_test_page_flag(IR2_OPND mem_opnd, int mem_imm, uint32_t flag);
+void gen_test_page_flag(IR2_OPND mem_opnd, int mem_imm, uint32_t flag,
+                        unsigned int mem_size);
 
 void clear_h32(IR2_OPND *opnd);
 

--- a/target/i386/latx/latx-options.c
+++ b/target/i386/latx/latx-options.c
@@ -101,6 +101,7 @@ int option_vpaes;
 int option_split_tb;
 int option_anonym;
 int option_mem_test;
+int option_minke_16k_page_check;
 int option_real_maps;
 int option_monitor_shared_mem;
 int option_private_mmap_shadow;
@@ -270,6 +271,7 @@ void options_init(void)
 #endif
     option_anonym = 0;
     option_mem_test = 0;
+    option_minke_16k_page_check = 0;
     option_real_maps = 0;
     option_monitor_shared_mem = 0;
     option_private_mmap_shadow = 0;

--- a/target/i386/latx/optimization/ir2-optimization.c
+++ b/target/i386/latx/optimization/ir2-optimization.c
@@ -619,13 +619,14 @@ void ir2_opt_push_pop_fix(TranslationBlock *tb, CPUState *cpu, int i)
                     op, curr_id, end_id, skip_count);
                 break;
             case LISA_ALIGN: {
-                if (!((curr_id - skip_count) & 0x1)) {
-                    skip_count++;
-                    end_id++;
-                    qemu_log_mask(LAT_IR2_SCHED,
-                        "\n[LAT_PUSH_FIX] op %d curr_id %d end_id %d skip_count %d\n",
-                        op, curr_id, end_id, skip_count);
-                }
+                int align = ir2_opnd_val(&curr->_opnd[0]);
+                /* Account for all preceding pseudo and optimized instructions. */
+                int host_offset = curr_id - end_id + i;
+                int padding = (align - host_offset % align) % align;
+
+                /* One pseudo instruction expands to padding host instructions. */
+                skip_count += 1 - padding;
+                end_id += 1 - padding;
                 break;
             }
             case LISA_FAR_JUMP:

--- a/target/i386/latx/translator/tr-avx-lsx.c
+++ b/target/i386/latx/translator/tr-avx-lsx.c
@@ -2615,10 +2615,10 @@ bool translate_vpxor_lsx(IR1_INST * pir1) {
                 lsassert(ir1_opnd_is_mem(opnd2));
                 src2 = ra_alloc_ftemp();
                 src2_high = ra_alloc_ftemp();
-                gen_test_page_flag(mem_opnd, mem_imm, PAGE_READ);
+                gen_test_page_flag(mem_opnd, mem_imm, PAGE_READ, 16);
                 la_vld(src2, mem_opnd, mem_imm);
                 mem_opnd = mem_imm_add_disp(mem_opnd, &mem_imm, 16);
-                gen_test_page_flag(mem_opnd, mem_imm, PAGE_READ);
+                gen_test_page_flag(mem_opnd, mem_imm, PAGE_READ, 16);
                 la_vld(src2_high, mem_opnd, mem_imm);
             }
 

--- a/target/i386/latx/translator/tr-avx-mov-lsx.c
+++ b/target/i386/latx/translator/tr-avx-mov-lsx.c
@@ -190,7 +190,7 @@ bool translate_vmovaps_lsx(IR1_INST *pir1)
             IR2_OPND high = ra_alloc_ftemp();
 
             address = convert_mem_to_itemp(src);
-            gen_test_page_flag(address, 0, PAGE_READ);
+            gen_test_page_flag(address, 0, PAGE_READ, 32);
             la_vld(low, address, 0);
             la_vld(high, address, 16);
             la_vori_b(ra_alloc_xmm(dest_index), low, 0);
@@ -206,7 +206,7 @@ bool translate_vmovaps_lsx(IR1_INST *pir1)
 
             address = convert_mem_to_itemp(dest);
             gen_test_page_flag(address, 0,
-                               PAGE_WRITE | PAGE_WRITE_ORG);
+                               PAGE_WRITE | PAGE_WRITE_ORG, 32);
             la_vst(low, address, 0);
             la_vst(high, address, 16);
             ra_free_temp(address);
@@ -225,7 +225,7 @@ bool translate_vmovaps_lsx(IR1_INST *pir1)
             IR2_OPND value = ra_alloc_ftemp();
 
             address = convert_mem_to_itemp(src);
-            gen_test_page_flag(address, 0, PAGE_READ);
+            gen_test_page_flag(address, 0, PAGE_READ, 16);
             la_vld(value, address, 0);
             la_vori_b(ra_alloc_xmm(dest_index), value, 0);
             clear_ymm_high128_shadow(dest_index);
@@ -236,7 +236,7 @@ bool translate_vmovaps_lsx(IR1_INST *pir1)
 
             address = convert_mem_to_itemp(dest);
             gen_test_page_flag(address, 0,
-                               PAGE_WRITE | PAGE_WRITE_ORG);
+                               PAGE_WRITE | PAGE_WRITE_ORG, 16);
             la_vst(ra_alloc_xmm(ir1_opnd_base_reg_num(src)),
                    address, 0);
             ra_free_temp(address);

--- a/target/i386/latx/translator/tr-lock-fast-atomic.c
+++ b/target/i386/latx/translator/tr-lock-fast-atomic.c
@@ -383,6 +383,8 @@ bool translate_lock_xchg_fast_atomic(IR1_INST *pir1)
     }
 
     IR2_INST *(*amswap_inst)(IR2_OPND, IR2_OPND, IR2_OPND);
+    gen_test_page_flag(mem_opnd, 0, PAGE_WRITE | PAGE_WRITE_ORG,
+                       opnd0_size / 8);
     amswap_inst = ATO_AMSWAP(opnd0_size);
 
     amswap_inst(src0, src1, mem_opnd);

--- a/target/i386/latx/translator/tr-lock-fast-atomic.c
+++ b/target/i386/latx/translator/tr-lock-fast-atomic.c
@@ -41,7 +41,8 @@ bool translate_lock_add_fast_atomic(IR1_INST *pir1)
     src0 = ra_alloc_itemp();
 
     mem_opnd = convert_mem_no_offset(opnd0);
-    gen_test_page_flag(mem_opnd, 0, PAGE_WRITE | PAGE_WRITE_ORG);
+    gen_test_page_flag(mem_opnd, 0, PAGE_WRITE | PAGE_WRITE_ORG,
+                       opnd0_size / 8);
 
     IR2_INST *(*amadd_inst)(IR2_OPND, IR2_OPND, IR2_OPND);
     amadd_inst = ATO_AMADD(opnd0_size);
@@ -69,7 +70,8 @@ bool translate_lock_and_fast_atomic(IR1_INST *pir1)
     src0 = ra_alloc_itemp();
 
     mem_opnd = convert_mem_no_offset(opnd0);
-    gen_test_page_flag(mem_opnd, 0, PAGE_WRITE | PAGE_WRITE_ORG);
+    gen_test_page_flag(mem_opnd, 0, PAGE_WRITE | PAGE_WRITE_ORG,
+                       opnd0_size / 8);
 
     src1 = load_ireg_from_ir1(opnd1, UNKNOWN_EXTENSION, false);
 
@@ -115,7 +117,8 @@ bool translate_lock_inc_fast_atomic(IR1_INST *pir1)
     src1 = ra_alloc_itemp();
 
     mem_opnd = convert_mem_no_offset(opnd0);
-    gen_test_page_flag(mem_opnd, 0, PAGE_WRITE | PAGE_WRITE_ORG);
+    gen_test_page_flag(mem_opnd, 0, PAGE_WRITE | PAGE_WRITE_ORG,
+                       opnd0_size / 8);
 
     IR2_INST *(*amadd_inst)(IR2_OPND, IR2_OPND, IR2_OPND);
     amadd_inst = ATO_AMADD(opnd0_size);
@@ -143,7 +146,8 @@ bool translate_lock_dec_fast_atomic(IR1_INST *pir1)
     src1 = ra_alloc_itemp();
 
     mem_opnd = convert_mem_no_offset(opnd0);
-    gen_test_page_flag(mem_opnd, 0, PAGE_WRITE | PAGE_WRITE_ORG);
+    gen_test_page_flag(mem_opnd, 0, PAGE_WRITE | PAGE_WRITE_ORG,
+                       opnd0_size / 8);
 
     IR2_INST *(*amadd_inst)(IR2_OPND, IR2_OPND, IR2_OPND);
     amadd_inst = ATO_AMADD(opnd0_size);
@@ -172,7 +176,8 @@ bool translate_lock_sub_fast_atomic(IR1_INST *pir1)
     temp = ra_alloc_itemp();
 
     mem_opnd = convert_mem_no_offset(opnd0);
-    gen_test_page_flag(mem_opnd, 0, PAGE_WRITE | PAGE_WRITE_ORG);
+    gen_test_page_flag(mem_opnd, 0, PAGE_WRITE | PAGE_WRITE_ORG,
+                       opnd0_size / 8);
 
     IR2_INST *(*amadd_inst)(IR2_OPND, IR2_OPND, IR2_OPND);
     amadd_inst = ATO_AMADD(opnd0_size);
@@ -201,7 +206,8 @@ bool translate_lock_or_fast_atomic(IR1_INST *pir1)
     src0 = ra_alloc_itemp();
 
     mem_opnd = convert_mem_no_offset(opnd0);
-    gen_test_page_flag(mem_opnd, 0, PAGE_WRITE | PAGE_WRITE_ORG);
+    gen_test_page_flag(mem_opnd, 0, PAGE_WRITE | PAGE_WRITE_ORG,
+                       opnd0_size / 8);
 
     src1 = load_ireg_from_ir1(opnd1, UNKNOWN_EXTENSION, false);
 
@@ -247,7 +253,8 @@ bool translate_lock_not_fast_atomic(IR1_INST *pir1)
     src1 = ra_alloc_itemp();
 
     mem_opnd = convert_mem_no_offset(opnd0);
-    gen_test_page_flag(mem_opnd, 0, PAGE_WRITE | PAGE_WRITE_ORG);
+    gen_test_page_flag(mem_opnd, 0, PAGE_WRITE | PAGE_WRITE_ORG,
+                       opnd0_size / 8);
 
     la_addi_d(src1, zero_ir2_opnd, -1);
 
@@ -291,7 +298,8 @@ bool translate_lock_xor_fast_atomic(IR1_INST *pir1)
     src0 = ra_alloc_itemp();
 
     mem_opnd = convert_mem_no_offset(opnd0);
-    gen_test_page_flag(mem_opnd, 0, PAGE_WRITE | PAGE_WRITE_ORG);
+    gen_test_page_flag(mem_opnd, 0, PAGE_WRITE | PAGE_WRITE_ORG,
+                       opnd0_size / 8);
 
     src1 = load_ireg_from_ir1(opnd1, UNKNOWN_EXTENSION, false);
 
@@ -337,7 +345,8 @@ bool translate_lock_xadd_fast_atomic(IR1_INST *pir1)
     src0 = ra_alloc_itemp();
 
     mem_opnd = convert_mem_no_offset(opnd0);
-    gen_test_page_flag(mem_opnd, 0, PAGE_WRITE | PAGE_WRITE_ORG);
+    gen_test_page_flag(mem_opnd, 0, PAGE_WRITE | PAGE_WRITE_ORG,
+                       opnd0_size / 8);
 
     IR2_INST *(*amadd_inst)(IR2_OPND, IR2_OPND, IR2_OPND);
     amadd_inst = ATO_AMADD(opnd0_size);
@@ -407,7 +416,8 @@ bool translate_lock_cmpxchg_fast_atomic(IR1_INST *pir1)
     IR2_OPND gpr_eax_opnd = ra_alloc_gpr(eax_index);
 
     IR2_OPND mem_opnd = convert_mem_no_offset(opnd0);
-    gen_test_page_flag(mem_opnd, 0, PAGE_WRITE | PAGE_WRITE_ORG);
+    gen_test_page_flag(mem_opnd, 0, PAGE_WRITE | PAGE_WRITE_ORG,
+                       opnd0_size / 8);
 
 #ifdef TARGET_X86_64
     if (CODEIS64 && opnd0_size == 64) {

--- a/target/i386/latx/translator/tr-lock.c
+++ b/target/i386/latx/translator/tr-lock.c
@@ -80,7 +80,8 @@ bool translate_lock_sbb(IR1_INST *pir1)
     mem_opnd = convert_mem_to_itemp(opnd0);
 #endif
 
-    gen_test_page_flag(mem_opnd, 0, PAGE_WRITE | PAGE_WRITE_ORG);
+    gen_test_page_flag(mem_opnd, 0, PAGE_WRITE | PAGE_WRITE_ORG,
+                       opnd0_size / 8);
 
     if (CODEIS64 && opnd0_size == 64) {
         la_sbc_d(dest, zero_ir2_opnd, src1);
@@ -220,7 +221,8 @@ bool translate_lock_add(IR1_INST *pir1)
     mem_opnd = convert_mem_to_itemp(opnd0);
 #endif
 
-    gen_test_page_flag(mem_opnd, 0, PAGE_WRITE | PAGE_WRITE_ORG);
+    gen_test_page_flag(mem_opnd, 0, PAGE_WRITE | PAGE_WRITE_ORG,
+                       opnd0_size / 8);
 
 #ifdef TARGET_X86_64
     if (CODEIS64 && opnd0_size == 64) {
@@ -355,7 +357,8 @@ bool translate_lock_adc(IR1_INST *pir1)
 #else
     mem_opnd = convert_mem_to_itemp(opnd0);
 #endif
-    gen_test_page_flag(mem_opnd, 0, PAGE_WRITE | PAGE_WRITE_ORG);
+    gen_test_page_flag(mem_opnd, 0, PAGE_WRITE | PAGE_WRITE_ORG,
+                       opnd0_size / 8);
 
 #ifdef TARGET_X86_64
     if (CODEIS64 && opnd0_size == 64) {
@@ -494,7 +497,8 @@ bool translate_lock_and(IR1_INST *pir1)
 #else
     mem_opnd = convert_mem_to_itemp(opnd0);
 #endif
-    gen_test_page_flag(mem_opnd, 0, PAGE_WRITE | PAGE_WRITE_ORG);
+    gen_test_page_flag(mem_opnd, 0, PAGE_WRITE | PAGE_WRITE_ORG,
+                       opnd0_size / 8);
 
 #ifdef TARGET_X86_64
     if (CODEIS64 && opnd0_size == 64) {
@@ -625,7 +629,8 @@ bool translate_lock_inc(IR1_INST *pir1)
 #else
     mem_opnd = convert_mem_to_itemp(opnd0);
 #endif
-    gen_test_page_flag(mem_opnd, 0, PAGE_WRITE | PAGE_WRITE_ORG);
+    gen_test_page_flag(mem_opnd, 0, PAGE_WRITE | PAGE_WRITE_ORG,
+                       opnd0_size / 8);
 
 #ifdef TARGET_X86_64
     if (CODEIS64 && opnd0_size == 64) {
@@ -762,7 +767,8 @@ bool translate_lock_dec(IR1_INST *pir1)
 #else
     mem_opnd = convert_mem_to_itemp(opnd0);
 #endif
-    gen_test_page_flag(mem_opnd, 0, PAGE_WRITE | PAGE_WRITE_ORG);
+    gen_test_page_flag(mem_opnd, 0, PAGE_WRITE | PAGE_WRITE_ORG,
+                       opnd0_size / 8);
 
 #ifdef TARGET_X86_64
     if (CODEIS64 && opnd0_size == 64) {
@@ -904,7 +910,8 @@ bool translate_lock_sub(IR1_INST *pir1)
 #else
     mem_opnd = convert_mem_to_itemp(opnd0);
 #endif
-    gen_test_page_flag(mem_opnd, 0, PAGE_WRITE | PAGE_WRITE_ORG);
+    gen_test_page_flag(mem_opnd, 0, PAGE_WRITE | PAGE_WRITE_ORG,
+                       opnd0_size / 8);
 
 #ifdef TARGET_X86_64
     if (CODEIS64 && opnd0_size == 64) {
@@ -1036,7 +1043,8 @@ bool translate_lock_neg(IR1_INST *pir1)
 #else
     mem_opnd = convert_mem_to_itemp(opnd0);
 #endif
-    gen_test_page_flag(mem_opnd, 0, PAGE_WRITE | PAGE_WRITE_ORG);
+    gen_test_page_flag(mem_opnd, 0, PAGE_WRITE | PAGE_WRITE_ORG,
+                       opnd0_size / 8);
 
 #ifdef TARGET_X86_64
     IR2_OPND label_ll_d = ra_alloc_label();
@@ -1185,7 +1193,8 @@ bool translate_lock_or(IR1_INST *pir1)
 #else
     mem_opnd = convert_mem_to_itemp(opnd0);
 #endif
-    gen_test_page_flag(mem_opnd, 0, PAGE_WRITE | PAGE_WRITE_ORG);
+    gen_test_page_flag(mem_opnd, 0, PAGE_WRITE | PAGE_WRITE_ORG,
+                       opnd0_size / 8);
 
 #ifdef TARGET_X86_64
     if (CODEIS64 && opnd0_size == 64) {
@@ -1317,7 +1326,8 @@ bool translate_lock_not(IR1_INST *pir1)
 #else
     mem_opnd = convert_mem_to_itemp(opnd0);
 #endif
-    gen_test_page_flag(mem_opnd, 0, PAGE_WRITE | PAGE_WRITE_ORG);
+    gen_test_page_flag(mem_opnd, 0, PAGE_WRITE | PAGE_WRITE_ORG,
+                       opnd0_size / 8);
 
 #ifdef TARGET_X86_64
     if (CODEIS64 && opnd0_size == 64) {
@@ -1456,7 +1466,8 @@ bool translate_lock_xor(IR1_INST *pir1)
 #else
     mem_opnd = convert_mem_to_itemp(opnd0);
 #endif
-    gen_test_page_flag(mem_opnd, 0, PAGE_WRITE | PAGE_WRITE_ORG);
+    gen_test_page_flag(mem_opnd, 0, PAGE_WRITE | PAGE_WRITE_ORG,
+                       opnd0_size / 8);
 
 #ifdef TARGET_X86_64
     if (CODEIS64 && opnd0_size == 64) {
@@ -1596,7 +1607,8 @@ bool translate_lock_xadd(IR1_INST *pir1)
 #else
     mem_opnd = convert_mem_to_itemp(opnd0);
 #endif
-    gen_test_page_flag(mem_opnd, 0, PAGE_WRITE | PAGE_WRITE_ORG);
+    gen_test_page_flag(mem_opnd, 0, PAGE_WRITE | PAGE_WRITE_ORG,
+                       opnd0_size / 8);
 
 #ifdef TARGET_X86_64
     if (CODEIS64 && opnd0_size == 64) {
@@ -1753,7 +1765,8 @@ bool translate_lock_cmpxchg(IR1_INST *pir1)
 #else
     mem_opnd = convert_mem_to_itemp(opnd0);
 #endif
-    gen_test_page_flag(mem_opnd, 0, PAGE_WRITE | PAGE_WRITE_ORG);
+    gen_test_page_flag(mem_opnd, 0, PAGE_WRITE | PAGE_WRITE_ORG,
+                       opnd0_size / 8);
 
 #ifdef TARGET_X86_64
     IR2_OPND label_ll_d = ra_alloc_label();

--- a/target/i386/latx/translator/tr-mov.c
+++ b/target/i386/latx/translator/tr-mov.c
@@ -1741,6 +1741,7 @@ bool translate_cmpxchg8b(IR1_INST *pir1)
         mem_opnd = convert_mem(opnd0, &imm);
     }
     ir2_set_opnd_type(&mem_opnd, IR2_OPND_GPR);
+    gen_test_page_flag(mem_opnd, imm, PAGE_WRITE | PAGE_WRITE_ORG, 8);
 
     /*
      * There is only one parameter from IR1.

--- a/target/i386/latx/translator/tr-mov.c
+++ b/target/i386/latx/translator/tr-mov.c
@@ -1417,6 +1417,8 @@ static bool translate_xchg_spinlock(IR1_INST *pir1)
         mem_opnd = convert_mem(opnd1, &imm);
     }
     ir2_set_opnd_type(&mem_opnd, IR2_OPND_GPR);
+    gen_test_page_flag(mem_opnd, imm, PAGE_WRITE | PAGE_WRITE_ORG,
+                       ir1_opnd_size(opnd0) / 8);
     IR2_OPND lat_lock_addr = tr_lat_spin_lock(mem_opnd, imm);
 
     if (ir1_opnd_is_mem(opnd0)) {
@@ -1550,6 +1552,10 @@ bool translate_xchg(IR1_INST *pir1)
         src1 = load_ireg_from_ir1(opnd0, UNKNOWN_EXTENSION, false);
         reg_opnd = opnd0;
     }
+
+    /* Check the original address before alignment or an atomic fallback. */
+    gen_test_page_flag(mem_opnd, 0, PAGE_WRITE | PAGE_WRITE_ORG,
+                       opnd0_size / 8);
 
 #ifdef TARGET_X86_64
     if (CODEIS64 && opnd0_size == 64) {

--- a/target/i386/latx/translator/tr-opnd-process.c
+++ b/target/i386/latx/translator/tr-opnd-process.c
@@ -197,7 +197,8 @@ void load_ireg_from_ir1_mem(IR2_OPND opnd2, IR1_OPND *opnd1,
         mem_opnd = mem_imm_add_disp(mem_opnd, &mem_imm, 8);
     }
 
-    gen_test_page_flag(mem_opnd, mem_imm, PAGE_READ);
+    gen_test_page_flag(mem_opnd, mem_imm, PAGE_READ,
+                       MIN(ir1_opnd_size(opnd1), 64) / 8);
 
     if ((mem_imm & 0xffff0000) == 0xdead0000) {
         IR2_OPND base, index;
@@ -584,7 +585,8 @@ static void store_ireg_to_ir1_mem(IR2_OPND value_opnd, IR1_OPND *opnd1,
         mem_opnd = mem_imm_add_disp(mem_opnd, &mem_imm, 8);
     }
 
-    gen_test_page_flag(mem_opnd, mem_imm, PAGE_WRITE | PAGE_WRITE_ORG);
+    gen_test_page_flag(mem_opnd, mem_imm, PAGE_WRITE | PAGE_WRITE_ORG,
+                       MIN(ir1_opnd_size(opnd1), 64) / 8);
 
     if((mem_imm&0xffff0000)==0xdead0000) {
         IR2_OPND base,index;
@@ -912,7 +914,9 @@ static void load_freg_from_ir1_mem(IR2_OPND opnd2, IR1_OPND *opnd1,
         mem_opnd = mem_imm_add_disp(mem_opnd, &mem_imm, 8);
     }
 
-    gen_test_page_flag(mem_opnd, mem_imm, PAGE_READ);
+    gen_test_page_flag(mem_opnd, mem_imm, PAGE_READ,
+                       ir1_opnd_size(opnd1) == 80 ? 10 :
+                       MIN(ir1_opnd_size(opnd1), 64) / 8);
 
     if (ir1_opnd_size(opnd1) == 32) {
         la_fld_s(opnd2, mem_opnd, mem_imm);
@@ -1164,7 +1168,9 @@ static void store_freg_to_ir1_mem(IR2_OPND opnd2, IR1_OPND *opnd1,
         mem_opnd = mem_imm_add_disp(mem_opnd, &mem_imm, 8);
     }
 
-    gen_test_page_flag(mem_opnd, mem_imm, PAGE_WRITE | PAGE_WRITE_ORG);
+    gen_test_page_flag(mem_opnd, mem_imm, PAGE_WRITE | PAGE_WRITE_ORG,
+                       ir1_opnd_size(opnd1) == 80 ? 10 :
+                       MIN(ir1_opnd_size(opnd1), 64) / 8);
 
     if (ir1_opnd_size(opnd1) == 32) {
         IR2_OPND ftemp = ra_alloc_ftemp_internal();
@@ -1299,7 +1305,7 @@ void load_freg128_from_ir1_mem(IR2_OPND opnd2, IR1_OPND *opnd1){
     lsassert(ir2_opnd_is_freg(&opnd2));
 
     IR2_OPND mem_opnd = convert_mem(opnd1, &little_disp);
-    gen_test_page_flag(mem_opnd, little_disp, PAGE_READ);
+    gen_test_page_flag(mem_opnd, little_disp, PAGE_READ, 16);
     la_vld(opnd2, mem_opnd, little_disp);
     return;
 }
@@ -1311,7 +1317,8 @@ void store_freg128_to_ir1_mem(IR2_OPND opnd2, IR1_OPND *opnd1){
     lsassert(ir2_opnd_is_freg(&opnd2));
 
     IR2_OPND mem_opnd = convert_mem(opnd1, &little_disp);
-    gen_test_page_flag(mem_opnd, little_disp, PAGE_WRITE | PAGE_WRITE_ORG);
+    gen_test_page_flag(mem_opnd, little_disp, PAGE_WRITE | PAGE_WRITE_ORG,
+                       16);
     la_vst(opnd2, mem_opnd, little_disp);
     return;
 }
@@ -1346,7 +1353,8 @@ void store_freg256_to_ir1_mem(IR2_OPND opnd2, IR1_OPND * opnd1) {
     lsassert(ir1_opnd_is_mem(opnd1));
     lsassert(ir2_opnd_is_freg( & opnd2));
     IR2_OPND mem_opnd = convert_mem(opnd1, & little_disp);
-    gen_test_page_flag(mem_opnd, little_disp, PAGE_WRITE | PAGE_WRITE_ORG);
+    gen_test_page_flag(mem_opnd, little_disp, PAGE_WRITE | PAGE_WRITE_ORG,
+                       32);
     la_xvst(opnd2, mem_opnd, little_disp);
 }
 
@@ -1356,7 +1364,7 @@ void load_freg256_from_ir1_mem(IR2_OPND opnd2, IR1_OPND * opnd1) {
     lsassert(ir2_opnd_is_freg( & opnd2));
 
     IR2_OPND mem_opnd = convert_mem(opnd1, & little_disp);
-    gen_test_page_flag(mem_opnd, little_disp, PAGE_READ);
+    gen_test_page_flag(mem_opnd, little_disp, PAGE_READ, 32);
     la_xvld(opnd2, mem_opnd, little_disp);
 }
 
@@ -1523,7 +1531,7 @@ IR2_OPND load_v128_from_ir1_mem_exact(IR1_OPND *opnd)
     lsassert(ir1_opnd_is_mem(opnd) && ir1_opnd_size(opnd) == 128);
     address = convert_mem_to_itemp(opnd);
     value = ra_alloc_ftemp();
-    gen_test_page_flag(address, 0, PAGE_READ);
+    gen_test_page_flag(address, 0, PAGE_READ, 16);
     la_vld(value, address, 0);
     ra_free_temp(address);
     return value;
@@ -1533,7 +1541,7 @@ IR2_OPND load_v128_from_guest_addr_exact(IR2_OPND address)
 {
     IR2_OPND value = ra_alloc_ftemp();
 
-    gen_test_page_flag(address, 0, PAGE_READ);
+    gen_test_page_flag(address, 0, PAGE_READ, 16);
     la_vld(value, address, 0);
     return value;
 }
@@ -1545,7 +1553,7 @@ void store_v128_to_ir1_mem_exact(IR2_OPND value, IR1_OPND *opnd)
     lsassert(ir2_opnd_is_freg(&value));
     lsassert(ir1_opnd_is_mem(opnd) && ir1_opnd_size(opnd) == 128);
     address = convert_mem_to_itemp(opnd);
-    gen_test_page_flag(address, 0, PAGE_WRITE | PAGE_WRITE_ORG);
+    gen_test_page_flag(address, 0, PAGE_WRITE | PAGE_WRITE_ORG, 16);
     la_vst(value, address, 0);
     ra_free_temp(address);
 }
@@ -1553,7 +1561,7 @@ void store_v128_to_ir1_mem_exact(IR2_OPND value, IR1_OPND *opnd)
 void store_v128_to_guest_addr_exact(IR2_OPND value, IR2_OPND address)
 {
     lsassert(ir2_opnd_is_freg(&value));
-    gen_test_page_flag(address, 0, PAGE_WRITE | PAGE_WRITE_ORG);
+    gen_test_page_flag(address, 0, PAGE_WRITE | PAGE_WRITE_ORG, 16);
     la_vst(value, address, 0);
 }
 
@@ -1566,7 +1574,7 @@ void load_v256_from_ir1_mem_exact(IR1_OPND *opnd,
     address = convert_mem_to_itemp(opnd);
     *low = ra_alloc_ftemp();
     *high = ra_alloc_ftemp();
-    gen_test_page_flag(address, 0, PAGE_READ);
+    gen_test_page_flag(address, 0, PAGE_READ, 32);
     la_vld(*low, address, 0);
     la_vld(*high, address, 16);
     ra_free_temp(address);
@@ -1580,7 +1588,7 @@ IR2_OPND load_v256_high_from_ir1_mem_exact(IR1_OPND *opnd)
     lsassert(ir1_opnd_is_mem(opnd) && ir1_opnd_size(opnd) == 256);
     address = convert_mem_to_itemp(opnd);
     high = ra_alloc_ftemp();
-    gen_test_page_flag(address, 0, PAGE_READ);
+    gen_test_page_flag(address, 16, PAGE_READ, 16);
     la_vld(high, address, 16);
     ra_free_temp(address);
     return high;
@@ -1594,7 +1602,7 @@ void store_v256_to_ir1_mem_exact(IR2_OPND low, IR2_OPND high,
     lsassert(ir2_opnd_is_freg(&low) && ir2_opnd_is_freg(&high));
     lsassert(ir1_opnd_is_mem(opnd) && ir1_opnd_size(opnd) == 256);
     address = convert_mem_to_itemp(opnd);
-    gen_test_page_flag(address, 0, PAGE_WRITE | PAGE_WRITE_ORG);
+    gen_test_page_flag(address, 0, PAGE_WRITE | PAGE_WRITE_ORG, 32);
     la_vst(low, address, 0);
     la_vst(high, address, 16);
     ra_free_temp(address);
@@ -1607,7 +1615,7 @@ void store_v256_low_to_ir1_mem_exact(IR2_OPND low, IR1_OPND *opnd)
     lsassert(ir2_opnd_is_freg(&low));
     lsassert(ir1_opnd_is_mem(opnd) && ir1_opnd_size(opnd) == 256);
     address = convert_mem_to_itemp(opnd);
-    gen_test_page_flag(address, 0, PAGE_WRITE | PAGE_WRITE_ORG);
+    gen_test_page_flag(address, 0, PAGE_WRITE | PAGE_WRITE_ORG, 16);
     la_vst(low, address, 0);
     ra_free_temp(address);
 }
@@ -1619,7 +1627,7 @@ void store_v256_high_to_ir1_mem_exact(IR2_OPND high, IR1_OPND *opnd)
     lsassert(ir2_opnd_is_freg(&high));
     lsassert(ir1_opnd_is_mem(opnd) && ir1_opnd_size(opnd) == 256);
     address = convert_mem_to_itemp(opnd);
-    gen_test_page_flag(address, 0, PAGE_WRITE | PAGE_WRITE_ORG);
+    gen_test_page_flag(address, 16, PAGE_WRITE | PAGE_WRITE_ORG, 16);
     la_vst(high, address, 16);
     ra_free_temp(address);
 }

--- a/target/i386/latx/translator/translate.c
+++ b/target/i386/latx/translator/translate.c
@@ -4317,7 +4317,8 @@ static inline void helper_restore_reg(IR2_OPND opnd)
             lsenv_offset_of_all_gpr(lsenv, ir2_opnd_base_reg_num(&opnd)));
 }
 
-void gen_test_page_flag(IR2_OPND mem_opnd, int mem_imm, uint32_t flag)
+void gen_test_page_flag(IR2_OPND mem_opnd, int mem_imm, uint32_t flag,
+                        unsigned int mem_size)
 {
     uint32_t required_flag = flag & PAGE_WRITE ? PAGE_WRITE : PAGE_READ;
 
@@ -4350,6 +4351,7 @@ void gen_test_page_flag(IR2_OPND mem_opnd, int mem_imm, uint32_t flag)
     IR2_OPND label1 = ra_alloc_label();
     IR2_OPND label2 = ra_alloc_label();
     IR2_OPND label_fault = ra_alloc_label();
+    IR2_OPND label_check_end = ra_alloc_label();
     bool need_restore0 = false;
     bool need_restore1 = false;
     bool need_restore2 = false;
@@ -4389,15 +4391,38 @@ void gen_test_page_flag(IR2_OPND mem_opnd, int mem_imm, uint32_t flag)
                           LATX_HOST_16K_PAGE_BITS);
             la_ldx_bu(itemp2, itemp0, itemp1);
             la_andi(itemp2, itemp2, required_flag);
-            la_beq(itemp2, zero_ir2_opnd, label_exit);
+            la_beq(itemp2, zero_ir2_opnd,
+                   mem_size > 1 ? label_check_end : label_exit);
         }
         li_d(itemp0, (ADDR)latx_4k_page_flags);
         la_bstrpick_d(itemp1, mem_addr, TARGET_ABI_BITS - 1,
                       TARGET_PAGE_BITS);
         la_ldx_bu(itemp2, itemp0, itemp1);
         la_andi(itemp2, itemp2, required_flag);
-        la_bne(itemp2, zero_ir2_opnd, label_exit);
+        la_bne(itemp2, zero_ir2_opnd,
+               mem_size > 1 ? label_check_end : label_exit);
         la_b(label_fault);
+        if (mem_size > 1) {
+            la_label(label_check_end);
+            la_addi_d(mem_addr, mem_addr, mem_size - 1);
+            if (option_mem_test != 2) {
+                li_d(itemp0, (ADDR)latx_16k_page_mixed);
+                la_bstrpick_d(itemp1, mem_addr, TARGET_ABI_BITS - 1,
+                              LATX_HOST_16K_PAGE_BITS);
+                la_ldx_bu(itemp2, itemp0, itemp1);
+                la_andi(itemp2, itemp2, required_flag);
+                la_beq(itemp2, zero_ir2_opnd, label_exit);
+            }
+            li_d(itemp0, (ADDR)latx_4k_page_flags);
+            la_bstrpick_d(itemp1, mem_addr, TARGET_ABI_BITS - 1,
+                          TARGET_PAGE_BITS);
+            la_ldx_bu(itemp2, itemp0, itemp1);
+            la_andi(itemp2, itemp2, required_flag);
+            la_bne(itemp2, zero_ir2_opnd, label_exit);
+            /* The first inaccessible byte is the start of the final page. */
+            la_bstrins_d(mem_addr, zero_ir2_opnd, TARGET_PAGE_BITS - 1, 0);
+            /* Fall through to label_fault. */
+        }
     } else
 #endif
     {

--- a/target/i386/latx/translator/translate.c
+++ b/target/i386/latx/translator/translate.c
@@ -4375,13 +4375,22 @@ void gen_test_page_flag(IR2_OPND mem_opnd, int mem_imm, uint32_t flag)
     IR2_OPND mem_addr = ra_alloc_statics(S_UD1);
     la_addi_d(mem_addr, mem_opnd, mem_imm);
 #if TARGET_ABI_BITS == 32
-    if (qemu_host_page_size == LATX_HOST_16K_PAGE_SIZE) {
-        li_d(itemp0, (ADDR)latx_16k_page_mixed);
-        la_bstrpick_d(itemp1, mem_addr, TARGET_ABI_BITS - 1,
-                      LATX_HOST_16K_PAGE_BITS);
-        la_ldx_bu(itemp2, itemp0, itemp1);
-        la_andi(itemp2, itemp2, required_flag);
-        la_beq(itemp2, zero_ir2_opnd, label_exit);
+    if (qemu_host_page_size == LATX_HOST_16K_PAGE_SIZE &&
+        (option_mem_test > 0 || option_minke_16k_page_check)) {
+        /*
+         * LATX_MT=1 checks a guest 4K page only when the surrounding host
+         * 16K page has mixed permissions. LATX_MT=2 always checks the cached
+         * guest-page flags. Both avoid the interval-tree walk while preserving
+         * guest read and write permissions.
+         */
+        if (option_mem_test != 2) {
+            li_d(itemp0, (ADDR)latx_16k_page_mixed);
+            la_bstrpick_d(itemp1, mem_addr, TARGET_ABI_BITS - 1,
+                          LATX_HOST_16K_PAGE_BITS);
+            la_ldx_bu(itemp2, itemp0, itemp1);
+            la_andi(itemp2, itemp2, required_flag);
+            la_beq(itemp2, zero_ir2_opnd, label_exit);
+        }
         li_d(itemp0, (ADDR)latx_4k_page_flags);
         la_bstrpick_d(itemp1, mem_addr, TARGET_ABI_BITS - 1,
                       TARGET_PAGE_BITS);

--- a/target/i386/latx/translator/translate.c
+++ b/target/i386/latx/translator/translate.c
@@ -4319,6 +4319,8 @@ static inline void helper_restore_reg(IR2_OPND opnd)
 
 void gen_test_page_flag(IR2_OPND mem_opnd, int mem_imm, uint32_t flag)
 {
+    uint32_t required_flag = flag & PAGE_WRITE ? PAGE_WRITE : PAGE_READ;
+
     if (!option_mem_test) {
         return;
     }
@@ -4331,6 +4333,7 @@ void gen_test_page_flag(IR2_OPND mem_opnd, int mem_imm, uint32_t flag)
     IR2_OPND label0 = ra_alloc_label();
     IR2_OPND label1 = ra_alloc_label();
     IR2_OPND label2 = ra_alloc_label();
+    IR2_OPND label_fault = ra_alloc_label();
     bool need_restore0 = false;
     bool need_restore1 = false;
     bool need_restore2 = false;
@@ -4355,37 +4358,58 @@ void gen_test_page_flag(IR2_OPND mem_opnd, int mem_imm, uint32_t flag)
 
     IR2_OPND mem_addr = ra_alloc_statics(S_UD1);
     la_addi_d(mem_addr, mem_opnd, mem_imm);
-    aot_load_host_addr(itemp0, (ADDR)&pageflags_root,
-        LOAD_PAGEFLAGS_ROOT, 0);
-    la_addi_d(itemp0, itemp0,
-            offsetof(IntervalTreeRoot, rb_root) + offsetof(RBRoot, rb_node));
-    la_ld_d(itemp0, itemp0, 0);
-    la_beq(itemp0, zero_ir2_opnd, label_exit);
+#if TARGET_ABI_BITS == 32
+    if (qemu_host_page_size == LATX_HOST_16K_PAGE_SIZE) {
+        li_d(itemp0, (ADDR)latx_16k_page_mixed);
+        la_bstrpick_d(itemp1, mem_addr, TARGET_ABI_BITS - 1,
+                      LATX_HOST_16K_PAGE_BITS);
+        la_ldx_bu(itemp2, itemp0, itemp1);
+        la_andi(itemp2, itemp2, required_flag);
+        la_beq(itemp2, zero_ir2_opnd, label_exit);
+        li_d(itemp0, (ADDR)latx_4k_page_flags);
+        la_bstrpick_d(itemp1, mem_addr, TARGET_ABI_BITS - 1,
+                      TARGET_PAGE_BITS);
+        la_ldx_bu(itemp2, itemp0, itemp1);
+        la_andi(itemp2, itemp2, required_flag);
+        la_bne(itemp2, zero_ir2_opnd, label_exit);
+        la_b(label_fault);
+    } else
+#endif
+    {
+        aot_load_host_addr(itemp0, (ADDR) (&pageflags_root),
+                           LOAD_PAGEFLAGS_ROOT, 0);
+        la_addi_d(itemp0, itemp0,
+                 offsetof(IntervalTreeRoot, rb_root) +
+                 offsetof(RBRoot, rb_node));
+        la_ld_d(itemp0, itemp0, 0);
+        la_beq(itemp0, zero_ir2_opnd, label_exit);
 
-    la_label(label0);
-    la_ld_d(itemp1, itemp0, 0x10);
-    la_beq(itemp1, zero_ir2_opnd, label1);
-    la_ld_d(itemp2, itemp1, 0x28);
-    la_bltu(itemp2, mem_addr, label1);
-    la_mov64(itemp0, itemp1);
-    la_b(label0);
+        la_label(label0);
+        la_ld_d(itemp1, itemp0, 0x10);
+        la_beq(itemp1, zero_ir2_opnd, label1);
+        la_ld_d(itemp2, itemp1, 0x28);
+        la_bltu(itemp2, mem_addr, label1);
+        la_mov64(itemp0, itemp1);
+        la_b(label0);
 
-    la_label(label1);
-    la_ld_d(itemp1, itemp0, 0x18);
-    la_bltu(mem_addr, itemp1, label_exit);
-    la_ld_d(itemp1, itemp0, 0x20);
-    la_bgeu(itemp1, mem_addr, label2);
-    la_ld_d(itemp0, itemp0, 0x8);
-    la_beq(itemp0, zero_ir2_opnd, label_exit);
-    la_ld_d(itemp1, itemp0, 0x28);
-    la_bgeu(itemp1, mem_addr, label0);
-    la_b(label_exit);
+        la_label(label1);
+        la_ld_d(itemp1, itemp0, 0x18);
+        la_bltu(mem_addr, itemp1, label_exit);
+        la_ld_d(itemp1, itemp0, 0x20);
+        la_bgeu(itemp1, mem_addr, label2);
+        la_ld_d(itemp0, itemp0, 0x8);
+        la_beq(itemp0, zero_ir2_opnd, label_exit);
+        la_ld_d(itemp1, itemp0, 0x28);
+        la_bgeu(itemp1, mem_addr, label0);
+        la_b(label_exit);
 
-    la_label(label2);
-    la_ld_w(itemp0, itemp0, 0x30);
-    la_andi(itemp0, itemp0, flag & 0xff);
-    la_bne(itemp0, zero_ir2_opnd, label_exit);
+        la_label(label2);
+        la_ld_w(itemp0, itemp0, 0x30);
+        la_andi(itemp0, itemp0, flag & 0xff);
+        la_bne(itemp0, zero_ir2_opnd, label_exit);
+    }
 
+    la_label(label_fault);
     IR2_OPND s_env = ra_alloc_statics(S_ENV);
 #ifdef TARGET_X86_64
     la_st_d(mem_addr, s_env, offsetof(CPUX86State, cr[2]));

--- a/target/i386/latx/translator/translate.c
+++ b/target/i386/latx/translator/translate.c
@@ -4322,7 +4322,23 @@ void gen_test_page_flag(IR2_OPND mem_opnd, int mem_imm, uint32_t flag)
     uint32_t required_flag = flag & PAGE_WRITE ? PAGE_WRITE : PAGE_READ;
 
     if (!option_mem_test) {
+#if TARGET_ABI_BITS == 32
+        TranslationBlock *current_tb;
+
+        if (!option_minke_16k_page_check) {
+            return;
+        }
+        current_tb = (TranslationBlock *)lsenv->tr_data->curr_tb;
+        if (!current_tb ||
+            !latx_minke_16k_write_check_pc(current_tb->pc)) {
+            return;
+        }
+        if (!(flag & PAGE_WRITE)) {
+            return;
+        }
+#else
         return;
+#endif
     }
     TranslationBlock *tb __attribute__((unused)) = NULL;
     if (option_aot) {

--- a/tests/integration/latx-16k-page-permission-i386.S
+++ b/tests/integration/latx-16k-page-permission-i386.S
@@ -64,7 +64,88 @@ _start:
     je xchg16_protected
     cmpb $'a', (%eax)
     je xchg_allowed
+    cmpb $'b', (%eax)
+    je cmpxchg_plain
+    cmpb $'l', (%eax)
+    je cmpxchg_locked
     jmp fail_args
+
+/* 0: crossing, 1: protected, 2: read-only unequal, 3/4: valid equal/unequal. */
+.macro cmpxchg_cases name, locked
+cmpxchg_\name:
+    movzbl 1(%eax), %esi
+    sub $'0', %esi
+    cmp $4, %esi
+    ja fail_args
+    cmp $2, %esi
+    jne 1f
+    /* Unequal comparisons still require write permission. */
+    mov $__NR_mprotect, %eax
+    lea 4096(%edi), %ebx
+    mov $4096, %ecx
+    mov $PROT_READ, %edx
+    int $0x80
+    test %eax, %eax
+    js fail_protect
+1:
+    lea 4092(%edi), %ebp
+    lea 4096(%edi), %eax
+    cmp $1, %esi
+    jne 2f
+    lea 4104(%edi), %ebp
+    mov %ebp, %eax
+2:
+    mov %eax, expected_address
+    cmp $3, %esi
+    jb 3f
+    lea 4080(%edi), %ebp
+3:
+    xor %eax, %eax
+    xor %edx, %edx
+    cmp $2, %esi
+    je 4f
+    cmp $4, %esi
+    jne 5f
+4:
+    inc %eax
+5:
+    mov $1, %ebx
+    mov $2, %ecx
+    movl $fault_cmpxchg_\name, expected_pc
+fault_cmpxchg_\name:
+.if \locked
+    lock cmpxchg8b (%ebp)
+.else
+    cmpxchg8b (%ebp)
+.endif
+    setz %cl
+    cmp $3, %esi
+    jb fail_access
+    cmp $4, %esi
+    je 6f
+    cmp $1, %cl
+    jne fail_access
+    cmpl $1, (%ebp)
+    jne fail_access
+    cmpl $2, 4(%ebp)
+    jne fail_access
+    jmp 7f
+6:
+    test %cl, %cl
+    jnz fail_access
+    cmpl $0, (%ebp)
+    jne fail_access
+    cmpl $0, 4(%ebp)
+    jne fail_access
+7:
+    or %edx, %eax
+    jnz fail_access
+    xor %ebx, %ebx
+    jmp exit
+.endm
+
+cmpxchg_cases plain, 0
+cmpxchg_cases locked, 1
 
 xchg32_protected:
     lea 4096(%edi), %eax

--- a/tests/integration/latx-16k-page-permission-i386.S
+++ b/tests/integration/latx-16k-page-permission-i386.S
@@ -58,7 +58,48 @@ _start:
     je valid_access
     cmpb $'p', (%eax)
     je read_after_push
+    cmpb $'x', (%eax)
+    je xchg32_protected
+    cmpb $'h', (%eax)
+    je xchg16_protected
+    cmpb $'a', (%eax)
+    je xchg_allowed
     jmp fail_args
+
+xchg32_protected:
+    lea 4096(%edi), %eax
+    mov %eax, expected_address
+    movl $fault_xchg32, expected_pc
+    mov $0x12345678, %eax
+fault_xchg32:
+    xchgl %eax, 4094(%edi)
+    jmp fail_access
+
+xchg16_protected:
+    lea 4096(%edi), %eax
+    mov %eax, expected_address
+    movl $fault_xchg16, expected_pc
+    mov $0x1234, %eax
+fault_xchg16:
+    xchgw %ax, 4095(%edi)
+    jmp fail_access
+
+xchg_allowed:
+    movl $123, 4092(%edi)
+    mov $456, %eax
+    xchgl %eax, 4092(%edi)
+    cmp $123, %eax
+    jne fail_access
+    cmpl $456, 4092(%edi)
+    jne fail_access
+    mov $789, %eax
+    xchgw %ax, 4092(%edi)
+    cmp $456, %ax
+    jne fail_access
+    cmpw $789, 4092(%edi)
+    jne fail_access
+    xor %ebx, %ebx
+    jmp exit
 
 read_protected:
     lea 4096(%edi), %eax

--- a/tests/integration/latx-16k-page-permission-i386.S
+++ b/tests/integration/latx-16k-page-permission-i386.S
@@ -1,0 +1,173 @@
+.equ __NR_exit, 1
+.equ __NR_mprotect, 125
+.equ __NR_rt_sigaction, 174
+.equ __NR_mmap2, 192
+
+.equ PROT_NONE, 0
+.equ PROT_READ, 1
+.equ PROT_WRITE, 2
+.equ MAP_PRIVATE, 2
+.equ MAP_ANONYMOUS, 0x20
+
+.section .text
+.global _start
+.type _start, @function
+_start:
+    mov %esp, expected_sp
+    mov $__NR_rt_sigaction, %eax
+    mov $11, %ebx
+    mov $segv_action, %ecx
+    xor %edx, %edx
+    mov $8, %esi
+    int $0x80
+    test %eax, %eax
+    jnz fail_signal
+
+    mov $__NR_mmap2, %eax
+    xor %ebx, %ebx
+    mov $16384, %ecx
+    mov $(PROT_READ | PROT_WRITE), %edx
+    mov $(MAP_PRIVATE | MAP_ANONYMOUS), %esi
+    mov $-1, %edi
+    xor %ebp, %ebp
+    int $0x80
+    cmp $-4095, %eax
+    jae fail_map
+    mov %eax, %edi
+
+    mov $__NR_mprotect, %eax
+    lea 4096(%edi), %ebx
+    mov $4096, %ecx
+    mov $PROT_NONE, %edx
+    int $0x80
+    test %eax, %eax
+    js fail_protect
+
+    cmpl $2, (%esp)
+    jne fail_args
+    mov 8(%esp), %eax
+    cmpb $'r', (%eax)
+    je read_protected
+    cmpb $'w', (%eax)
+    je write_across_boundary
+    cmpb $'s', (%eax)
+    je write_protected
+    cmpb $'c', (%eax)
+    je read_across_boundary
+    cmpb $'v', (%eax)
+    je valid_access
+    cmpb $'p', (%eax)
+    je read_after_push
+    jmp fail_args
+
+read_protected:
+    lea 4096(%edi), %eax
+    mov %eax, expected_address
+    movl $fault_read, expected_pc
+fault_read:
+    movl 4096(%edi), %eax
+    jmp fail_access
+
+write_across_boundary:
+    lea 4096(%edi), %eax
+    mov %eax, expected_address
+    movl $fault_cross_write, expected_pc
+    pxor %xmm0, %xmm0
+fault_cross_write:
+    movdqu %xmm0, 4092(%edi)
+    jmp fail_access
+
+write_protected:
+    lea 4100(%edi), %eax
+    mov %eax, expected_address
+    movl $fault_write, expected_pc
+fault_write:
+    movl $0, 4100(%edi)
+    jmp fail_access
+
+read_across_boundary:
+    lea 4096(%edi), %eax
+    mov %eax, expected_address
+    movl $fault_cross_read, expected_pc
+fault_cross_read:
+    movl 4094(%edi), %eax
+    jmp fail_access
+
+valid_access:
+    movl $123, 4092(%edi)
+    cmpl $123, 4092(%edi)
+    jne fail_access
+    xor %ebx, %ebx
+    jmp exit
+
+read_after_push:
+    lea -8(%esp), %eax
+    mov %eax, expected_sp
+    lea 4096(%edi), %eax
+    mov %eax, expected_address
+    movl $fault_after_push, expected_pc
+    push %eax
+    push %edx
+fault_after_push:
+    movl 4096(%edi), %eax
+    jmp fail_access
+
+/* i386 SA_SIGINFO: handler(signo, siginfo, ucontext). */
+segv_handler:
+    cmpl $11, 4(%esp)
+    jne fail_signal
+    mov 8(%esp), %eax
+    cmpl $2, 8(%eax) /* SEGV_ACCERR */
+    jne fail_signal
+    mov 12(%eax), %edx /* si_addr */
+    cmp expected_address, %edx
+    jne fail_address
+    mov 12(%esp), %eax
+    mov 76(%eax), %edx /* uc_mcontext.gregs[REG_EIP] */
+    cmp expected_pc, %edx
+    jne fail_pc
+    mov 48(%eax), %edx /* uc_mcontext.gregs[REG_ESP] */
+    cmp expected_sp, %edx
+    jne fail_sp
+    xor %ebx, %ebx
+    jmp exit
+
+fail_access:
+    mov $12, %ebx
+    jmp exit
+fail_map:
+    mov $10, %ebx
+    jmp exit
+fail_protect:
+    mov $11, %ebx
+    jmp exit
+fail_args:
+    mov $13, %ebx
+    jmp exit
+fail_signal:
+    mov $14, %ebx
+    jmp exit
+fail_address:
+    mov $15, %ebx
+    jmp exit
+fail_pc:
+    mov $16, %ebx
+    jmp exit
+fail_sp:
+    mov $17, %ebx
+exit:
+    mov $__NR_exit, %eax
+    int $0x80
+
+.section .data
+.align 4
+segv_action:
+    .long segv_handler, 4, 0 /* SA_SIGINFO; handler exits directly. */
+    .quad 0
+expected_address:
+    .long 0
+expected_pc:
+    .long 0
+expected_sp:
+    .long 0
+.section .note.GNU-stack,"",@progbits

--- a/tests/integration/latx-16k-page-permission-i386.S
+++ b/tests/integration/latx-16k-page-permission-i386.S
@@ -98,6 +98,35 @@ xchg_allowed:
     jne fail_access
     cmpw $789, 4092(%edi)
     jne fail_access
+    /* Exercise the unaligned LL/SC path and its wider-atomic fallback. */
+    movl $123, 4089(%edi)
+    mov $456, %eax
+    xchgl %eax, 4089(%edi)
+    cmp $123, %eax
+    jne fail_access
+    cmpl $456, 4089(%edi)
+    jne fail_access
+    movw $123, 4091(%edi)
+    mov $456, %eax
+    xchgw %ax, 4091(%edi)
+    cmp $123, %ax
+    jne fail_access
+    cmpw $456, 4091(%edi)
+    jne fail_access
+    movl $123, 4086(%edi)
+    mov $456, %eax
+    xchgl %eax, 4086(%edi)
+    cmp $123, %eax
+    jne fail_access
+    cmpl $456, 4086(%edi)
+    jne fail_access
+    movw $123, 4087(%edi)
+    mov $456, %eax
+    xchgw %ax, 4087(%edi)
+    cmp $123, %ax
+    jne fail_access
+    cmpw $456, 4087(%edi)
+    jne fail_access
     xor %ebx, %ebx
     jmp exit
 

--- a/tests/integration/registrations/process/meson.build
+++ b/tests/integration/registrations/process/meson.build
@@ -95,6 +95,14 @@ if 'i386-linux-user' in target_dirs
     ],
   }]
   latx_integration_tests += [{
+    'name': 'test-latx-16k-page-permission-i386',
+    'runner': find_program('../../test-latx-16k-page-permission-i386.sh'),
+    'args': [
+      emulators['latx-i386'],
+      files('../../latx-16k-page-permission-i386.S'),
+    ],
+  }]
+  latx_integration_tests += [{
     'name': 'test-fd-transform-race-i386',
     'runner': find_program('../../test-fd-transform-race-i386.sh'),
     'args': [

--- a/tests/integration/test-latx-16k-page-permission-i386.sh
+++ b/tests/integration/test-latx-16k-page-permission-i386.sh
@@ -12,6 +12,11 @@ if [ "$(getconf PAGESIZE)" != 16384 ]; then
 fi
 
 fixture=${LATX_16K_PERMISSION_FIXTURE:-}
+fallback=${LATX_16K_XCHG_FALLBACK:-0}
+if [ "$fallback" = 1 ] && ! command -v gdb >/dev/null 2>&1; then
+    echo "SKIP: gdb is required to select the XCHG fallback"
+    exit 77
+fi
 if [ -n "$fixture" ]; then
     if [ ! -f "$fixture" ] || [ ! -x "$fixture" ]; then
         echo "FAIL: prebuilt i386 fixture is not executable: $fixture" >&2
@@ -42,8 +47,20 @@ run_fault_case()
     case_name=$2
     set +e
     # Disable the single-thread XCHG load/store shortcut to test atomics.
-    LATX_AOT=0 LATX_KZT=0 LATX_CLOSE_PARALLEL=1 LATX_MT="$mode" \
-        timeout -s KILL 10 "$emulator" "$fixture" "$case_name"
+    if [ "$fallback" = 1 ]; then
+        # Select the fallback after hardware-dependent options are initialized.
+        LATX_AOT=0 LATX_KZT=0 LATX_CLOSE_PARALLEL=1 LATX_MT="$mode" \
+            timeout -s KILL 30 gdb -q -batch --return-child-result \
+            -ex 'handle SIGBUS nostop noprint pass' \
+            -ex 'handle SIGSEGV nostop noprint pass' \
+            -ex 'break translate_xchg' -ex run \
+            -ex 'set {int}&option_fast_atomic = 0' \
+            -ex 'disable breakpoints' -ex continue \
+            --args "$emulator" "$fixture" "$case_name"
+    else
+        LATX_AOT=0 LATX_KZT=0 LATX_CLOSE_PARALLEL=1 LATX_MT="$mode" \
+            timeout -s KILL 10 "$emulator" "$fixture" "$case_name"
+    fi
     ret=$?
     set -e
 
@@ -62,6 +79,12 @@ run_fault_case()
 }
 
 for mode in 1 2; do
+    if [ "$fallback" = 1 ]; then
+        run_fault_case "$mode" x
+        run_fault_case "$mode" h
+        run_fault_case "$mode" a
+        continue
+    fi
     run_fault_case "$mode" r
     run_fault_case "$mode" w
     run_fault_case "$mode" s

--- a/tests/integration/test-latx-16k-page-permission-i386.sh
+++ b/tests/integration/test-latx-16k-page-permission-i386.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+set -eu
+
+emulator=$1
+source_file=$2
+workdir=$(mktemp -d)
+trap 'rm -rf "$workdir"' EXIT HUP INT TERM
+
+if [ "$(getconf PAGESIZE)" != 16384 ]; then
+    echo "SKIP: the guest permission test requires a 16K host page"
+    exit 77
+fi
+
+fixture=${LATX_16K_PERMISSION_FIXTURE:-}
+if [ -n "$fixture" ]; then
+    if [ ! -f "$fixture" ] || [ ! -x "$fixture" ]; then
+        echo "FAIL: prebuilt i386 fixture is not executable: $fixture" >&2
+        exit 1
+    fi
+else
+    if command -v clang-19 >/dev/null 2>&1; then
+        clang=clang-19
+    elif command -v clang >/dev/null 2>&1; then
+        clang=clang
+    else
+        echo "SKIP: clang is required; alternatively set LATX_16K_PERMISSION_FIXTURE"
+        exit 77
+    fi
+    if ! command -v ld.lld >/dev/null 2>&1; then
+        echo "SKIP: ld.lld is required; alternatively set LATX_16K_PERMISSION_FIXTURE"
+        exit 77
+    fi
+    fixture=$workdir/latx-16k-page-permission
+    # Toolchain availability was checked above. Compilation errors must fail.
+    "$clang" --target=i386-linux-gnu -fuse-ld=lld -nostdlib -static -no-pie \
+        -Wl,--build-id=none "$source_file" -o "$fixture"
+fi
+
+run_fault_case()
+{
+    mode=$1
+    case_name=$2
+    set +e
+    LATX_AOT=0 LATX_KZT=0 LATX_MT="$mode" timeout -s KILL 10 \
+        "$emulator" "$fixture" "$case_name"
+    ret=$?
+    set -e
+
+    case $ret in
+    0) echo "PASS: LATX_MT=$mode $case_name signal context or valid access" ;;
+    10) echo "FAIL: guest mmap failed" >&2; exit 1 ;;
+    11) echo "FAIL: guest mprotect failed" >&2; exit 1 ;;
+    12) echo "FAIL: $case_name access bypassed guest permissions" >&2; exit 1 ;;
+    14) echo "FAIL: wrong signal or signal setup failed" >&2; exit 1 ;;
+    15) echo "FAIL: incorrect fault address" >&2; exit 1 ;;
+    16) echo "FAIL: incorrect fault instruction address" >&2; exit 1 ;;
+    17) echo "FAIL: incorrect fault stack pointer" >&2; exit 1 ;;
+    124|137) echo "FAIL: $case_name access timed out" >&2; exit 1 ;;
+    *) echo "FAIL: unexpected $case_name status $ret" >&2; exit 1 ;;
+    esac
+}
+
+for mode in 1 2; do
+    run_fault_case "$mode" r
+    run_fault_case "$mode" w
+    run_fault_case "$mode" s
+    run_fault_case "$mode" c
+    run_fault_case "$mode" v
+    run_fault_case "$mode" p
+done

--- a/tests/integration/test-latx-16k-page-permission-i386.sh
+++ b/tests/integration/test-latx-16k-page-permission-i386.sh
@@ -94,4 +94,7 @@ for mode in 1 2; do
     run_fault_case "$mode" x
     run_fault_case "$mode" h
     run_fault_case "$mode" a
+    for case_name in b0 b1 b2 b3 b4 l0 l1 l2 l3 l4; do
+        run_fault_case "$mode" "$case_name"
+    done
 done

--- a/tests/integration/test-latx-16k-page-permission-i386.sh
+++ b/tests/integration/test-latx-16k-page-permission-i386.sh
@@ -41,8 +41,9 @@ run_fault_case()
     mode=$1
     case_name=$2
     set +e
-    LATX_AOT=0 LATX_KZT=0 LATX_MT="$mode" timeout -s KILL 10 \
-        "$emulator" "$fixture" "$case_name"
+    # Disable the single-thread XCHG load/store shortcut to test atomics.
+    LATX_AOT=0 LATX_KZT=0 LATX_CLOSE_PARALLEL=1 LATX_MT="$mode" \
+        timeout -s KILL 10 "$emulator" "$fixture" "$case_name"
     ret=$?
     set -e
 
@@ -67,4 +68,7 @@ for mode in 1 2; do
     run_fault_case "$mode" c
     run_fault_case "$mode" v
     run_fault_case "$mode" p
+    run_fault_case "$mode" x
+    run_fault_case "$mode" h
+    run_fault_case "$mode" a
 done


### PR DESCRIPTION
## Summary / 变更说明

Preserve the cached permission-check fast path needed by
`Minke.MI.Organ.exe` on 16K LoongArch hosts while enforcing guest 4K
permissions for instrumented accesses.

A readable/writable guest page can share a host page with a protected
guest page. The merged host mapping alone cannot enforce that boundary.
Global checks now cover reads as well as writes, and the 32-bit cached
path checks both the first and final guest page of each instrumented
access. A crossing fault reports the first inaccessible byte rather than
the access endpoint.

- `LATX_MT=1`: consult exact guest-page flags when the host page has mixed
  permissions for the requested access type.
- `LATX_MT=2`: always consult cached guest-page flags on the 32-bit 16K path.
- `LATX_MT=0`: leave global instrumentation disabled. The existing explicit
  `LATX_MINKE_16K_PAGE_CHECK` option retains selective Minke write checks.
- Both enabled policies retain cache lookups instead of interval-tree walks
  on the 32-bit 16K path.
- Correct alignment accounting in push/pop fault-state recovery, exposed
  by the permission instrumentation's generated code.
- Add an i386 regression that checks signal code, fault address, instruction
  pointer and stack pointer. The runner accepts a prebuilt fixture through
  `LATX_16K_PERMISSION_FIXTURE`; actual compilation failures are errors.

The series separates the original fast-path/application changes, read
permission restoration, policy selection, crossing checks, fault recovery,
fault address correction and test-runner correction into focused commits.

## Validation / 验证

Final patched `latx-i386` built on host 58 (16K LoongArch pages).
Binary SHA-256:
`63b71760c2a771e56a94199832a213f5f09c6df8de4f29a90fc6bfac01b96a06`.

- Built the static i386 fixture on the x86 host with GCC; all six cases
  passed natively.
- On 58, all six cases passed under each of `LATX_MT=1` and `LATX_MT=2`:
  protected read, crossing vector write, protected write at a nonzero page
  offset, crossing read, valid access, and a fault after pushes.
- Verified the stronger regression detects the previous incorrect crossing
  fault address. Earlier control runs with `LATX_MT=0` allowed the protected
  read and crossing write to proceed.
- Meson targeted integration test passed using the prebuilt fixture:
  1 passed, 0 failed, 0 skipped.
- Existing `mprotect-4k-test` and
  `lock-cmpxchg8b-on-page-no-write-unalign` passed in both enabled modes.
- Injected fixture compilation failure propagated status 42; an invalid
  prebuilt fixture failed with status 1.
- Commit-message, author/DCO and whitespace checks passed.

Remaining validation: the final revision has not rerun the medical
application GUI/startup timing comparison or the full build matrix. A broad
test rebuild on 58 encountered pre-existing unused-variable/function errors
in `tests/unit/test-x11-async-handler.c` under `-Werror`; the translator was
built separately and the targeted integration test used `--no-rebuild`.
Earlier login-window and full-matrix results apply to the original PR
revision, not to this final revision.

## Checklist / 检查项

- [x] I have read `CONTRIBUTING.md`.
- [x] Every commit contains a DCO sign-off matching its author.
- [x] Relevant build/test results and remaining validation are included.
