### PR TITLE
LATX, fix: Ignore segment bases in LEA

### DIFF
--- a/target/i386/latx/translator/tr-mov.c
+++ b/target/i386/latx/translator/tr-mov.c
@@ -1390,11 +1390,14 @@ bool translate_lea(IR1_INST *pir1)
 {
     IR1_OPND *op0 = ir1_get_opnd(pir1, 0);
     IR1_OPND *op1 = ir1_get_opnd(pir1, 1);
+    IR1_OPND addr = *op1;
     int op0_size = ir1_opnd_size(op0);
     int op0_gpr_num = ir1_opnd_base_reg_num(op0);
     IR2_OPND dest_op = ra_alloc_gpr(op0_gpr_num);
 
-    convert_mem_to_specific_gpr(op1, dest_op, op0_size);
+    /* LEA computes only the effective offset; segment bases are ignored. */
+    addr.mem.segment = dt_X86_REG_INVALID;
+    convert_mem_to_specific_gpr(&addr, dest_op, op0_size);
 
     return true;
 }


### PR DESCRIPTION
LEA computes an effective offset and must not apply FS or GS segment bases. The shared memory-address conversion path added the segment base and corrupted IDTest's embedded resource copy.
Copy the operand and clear its segment before lowering the address.

## Summary / 变更说明

<!-- What does this change do and why? / 这项变更做了什么，为什么需要？ -->

## Validation / 验证

<!-- List the builds and tests you ran, or explain why they are not applicable.
请列出执行过的构建和测试；如不适用，请说明原因。 -->

## Checklist / 检查项

- [ ] I have read `CONTRIBUTING.md`. / 我已阅读 `CONTRIBUTING.md`。
- [ ] Every commit contains a DCO sign-off (`git commit -s`). /
      每个提交都包含 DCO 签署（`git commit -s`）。
- [ ] I have included relevant build or test results, or explained why they
      are not applicable. /
      我已提供相关构建或测试结果，或说明了不适用的原因。
