### PR TITLE
LATX, fix: Apply x87 rounding mode to host FCSR

### DIFF
--- a/target/i386/latx/translator/tr-softfpu.c
+++ b/target/i386/latx/translator/tr-softfpu.c
@@ -350,6 +350,7 @@ static void la_update_fp_status(IR2_OPND cw_opnd)
     /* Rounding Control (11, 10)*/
     la_ori(itemp, cw_opnd, 0);
     update_fcsr_rm(itemp, tmp_fcsr);
+    la_movgr2fcsr(fcsr_ir2_opnd, tmp_fcsr);
     la_bstrpick_d(itemp, cw_opnd, 11, 10);
     la_st_b(itemp, env_ir2_opnd, round_mode_offset);
 


### PR DESCRIPTION
## Motivation

The guest x87 control word selects one of four rounding modes, but the optimized conversion path could execute with a different LoongArch host FCSR rounding mode. Integer and floating-point conversions could therefore round differently from x87 semantics.

## Changes

- Apply the x87 rounding mode to the host FCSR before the affected optimized operations.

## Validation

- `ninja -C build32 latx-i386`
- `ninja -C build64 latx-x86_64`
- `LATX_SOFTFPU=2 LATX_SOFTFPU_FAST=0xc00000 build32/latx-i386 x87-conversion-regression`
- All four rounding modes completed successfully.

## Scope

This PR contains one rounding-correctness fix.
