### PR TITLE
LATX, AOT: statically reduce L1I set conflicts

### DIFF
--- a/linux-user/main.c
+++ b/linux-user/main.c
@@ -839,6 +839,18 @@ static void handle_arg_latx_aot(const char *arg)
     }
 }
 
+static void handle_arg_latx_aot_static_layout(const char *arg)
+{
+    long value;
+
+    if (qemu_strtol(arg, NULL, 0, &value) < 0 ||
+        (value != 0 && value != 1)) {
+        error_report("LATX_AOT_STATIC_LAYOUT must be 0 or 1");
+        exit(EXIT_FAILURE);
+    }
+    option_aot_static_layout = value;
+}
+
 static void handle_arg_latx_aot_pe_profile(const char *arg)
 {
     option_aot_pe_profile = strtol(arg, NULL, 0);
@@ -964,6 +976,8 @@ static const struct qemu_argument arg_table[] = {
 #ifdef CONFIG_LATX_AOT
     {"latx-aot",    "LATX_AOT",     true,  handle_arg_latx_aot,
     "",           "enable aot"},
+    {"latx-aot-static-layout", "LATX_AOT_STATIC_LAYOUT", true,
+    handle_arg_latx_aot_static_layout, "", "reduce static AOT L1I conflicts"},
     {"latx-aot-pe-profile", "LATX_AOT_PE_PROFILE", true,
     handle_arg_latx_aot_pe_profile, "", "split libcef PE AOT by process role"},
     {"latx-aot-file-size", "LAT_AOT_FILE_SIZE", false,

--- a/meson.build
+++ b/meson.build
@@ -701,6 +701,7 @@ foreach target : target_dirs
       files(
         'target/i386/latx/sbt/tests/aot-cache-reader-test.c',
         'target/i386/latx/sbt/aot_reader.c',
+        'target/i386/latx/sbt/aot_static_layout.c',
         'target/i386/latx/sbt/aot_lib.c',
         'target/i386/latx/sbt/file_ctx.c'
       ) + genh + tcg_trace_genh + [syscall_nr_generated],
@@ -715,6 +716,25 @@ foreach target : target_dirs
     test(
       'latx-aot-cache-reader',
       aot_cache_reader_test,
+      suite: 'lat-pr-fast',
+    )
+
+    aot_static_layout_test = executable(
+      'test-latx-aot-static-layout',
+      files(
+        'target/i386/latx/sbt/tests/aot-static-layout-test.c',
+        'target/i386/latx/sbt/aot_static_layout.c'
+      ) +
+      genh + tcg_trace_genh + [syscall_nr_generated],
+      build_by_default: false,
+      c_args: smc_reload_test_c_args,
+      dependencies: [glib],
+      include_directories: target_inc,
+      link_args: smc_reload_test_link_args
+    )
+    test(
+      'latx-aot-static-layout',
+      aot_static_layout_test,
       suite: 'lat-pr-fast',
     )
 

--- a/target/i386/latx/include/aot.h
+++ b/target/i386/latx/include/aot.h
@@ -57,7 +57,14 @@ typedef struct aot_header {
 #define CACHE_AOT_FILE      4
 #define HASH_AOT_FILE       8
     uint8_t aot_file_type;
+    uint8_t layout_line_log2;
+    uint8_t layout_set_log2;
+    uint8_t layout_ways;
+#define AOT_STATIC_LAYOUT_MAGIC 0x534c3149
+    uint32_t layout_magic;
 } aot_header;
+
+_Static_assert(sizeof(aot_header) == 56, "aot_header file format");
 
 typedef struct aot_file_info {
     void *p;
@@ -143,7 +150,13 @@ typedef struct aot_tb {
     uint16_t first_jmp_align;
     uint8_t last_ir1_type;
     uint8_t eflag_use;
-    int8_t canlink[2];
+    union {
+        int8_t canlink[2];
+        struct {
+            uint8_t layout_padding_lines;
+            uint8_t layout_reserved;
+        };
+    };
 } aot_tb;
 
 typedef enum aot_rel_kind {

--- a/target/i386/latx/include/aot.h
+++ b/target/i386/latx/include/aot.h
@@ -96,6 +96,7 @@ typedef struct aot_segment {
     uint32_t segment_tbs_num;
     /* Offset of page_table in AOT. */
     uint32_t page_table_offset;
+    uint32_t layout_padding_budget[2];
     uint8_t aot_file_type;
 } aot_segment;
 
@@ -150,13 +151,12 @@ typedef struct aot_tb {
     uint16_t first_jmp_align;
     uint8_t last_ir1_type;
     uint8_t eflag_use;
-    union {
-        int8_t canlink[2];
-        struct {
-            uint8_t layout_padding_lines;
-            uint8_t layout_reserved;
-        };
-    };
+    int8_t canlink[2];
+#define AOT_LAYOUT_COMPONENT_NONE UINT16_MAX
+    uint16_t layout_component;
+    uint8_t layout_padding_lines;
+#define AOT_LAYOUT_MOVABLE 0x1
+    uint8_t layout_flags;
 } aot_tb;
 
 typedef enum aot_rel_kind {

--- a/target/i386/latx/include/aot_static_layout.h
+++ b/target/i386/latx/include/aot_static_layout.h
@@ -1,0 +1,85 @@
+/*
+ * SPDX-FileCopyrightText: 2021-2026 LAT Project Authors
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#ifndef LATX_AOT_STATIC_LAYOUT_H
+#define LATX_AOT_STATIC_LAYOUT_H
+
+#include "qemu-def.h"
+
+#define AOT_STATIC_LAYOUT_NO_COMPONENT UINT32_MAX
+#define AOT_STATIC_LAYOUT_PADDING_PERCENT 1
+
+typedef enum AOTStaticLayoutEdgeKind {
+    AOT_LAYOUT_EDGE_FLOW,
+    AOT_LAYOUT_EDGE_CALL,
+} AOTStaticLayoutEdgeKind;
+
+typedef struct AOTStaticLayoutNode {
+    target_ulong guest_pc;
+    uint32_t code_size;
+    uint32_t component;
+    bool can_pad;
+} AOTStaticLayoutNode;
+
+typedef struct AOTStaticLayoutEdge {
+    uint32_t from;
+    uint32_t to;
+    AOTStaticLayoutEdgeKind kind;
+} AOTStaticLayoutEdge;
+
+typedef struct AOTStaticLayout AOTStaticLayout;
+struct aot_segment;
+struct aot_tb;
+struct aot_header;
+
+uint32_t aot_static_layout_find_components(AOTStaticLayoutNode *nodes,
+                                           uint32_t node_count,
+                                           const AOTStaticLayoutEdge *edges,
+                                           uint32_t edge_count);
+
+AOTStaticLayout *aot_static_layout_new(const AOTStaticLayoutNode *nodes,
+                                       uint32_t node_count,
+                                       uint32_t component_count,
+                                       uint32_t line_size,
+                                       uint32_t set_count,
+                                       uint32_t ways);
+
+uintptr_t aot_static_layout_place(AOTStaticLayout *layout,
+                                  uint32_t node_index,
+                                  uintptr_t host_code,
+                                  size_t available_padding);
+
+bool aot_static_layout_get_l1i_geometry(uint32_t *line_size,
+                                        uint32_t *set_count,
+                                        uint32_t *ways);
+
+bool aot_static_layout_store(const struct aot_segment *segment,
+                             struct aot_tb *tbs, uint32_t cflags,
+                             target_ulong segment_base,
+                             uint32_t line_size, uint32_t set_count,
+                             uint32_t ways);
+
+bool aot_static_layout_store_header(struct aot_header *header,
+                                    struct aot_segment *segments);
+
+bool aot_static_layout_header_matches(const struct aot_header *header,
+                                      uint32_t line_size,
+                                      uint32_t set_count, uint32_t ways);
+
+uintptr_t aot_static_layout_stored_padding(const struct aot_header *header,
+                                           const struct aot_tb *tb,
+                                           uint32_t line_size,
+                                           uint32_t set_count, uint32_t ways,
+                                           size_t available_padding);
+
+uint64_t aot_static_layout_cost(const AOTStaticLayout *layout,
+                                uint32_t component);
+
+size_t aot_static_layout_padding_used(const AOTStaticLayout *layout);
+
+void aot_static_layout_free(AOTStaticLayout *layout);
+
+#endif

--- a/target/i386/latx/include/aot_static_layout.h
+++ b/target/i386/latx/include/aot_static_layout.h
@@ -31,6 +31,7 @@ typedef struct AOTStaticLayoutEdge {
 } AOTStaticLayoutEdge;
 
 typedef struct AOTStaticLayout AOTStaticLayout;
+typedef struct AOTStaticLazyLayout AOTStaticLazyLayout;
 struct aot_segment;
 struct aot_tb;
 struct aot_header;
@@ -56,7 +57,7 @@ bool aot_static_layout_get_l1i_geometry(uint32_t *line_size,
                                         uint32_t *set_count,
                                         uint32_t *ways);
 
-bool aot_static_layout_store(const struct aot_segment *segment,
+bool aot_static_layout_store(struct aot_segment *segment,
                              struct aot_tb *tbs, uint32_t cflags,
                              target_ulong segment_base,
                              uint32_t line_size, uint32_t set_count,
@@ -81,5 +82,19 @@ uint64_t aot_static_layout_cost(const AOTStaticLayout *layout,
 size_t aot_static_layout_padding_used(const AOTStaticLayout *layout);
 
 void aot_static_layout_free(AOTStaticLayout *layout);
+
+AOTStaticLazyLayout *aot_static_lazy_layout_new(uint32_t line_size,
+                                                uint32_t set_count,
+                                                uint32_t ways,
+                                                size_t padding_budget);
+
+uintptr_t aot_static_lazy_layout_place(AOTStaticLazyLayout *layout,
+                                       uint16_t component, bool movable,
+                                       target_ulong guest_pc,
+                                       uintptr_t host_code,
+                                       uint32_t code_size,
+                                       size_t available_padding);
+
+void aot_static_lazy_layout_free(AOTStaticLazyLayout *layout);
 
 #endif

--- a/target/i386/latx/include/latx-options.h
+++ b/target/i386/latx/include/latx-options.h
@@ -68,6 +68,7 @@ extern int option_tunnel_lib;
 extern uint64_t option_end_trace_addr;
 extern uint64_t option_begin_trace_addr;
 extern int option_aot;
+extern int option_aot_static_layout;
 extern int option_smc_reload;
 extern int option_aot_wine;
 extern int option_load_aot;
@@ -168,6 +169,7 @@ extern unsigned long long counter_mips_tr;
 #if defined(CONFIG_LATX) && defined(CONFIG_LATX_AOT)
 #define ENVSUP_AOT \
     ENVFUN(LATX_AOT, handle_arg_latx_aot) \
+    ENVFUN(LATX_AOT_STATIC_LAYOUT, handle_arg_latx_aot_static_layout) \
     ENVFUN(LAT_AOT_FILE_SIZE, handle_arg_lat_aot_file_size) \
     ENVFUN(LAT_AOT_LEFT_FILE_SIZE, handle_arg_lat_aot_left_file_size) \
     ENVFUN(LATX_AOT_WINE_PEFILES_CACHE, handle_arg_latx_aot_wine_pefiles_cache)

--- a/target/i386/latx/latx-options.c
+++ b/target/i386/latx/latx-options.c
@@ -75,6 +75,7 @@ int option_trace_ir1;
 int option_latx_disassemble_trace_cmp;
 int option_debug_lative;
 int option_aot;
+int option_aot_static_layout;
 int option_load_aot;
 int option_aot_wine;
 int option_smc_reload;
@@ -249,6 +250,7 @@ void options_init(void)
 
 #ifdef CONFIG_LATX_AOT
     option_aot = 1;
+    option_aot_static_layout = 0;
     option_load_aot = 1;
     option_aot_wine = 0;
     option_debug_aot = 0;

--- a/target/i386/latx/sbt/aot.c
+++ b/target/i386/latx/sbt/aot.c
@@ -25,6 +25,7 @@
 #include "aot_reader.h"
 #include "aot_merge.h"
 #include "aot_recover_tb.h"
+#include "aot_static_layout.h"
 #include "aot_smc.h"
 #include "aot_page.h"
 #include "../translator/tr-vpaes.h"
@@ -672,6 +673,11 @@ static long get_fileSize(FILE* file)
 
 static bool generated_aot_file;
 
+static bool fill_static_layout(aot_header *header, aot_segment *segments)
+{
+    return aot_static_layout_store_header(header, segments);
+}
+
 static int write_aot_file(int *lockfd, aot_header *p_header, uint32_t *p_insn, 
         uint32_t *insn_buffer, unsigned long total_code_cache_size,
         uint8_t *p_ir1, uint8_t *ir1_buffer, int ir1_size)
@@ -766,6 +772,10 @@ int do_generate_aot(int first_seg_in_lib, int end_seg_in_lib)
 
     p_header->aot_file_type =
         seg_info_vector[first_seg_in_lib]->aot_file_type;
+    p_header->layout_line_log2 = 0;
+    p_header->layout_set_log2 = 0;
+    p_header->layout_ways = 0;
+    p_header->layout_magic = 0;
 
     if (p_header->aot_file_type & (ELF_AOT_FILE | PE_AOT_FILE)) {
         struct stat statbuf;
@@ -802,6 +812,9 @@ int do_generate_aot(int first_seg_in_lib, int end_seg_in_lib)
     if(total_code_cache_size == 0) {
         free(p_header);
         return false;
+    }
+    if (option_aot_static_layout) {
+        fill_static_layout(p_header, p_segments);
     }
     /* fill relocation table */
     fill_rel_table(p_header);

--- a/target/i386/latx/sbt/aot.c
+++ b/target/i386/latx/sbt/aot.c
@@ -313,6 +313,8 @@ static void fill_seg_table(int seg_info_begin, int seg_info_end,
         p_segments[seg_id_in_lib].lib_name_offset =
             (uintptr_t)last_name - (uintptr_t)p_header;
         p_segments[seg_id_in_lib].segment_tbs_num = 0;
+        p_segments[seg_id_in_lib].layout_padding_budget[0] = 0;
+        p_segments[seg_id_in_lib].layout_padding_budget[1] = 0;
         p_segments[seg_id_in_lib].page_table_offset = 
             (uintptr_t)(aot_page_table + page_index) - (uintptr_t)p_header;
         page_index += (curr_seg_info->seg_end - curr_seg_info->seg_begin

--- a/target/i386/latx/sbt/aot_merge.c
+++ b/target/i386/latx/sbt/aot_merge.c
@@ -495,6 +495,8 @@ static bool merge_aot_generate(void)
         p_segments[i].lib_name_offset =
             (uintptr_t)last_name - (uintptr_t)p_header;
         p_segments[i].segment_tbs_num = 0;
+        p_segments[i].layout_padding_budget[0] = 0;
+        p_segments[i].layout_padding_budget[1] = 0;
         p_segments[i].page_table_offset = 
             (uintptr_t)(aot_page_table + page_index) - (uintptr_t)p_header;
         page_index += (curr_seg_info->seg_end - curr_seg_info->seg_begin

--- a/target/i386/latx/sbt/aot_merge.c
+++ b/target/i386/latx/sbt/aot_merge.c
@@ -10,6 +10,7 @@
  * @brief AOT optimization
  */
 #include "aot_merge.h"
+#include "aot_static_layout.h"
 #include "latx-options.h"
 #include "file_ctx.h"
 
@@ -464,6 +465,10 @@ static bool merge_aot_generate(void)
     char *curr_name = aot_x86_lib_names;
     uint8_t aot_file_type = get_file_type(merge_seg_info_vector[0]->file_name);
     p_header->aot_file_type = aot_file_type;
+    p_header->layout_line_log2 = 0;
+    p_header->layout_set_log2 = 0;
+    p_header->layout_ways = 0;
+    p_header->layout_magic = 0;
     int page_index = 0;
     for (int i = 0; i < seg_info_num; i++) {
         seg_info *curr_seg_info = merge_seg_info_vector[i]->s_info;
@@ -563,6 +568,9 @@ static bool merge_aot_generate(void)
     assert((void *)curr_insn - (void *)insn_buffer == total_code_cache_size);
     if (total_code_cache_size == 0) {
         goto out;
+    }
+    if (option_aot_static_layout) {
+        aot_static_layout_store_header(p_header, p_segments);
     }
     /* Write file metadata infomation(aot_buffer) into aot. */
 

--- a/target/i386/latx/sbt/aot_recover_tb.c
+++ b/target/i386/latx/sbt/aot_recover_tb.c
@@ -445,6 +445,12 @@ static bool check_ir1(target_ulong seg_begin, struct aot_tb *p_aot_tbs, int num,
 
 inline int load_page_4(target_ulong pc, uint32_t cflags, seg_info *info)
 {
+#if defined(CONFIG_LATX_TU) && defined(CONFIG_LATX_TBMINI_ENABLE)
+    AOTStaticLazyLayout *previous_layout = aot_static_lazy_current;
+
+    aot_static_lazy_current = option_aot == 1 && option_aot_static_layout ?
+        aot_static_lazy_get(info, cflags) : NULL;
+#endif
     int ret = load_page(pc, cflags, info);
     pc += TARGET_PAGE_SIZE;
     load_page(pc, cflags, info);
@@ -453,6 +459,9 @@ inline int load_page_4(target_ulong pc, uint32_t cflags, seg_info *info)
     pc += TARGET_PAGE_SIZE;
     load_page(pc, cflags, info);
     try_aot_link();
+#if defined(CONFIG_LATX_TU) && defined(CONFIG_LATX_TBMINI_ENABLE)
+    aot_static_lazy_current = previous_layout;
+#endif
     return ret;
 }
 
@@ -547,13 +556,8 @@ inline int load_page(target_ulong pc, uint32_t cflags, seg_info *info)
 
     tcg_ctx->tb_cflags = cflags;
 
-    AOTStaticLazyLayout *previous_layout = aot_static_lazy_current;
-
-    aot_static_lazy_current = option_aot == 1 && option_aot_static_layout ?
-        aot_static_lazy_get(info, cflags) : NULL;
     recover_tb_range(p1, p_aot_tbs, tb_num_in_page, info->seg_begin,
                      info->seg_end);
-    aot_static_lazy_current = previous_layout;
     return 1;
 }
 

--- a/target/i386/latx/sbt/aot_recover_tb.c
+++ b/target/i386/latx/sbt/aot_recover_tb.c
@@ -12,6 +12,7 @@
 #include "qemu/osdep.h"
 
 #include "aot_recover_tb.h"
+#include "aot_static_layout.h"
 #include "latx-options.h"
 #include "lsenv.h"
 #include "accel/tcg/internal.h"
@@ -25,6 +26,33 @@
 #endif
 
 #ifdef CONFIG_LATX_AOT
+
+#if defined(CONFIG_LATX_TU) && defined(CONFIG_LATX_TBMINI_ENABLE)
+static __thread bool aot_static_layout_stored;
+static __thread uint32_t aot_static_layout_line_size;
+
+static bool aot_static_layout_header_usable(const aot_header *header)
+{
+    uint32_t line_size;
+    uint32_t set_count;
+    uint32_t ways;
+
+    if (!aot_static_layout_get_l1i_geometry(&line_size, &set_count, &ways) ||
+        line_size != qemu_icache_linesize ||
+        !aot_static_layout_header_matches(header, line_size, set_count,
+                                          ways)) {
+        return false;
+    }
+    aot_static_layout_line_size = line_size;
+    return true;
+}
+
+static void aot_static_layout_destroy(void)
+{
+    aot_static_layout_stored = false;
+    aot_static_layout_line_size = 0;
+}
+#endif
 
 inline static void copy_code_to_buff(void *tb_buff, aot_tb *p_aot_tb) {
     assert(p_aot_tb->tu_size >= p_aot_tb->tb_cache_size);
@@ -211,6 +239,39 @@ static void recover_tb_range(target_ulong page, struct aot_tb *p_aot_tbs,
         }
 #if defined(CONFIG_LATX_TBMINI_ENABLE)
         int tb_num_in_tu = j - i;
+
+        if (aot_static_layout_stored) {
+            uintptr_t table = ROUND_UP((uintptr_t)tcg_ctx->code_gen_ptr,
+                                       CODE_GEN_ALIGN);
+            uintptr_t table_size = sizeof(struct TBMini) *
+                                   (tb_num_in_tu + 1);
+            uintptr_t code = ROUND_UP(table + table_size,
+                                      qemu_icache_linesize);
+            uintptr_t unpadded_end = ROUND_UP(code + p_aot_tbs[i].tu_size,
+                                              CODE_GEN_ALIGN);
+            size_t available = unpadded_end <
+                               (uintptr_t)tcg_ctx->code_gen_highwater ?
+                               (uintptr_t)tcg_ctx->code_gen_highwater -
+                               unpadded_end : 0;
+            uintptr_t padding;
+            uintptr_t planned_padding =
+                (uintptr_t)p_aot_tbs[i].layout_padding_lines *
+                aot_static_layout_line_size;
+
+            padding = aot_static_layout_stored_padding(
+                aot_buffer, &p_aot_tbs[i], aot_static_layout_line_size,
+                1U << ((aot_header *)aot_buffer)->layout_set_log2,
+                ((aot_header *)aot_buffer)->layout_ways, available);
+            if (planned_padding && !padding) {
+                aot_static_layout_stored = false;
+            }
+
+            assert((padding & (qemu_icache_linesize - 1)) == 0);
+            if (padding) {
+                qatomic_set(&tcg_ctx->code_gen_ptr,
+                            tcg_ctx->code_gen_ptr + padding);
+            }
+        }
         /* Reserve space for tu tbmin table. */
         TBMini *tbmini_ptr= (TBMini *)
             ROUND_UP((uintptr_t)tcg_ctx->code_gen_ptr, CODE_GEN_ALIGN);
@@ -317,12 +378,27 @@ inline int load_page_4(target_ulong pc, uint32_t cflags, seg_info *info)
 
 static int load_all_seg(uint32_t cflags, seg_info *info)
 {
+#if defined(CONFIG_LATX_TU) && defined(CONFIG_LATX_TBMINI_ENABLE)
+    bool static_layout = option_aot_static_layout;
+#endif
+
     info->seg_flag |= SEG_RUNNING;
+#if defined(CONFIG_LATX_TU) && defined(CONFIG_LATX_TBMINI_ENABLE)
+    if (static_layout) {
+        aot_static_layout_stored = aot_static_layout_header_usable(
+            info->buffer);
+    }
+#endif
     for (target_ulong addr = info->seg_begin; addr < info->seg_end;
             addr += TARGET_PAGE_SIZE) {
         load_page(addr, cflags, info);
     }
     try_aot_link();
+#if defined(CONFIG_LATX_TU) && defined(CONFIG_LATX_TBMINI_ENABLE)
+    if (static_layout) {
+        aot_static_layout_destroy();
+    }
+#endif
     return 1;
 }
 

--- a/target/i386/latx/sbt/aot_recover_tb.c
+++ b/target/i386/latx/sbt/aot_recover_tb.c
@@ -30,6 +30,34 @@
 #if defined(CONFIG_LATX_TU) && defined(CONFIG_LATX_TBMINI_ENABLE)
 static __thread bool aot_static_layout_stored;
 static __thread uint32_t aot_static_layout_line_size;
+static __thread uint32_t aot_static_layout_set_count;
+static __thread uint32_t aot_static_layout_ways;
+static __thread AOTStaticLazyLayout *aot_static_lazy_current;
+static __thread GHashTable *aot_static_lazy_states[2];
+static __thread unsigned aot_static_lazy_flush_count;
+
+typedef struct AOTLazyState {
+    AOTStaticLazyLayout *layout;
+    const void *buffer;
+} AOTLazyState;
+
+static void aot_lazy_state_free(gpointer data)
+{
+    AOTLazyState *state = data;
+
+    aot_static_lazy_layout_free(state->layout);
+    g_free(state);
+}
+
+static void aot_static_lazy_reset(void)
+{
+    for (uint32_t i = 0; i < G_N_ELEMENTS(aot_static_lazy_states); i++) {
+        if (aot_static_lazy_states[i]) {
+            g_hash_table_remove_all(aot_static_lazy_states[i]);
+        }
+    }
+    aot_static_lazy_current = NULL;
+}
 
 static bool aot_static_layout_header_usable(const aot_header *header)
 {
@@ -44,13 +72,57 @@ static bool aot_static_layout_header_usable(const aot_header *header)
         return false;
     }
     aot_static_layout_line_size = line_size;
+    aot_static_layout_set_count = set_count;
+    aot_static_layout_ways = ways;
     return true;
+}
+
+static AOTStaticLazyLayout *aot_static_lazy_get(seg_info *info,
+                                                uint32_t cflags)
+{
+    aot_segment *segment = info->p_segment;
+    aot_header *header = info->buffer;
+    uint32_t parallel = cflags & CF_PARALLEL ? 1 : 0;
+    unsigned flush_count = qatomic_read(&tb_ctx.tb_flush_count);
+    GHashTable *states;
+    AOTLazyState *state;
+
+    if (!aot_static_layout_header_usable(header)) {
+        return NULL;
+    }
+    if (aot_static_lazy_flush_count != flush_count) {
+        aot_static_lazy_reset();
+        aot_static_lazy_flush_count = flush_count;
+    }
+    states = aot_static_lazy_states[parallel];
+    if (!states) {
+        states = g_hash_table_new_full(g_direct_hash, g_direct_equal, NULL,
+                                       aot_lazy_state_free);
+        aot_static_lazy_states[parallel] = states;
+    }
+    state = g_hash_table_lookup(states, segment);
+    if (state && state->buffer != info->buffer) {
+        g_hash_table_remove(states, segment);
+        state = NULL;
+    }
+    if (!state) {
+        state = g_new0(AOTLazyState, 1);
+        state->layout = aot_static_lazy_layout_new(
+            aot_static_layout_line_size, aot_static_layout_set_count,
+            aot_static_layout_ways,
+            segment->layout_padding_budget[parallel]);
+        state->buffer = info->buffer;
+        g_hash_table_insert(states, segment, state);
+    }
+    return state->layout;
 }
 
 static void aot_static_layout_destroy(void)
 {
     aot_static_layout_stored = false;
     aot_static_layout_line_size = 0;
+    aot_static_layout_set_count = 0;
+    aot_static_layout_ways = 0;
 }
 #endif
 
@@ -239,8 +311,9 @@ static void recover_tb_range(target_ulong page, struct aot_tb *p_aot_tbs,
         }
 #if defined(CONFIG_LATX_TBMINI_ENABLE)
         int tb_num_in_tu = j - i;
+        target_ulong tu_guest = start + p_aot_tbs[i].offset_in_segment;
 
-        if (aot_static_layout_stored) {
+        if (aot_static_layout_stored || aot_static_lazy_current) {
             uintptr_t table = ROUND_UP((uintptr_t)tcg_ctx->code_gen_ptr,
                                        CODE_GEN_ALIGN);
             uintptr_t table_size = sizeof(struct TBMini) *
@@ -254,16 +327,24 @@ static void recover_tb_range(target_ulong page, struct aot_tb *p_aot_tbs,
                                (uintptr_t)tcg_ctx->code_gen_highwater -
                                unpadded_end : 0;
             uintptr_t padding;
-            uintptr_t planned_padding =
-                (uintptr_t)p_aot_tbs[i].layout_padding_lines *
-                aot_static_layout_line_size;
+            if (aot_static_layout_stored) {
+                uintptr_t planned_padding =
+                    (uintptr_t)p_aot_tbs[i].layout_padding_lines *
+                    aot_static_layout_line_size;
 
-            padding = aot_static_layout_stored_padding(
-                aot_buffer, &p_aot_tbs[i], aot_static_layout_line_size,
-                1U << ((aot_header *)aot_buffer)->layout_set_log2,
-                ((aot_header *)aot_buffer)->layout_ways, available);
-            if (planned_padding && !padding) {
-                aot_static_layout_stored = false;
+                padding = aot_static_layout_stored_padding(
+                    aot_buffer, &p_aot_tbs[i], aot_static_layout_line_size,
+                    aot_static_layout_set_count, aot_static_layout_ways,
+                    available);
+                if (planned_padding && !padding) {
+                    aot_static_layout_stored = false;
+                }
+            } else {
+                padding = aot_static_lazy_layout_place(
+                    aot_static_lazy_current,
+                    p_aot_tbs[i].layout_component,
+                    p_aot_tbs[i].layout_flags & AOT_LAYOUT_MOVABLE,
+                    tu_guest, code, p_aot_tbs[i].tu_size, available);
             }
 
             assert((padding & (qemu_icache_linesize - 1)) == 0);
@@ -466,7 +547,13 @@ inline int load_page(target_ulong pc, uint32_t cflags, seg_info *info)
 
     tcg_ctx->tb_cflags = cflags;
 
-    recover_tb_range(p1, p_aot_tbs, tb_num_in_page, info->seg_begin, info->seg_end);
+    AOTStaticLazyLayout *previous_layout = aot_static_lazy_current;
+
+    aot_static_lazy_current = option_aot == 1 && option_aot_static_layout ?
+        aot_static_lazy_get(info, cflags) : NULL;
+    recover_tb_range(p1, p_aot_tbs, tb_num_in_page, info->seg_begin,
+                     info->seg_end);
+    aot_static_lazy_current = previous_layout;
     return 1;
 }
 

--- a/target/i386/latx/sbt/aot_static_layout.c
+++ b/target/i386/latx/sbt/aot_static_layout.c
@@ -25,6 +25,17 @@ struct AOTStaticLayout {
     size_t padding_used;
 };
 
+struct AOTStaticLazyLayout {
+    GHashTable *pressure;
+    GHashTable *placed;
+    uint32_t *scratch;
+    uint32_t line_size;
+    uint32_t set_count;
+    uint32_t ways;
+    size_t padding_budget;
+    size_t padding_used;
+};
+
 static bool read_uint_file(const char *path, uint32_t *value)
 {
     g_autofree char *text = NULL;
@@ -456,6 +467,133 @@ void aot_static_layout_free(AOTStaticLayout *layout)
     g_free(layout);
 }
 
+static uint32_t *lazy_component_pressure(AOTStaticLazyLayout *layout,
+                                         uint16_t component)
+{
+    gpointer key = (gpointer)(uintptr_t)(component + 1);
+    uint32_t *pressure = g_hash_table_lookup(layout->pressure, key);
+
+    if (!pressure) {
+        pressure = g_new0(uint32_t, layout->set_count);
+        g_hash_table_insert(layout->pressure, key, pressure);
+    }
+    return pressure;
+}
+
+static void lazy_add_footprint(const AOTStaticLazyLayout *layout,
+                               uint32_t *pressure, uintptr_t host_code,
+                               uint32_t code_size)
+{
+    uint32_t lines = DIV_ROUND_UP(code_size, layout->line_size);
+    uint32_t first_set = host_code / layout->line_size % layout->set_count;
+
+    for (uint32_t i = 0; i < lines; i++) {
+        pressure[(first_set + i) % layout->set_count]++;
+    }
+}
+
+static uint64_t lazy_pressure_cost(const AOTStaticLazyLayout *layout,
+                                   const uint32_t *pressure)
+{
+    uint64_t cost = 0;
+
+    for (uint32_t i = 0; i < layout->set_count; i++) {
+        if (pressure[i] > layout->ways) {
+            uint64_t overflow = pressure[i] - layout->ways;
+
+            cost += overflow * overflow;
+        }
+    }
+    return cost;
+}
+
+static uint64_t lazy_candidate_cost(AOTStaticLazyLayout *layout,
+                                    const uint32_t *pressure,
+                                    uintptr_t host_code, uint32_t code_size)
+{
+    memcpy(layout->scratch, pressure,
+           sizeof(*layout->scratch) * layout->set_count);
+    lazy_add_footprint(layout, layout->scratch, host_code, code_size);
+    return lazy_pressure_cost(layout, layout->scratch);
+}
+
+AOTStaticLazyLayout *aot_static_lazy_layout_new(uint32_t line_size,
+                                                uint32_t set_count,
+                                                uint32_t ways,
+                                                size_t padding_budget)
+{
+    AOTStaticLazyLayout *layout;
+
+    if (!line_size || !set_count || !ways) {
+        return NULL;
+    }
+    layout = g_new0(AOTStaticLazyLayout, 1);
+    layout->pressure = g_hash_table_new_full(g_direct_hash, g_direct_equal,
+                                             NULL, g_free);
+    layout->placed = g_hash_table_new(g_direct_hash, g_direct_equal);
+    layout->scratch = g_new(uint32_t, set_count);
+    layout->line_size = line_size;
+    layout->set_count = set_count;
+    layout->ways = ways;
+    layout->padding_budget = ROUND_DOWN(padding_budget, line_size);
+    return layout;
+}
+
+uintptr_t aot_static_lazy_layout_place(AOTStaticLazyLayout *layout,
+                                       uint16_t component, bool movable,
+                                       target_ulong guest_pc,
+                                       uintptr_t host_code,
+                                       uint32_t code_size,
+                                       size_t available_padding)
+{
+    gpointer guest_key = (gpointer)(uintptr_t)guest_pc;
+    uint32_t *pressure;
+    uintptr_t best_padding = 0;
+    uintptr_t max_padding;
+    uint64_t best_cost;
+
+    if (!layout || component == AOT_LAYOUT_COMPONENT_NONE ||
+        g_hash_table_contains(layout->placed, guest_key)) {
+        return 0;
+    }
+    g_hash_table_add(layout->placed, guest_key);
+    pressure = lazy_component_pressure(layout, component);
+    if (!movable) {
+        lazy_add_footprint(layout, pressure, host_code, code_size);
+        return 0;
+    }
+
+    best_cost = lazy_candidate_cost(layout, pressure, host_code, code_size);
+    max_padding = MIN((uintptr_t)layout->line_size * layout->ways,
+                      layout->padding_budget - layout->padding_used);
+    max_padding = MIN(max_padding, available_padding);
+    for (uintptr_t padding = layout->line_size;
+         padding <= max_padding; padding += layout->line_size) {
+        uint64_t cost = lazy_candidate_cost(layout, pressure,
+                                            host_code + padding, code_size);
+        uint64_t score = cost + padding / layout->line_size;
+
+        if (score < best_cost) {
+            best_cost = score;
+            best_padding = padding;
+        }
+    }
+    lazy_add_footprint(layout, pressure, host_code + best_padding, code_size);
+    layout->padding_used += best_padding;
+    return best_padding;
+}
+
+void aot_static_lazy_layout_free(AOTStaticLazyLayout *layout)
+{
+    if (!layout) {
+        return;
+    }
+    g_hash_table_destroy(layout->placed);
+    g_hash_table_destroy(layout->pressure);
+    g_free(layout->scratch);
+    g_free(layout);
+}
+
 static bool stored_matching_cflags(const aot_tb *tb, uint32_t cflags)
 {
     return (tb->cflags & CF_PARALLEL) == (cflags & CF_PARALLEL);
@@ -477,7 +615,7 @@ static void stored_add_edge(AOTStaticLayoutEdge *edges, uint32_t *edge_count,
     (*edge_count)++;
 }
 
-bool aot_static_layout_store(const aot_segment *segment, aot_tb *tbs,
+bool aot_static_layout_store(aot_segment *segment, aot_tb *tbs,
                              uint32_t cflags, target_ulong segment_base,
                              uint32_t line_size, uint32_t set_count,
                              uint32_t ways)
@@ -495,6 +633,8 @@ bool aot_static_layout_store(const aot_segment *segment, aot_tb *tbs,
     uint32_t component_count;
     uint32_t current_node = AOT_STATIC_LAYOUT_NO_COMPONENT;
     uintptr_t cursor = 0;
+    size_t total_code_size = 0;
+    uint32_t parallel = cflags & CF_PARALLEL ? 1 : 0;
 
     if (!line_size || !set_count || !ways) {
         return false;
@@ -532,7 +672,8 @@ bool aot_static_layout_store(const aot_segment *segment, aot_tb *tbs,
             nodes[current_node].code_size = tb->tu_size;
             nodes[current_node].component = AOT_STATIC_LAYOUT_NO_COMPONENT;
             tb->layout_padding_lines = 0;
-            tb->layout_reserved = 0;
+            tb->layout_component = AOT_LAYOUT_COMPONENT_NONE;
+            tb->layout_flags = 0;
         }
         if (current_node == AOT_STATIC_LAYOUT_NO_COMPONENT ||
             tb->tu_id != (uint32_t)nodes[current_node].guest_pc) {
@@ -600,6 +741,9 @@ bool aot_static_layout_store(const aot_segment *segment, aot_tb *tbs,
             nodes[edges[i].to].can_pad = true;
         }
     }
+    if (component_count >= AOT_LAYOUT_COMPONENT_NONE) {
+        component_count = 0;
+    }
     if (component_count) {
         layout = aot_static_layout_new(nodes, node_count, component_count,
                                        line_size, set_count, ways);
@@ -609,6 +753,15 @@ bool aot_static_layout_store(const aot_segment *segment, aot_tb *tbs,
         uintptr_t table;
         uintptr_t code;
         uintptr_t padding = 0;
+
+        total_code_size += nodes[i].code_size;
+        if (layout &&
+            nodes[i].component != AOT_STATIC_LAYOUT_NO_COMPONENT) {
+            tbs[first_tb[i]].layout_component = nodes[i].component;
+            if (nodes[i].can_pad) {
+                tbs[first_tb[i]].layout_flags |= AOT_LAYOUT_MOVABLE;
+            }
+        }
 
         cursor = ROUND_UP(cursor, line_size);
         cursor += (uintptr_t)ROUND_UP(sizeof(TranslationBlock), line_size) *
@@ -625,6 +778,8 @@ bool aot_static_layout_store(const aot_segment *segment, aot_tb *tbs,
         cursor = ROUND_UP(code + padding + nodes[i].code_size,
                           CODE_GEN_ALIGN);
     }
+    segment->layout_padding_budget[parallel] = ROUND_DOWN(
+        total_code_size / 100, line_size);
 
     aot_static_layout_free(layout);
     g_hash_table_destroy(tb_nodes);

--- a/target/i386/latx/sbt/aot_static_layout.c
+++ b/target/i386/latx/sbt/aot_static_layout.c
@@ -1,0 +1,699 @@
+/*
+ * SPDX-FileCopyrightText: 2021-2026 LAT Project Authors
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#include "qemu/osdep.h"
+#include "qemu/cutils.h"
+
+#include "aot.h"
+#include "aot_static_layout.h"
+#include "exec/exec-all.h"
+
+struct AOTStaticLayout {
+    AOTStaticLayoutNode *nodes;
+    uint32_t *pressure;
+    uint32_t *scratch;
+    bool *placed;
+    uint32_t node_count;
+    uint32_t component_count;
+    uint32_t line_size;
+    uint32_t set_count;
+    uint32_t ways;
+    size_t padding_budget;
+    size_t padding_used;
+};
+
+static bool read_uint_file(const char *path, uint32_t *value)
+{
+    g_autofree char *text = NULL;
+    const char *end;
+    uint64_t parsed;
+
+    if (!g_file_get_contents(path, &text, NULL, NULL) ||
+        qemu_strtou64(text, &end, 10, &parsed) < 0 || parsed > UINT32_MAX) {
+        return false;
+    }
+    while (g_ascii_isspace(*end)) {
+        end++;
+    }
+    if (*end) {
+        return false;
+    }
+    *value = parsed;
+    return true;
+}
+
+static bool detect_l1i_geometry(uint32_t *line_size, uint32_t *set_count,
+                                uint32_t *ways)
+{
+    for (uint32_t index = 0; index < 16; index++) {
+        g_autofree char *base = g_strdup_printf(
+            "/sys/devices/system/cpu/cpu0/cache/index%u", index);
+        g_autofree char *level_path = g_build_filename(base, "level", NULL);
+        g_autofree char *type_path = g_build_filename(base, "type", NULL);
+        g_autofree char *line_path = g_build_filename(
+            base, "coherency_line_size", NULL);
+        g_autofree char *sets_path = g_build_filename(
+            base, "number_of_sets", NULL);
+        g_autofree char *ways_path = g_build_filename(
+            base, "ways_of_associativity", NULL);
+        g_autofree char *type = NULL;
+        uint32_t level;
+
+        if (!read_uint_file(level_path, &level) || level != 1 ||
+            !g_file_get_contents(type_path, &type, NULL, NULL) ||
+            (!g_str_has_prefix(type, "Instruction") &&
+             !g_str_has_prefix(type, "Unified"))) {
+            continue;
+        }
+        return read_uint_file(line_path, line_size) &&
+               read_uint_file(sets_path, set_count) &&
+               read_uint_file(ways_path, ways) &&
+               *line_size && *set_count && *ways;
+    }
+    return false;
+}
+
+bool aot_static_layout_get_l1i_geometry(uint32_t *line_size,
+                                        uint32_t *set_count,
+                                        uint32_t *ways)
+{
+    static gsize initialized;
+    static uint32_t cached_line_size;
+    static uint32_t cached_set_count;
+    static uint32_t cached_ways;
+    static bool valid;
+
+    if (g_once_init_enter(&initialized)) {
+        valid = detect_l1i_geometry(&cached_line_size, &cached_set_count,
+                                    &cached_ways);
+        g_once_init_leave(&initialized, 1);
+    }
+    if (!valid) {
+        return false;
+    }
+    *line_size = cached_line_size;
+    *set_count = cached_set_count;
+    *ways = cached_ways;
+    return true;
+}
+
+static uint32_t find_root(uint32_t *parents, uint32_t node)
+{
+    while (parents[node] != node) {
+        parents[node] = parents[parents[node]];
+        node = parents[node];
+    }
+    return node;
+}
+
+static void union_nodes(uint32_t *parents, uint32_t left, uint32_t right)
+{
+    left = find_root(parents, left);
+    right = find_root(parents, right);
+    if (left != right) {
+        parents[right] = left;
+    }
+}
+
+typedef struct AOTTarjanState {
+    const uint32_t *offsets;
+    const uint32_t *targets;
+    int32_t *index;
+    int32_t *lowlink;
+    uint32_t *stack;
+    uint32_t *scc;
+    uint32_t *scc_size;
+    bool *on_stack;
+    uint32_t stack_size;
+    uint32_t next_index;
+    uint32_t scc_count;
+} AOTTarjanState;
+
+static void tarjan_visit(AOTTarjanState *state, uint32_t node)
+{
+    state->index[node] = state->next_index;
+    state->lowlink[node] = state->next_index++;
+    state->stack[state->stack_size++] = node;
+    state->on_stack[node] = true;
+
+    for (uint32_t i = state->offsets[node];
+         i < state->offsets[node + 1]; i++) {
+        uint32_t target = state->targets[i];
+
+        if (state->index[target] < 0) {
+            tarjan_visit(state, target);
+            state->lowlink[node] = MIN(state->lowlink[node],
+                                       state->lowlink[target]);
+        } else if (state->on_stack[target]) {
+            state->lowlink[node] = MIN(state->lowlink[node],
+                                       state->index[target]);
+        }
+    }
+
+    if (state->lowlink[node] == state->index[node]) {
+        uint32_t member;
+
+        do {
+            member = state->stack[--state->stack_size];
+            state->on_stack[member] = false;
+            state->scc[member] = state->scc_count;
+            state->scc_size[state->scc_count]++;
+        } while (member != node);
+        state->scc_count++;
+    }
+}
+
+uint32_t aot_static_layout_find_components(AOTStaticLayoutNode *nodes,
+                                           uint32_t node_count,
+                                           const AOTStaticLayoutEdge *edges,
+                                           uint32_t edge_count)
+{
+    AOTTarjanState tarjan = { 0 };
+    uint32_t *offsets;
+    uint32_t *targets;
+    uint32_t *cursor;
+    uint32_t *parents;
+    uint32_t *root_component;
+    uint32_t *scc_first;
+    bool *hot;
+    uint32_t component_count = 0;
+    uint32_t flow_edge_count = 0;
+
+    if (!node_count) {
+        return 0;
+    }
+
+    offsets = g_new0(uint32_t, node_count + 1);
+    parents = g_new(uint32_t, node_count);
+    root_component = g_new(uint32_t, node_count);
+    scc_first = g_new(uint32_t, node_count);
+    hot = g_new0(bool, node_count);
+
+    for (uint32_t i = 0; i < node_count; i++) {
+        parents[i] = i;
+        root_component[i] = AOT_STATIC_LAYOUT_NO_COMPONENT;
+        scc_first[i] = AOT_STATIC_LAYOUT_NO_COMPONENT;
+        nodes[i].component = AOT_STATIC_LAYOUT_NO_COMPONENT;
+    }
+
+    for (uint32_t i = 0; i < edge_count; i++) {
+        if (edges[i].from >= node_count || edges[i].to >= node_count ||
+            edges[i].kind != AOT_LAYOUT_EDGE_FLOW) {
+            continue;
+        }
+        offsets[edges[i].from + 1]++;
+        flow_edge_count++;
+    }
+    for (uint32_t i = 1; i <= node_count; i++) {
+        offsets[i] += offsets[i - 1];
+    }
+    targets = g_new(uint32_t, flow_edge_count);
+    cursor = g_new(uint32_t, node_count);
+    memcpy(cursor, offsets, sizeof(*offsets) * node_count);
+    for (uint32_t i = 0; i < edge_count; i++) {
+        if (edges[i].from < node_count && edges[i].to < node_count &&
+            edges[i].kind == AOT_LAYOUT_EDGE_FLOW) {
+            targets[cursor[edges[i].from]++] = edges[i].to;
+        }
+    }
+    g_free(cursor);
+
+    tarjan.offsets = offsets;
+    tarjan.targets = targets;
+    tarjan.index = g_new(int32_t, node_count);
+    tarjan.lowlink = g_new(int32_t, node_count);
+    tarjan.stack = g_new(uint32_t, node_count);
+    tarjan.scc = g_new(uint32_t, node_count);
+    tarjan.scc_size = g_new0(uint32_t, node_count);
+    tarjan.on_stack = g_new0(bool, node_count);
+    memset(tarjan.index, -1, sizeof(*tarjan.index) * node_count);
+
+    for (uint32_t i = 0; i < node_count; i++) {
+        if (tarjan.index[i] < 0) {
+            tarjan_visit(&tarjan, i);
+        }
+    }
+
+    for (uint32_t i = 0; i < node_count; i++) {
+        if (tarjan.scc_size[tarjan.scc[i]] > 1) {
+            hot[i] = true;
+        }
+    }
+    for (uint32_t i = 0; i < edge_count; i++) {
+        if (edges[i].from < node_count && edges[i].to < node_count &&
+            edges[i].kind == AOT_LAYOUT_EDGE_FLOW &&
+            edges[i].from == edges[i].to) {
+            hot[edges[i].from] = true;
+        }
+    }
+    for (uint32_t i = 0; i < node_count; i++) {
+        if (hot[i]) {
+            uint32_t scc = tarjan.scc[i];
+
+            if (scc_first[scc] == AOT_STATIC_LAYOUT_NO_COMPONENT) {
+                scc_first[scc] = i;
+            } else {
+                union_nodes(parents, scc_first[scc], i);
+            }
+        }
+    }
+
+    for (uint32_t i = 0; i < edge_count; i++) {
+        uint32_t from = edges[i].from;
+        uint32_t to = edges[i].to;
+
+        if (from >= node_count || to >= node_count ||
+            edges[i].kind != AOT_LAYOUT_EDGE_CALL || !hot[from]) {
+            continue;
+        }
+        hot[to] = true;
+        union_nodes(parents, from, to);
+    }
+
+    for (uint32_t i = 0; i < node_count; i++) {
+        uint32_t root;
+
+        if (!hot[i]) {
+            continue;
+        }
+        root = find_root(parents, i);
+        if (root_component[root] == AOT_STATIC_LAYOUT_NO_COMPONENT) {
+            root_component[root] = component_count++;
+        }
+        nodes[i].component = root_component[root];
+    }
+
+    g_free(hot);
+    g_free(scc_first);
+    g_free(root_component);
+    g_free(parents);
+    g_free(tarjan.on_stack);
+    g_free(tarjan.scc_size);
+    g_free(tarjan.scc);
+    g_free(tarjan.stack);
+    g_free(tarjan.lowlink);
+    g_free(tarjan.index);
+    g_free(targets);
+    g_free(offsets);
+    return component_count;
+}
+
+static uint32_t line_set(const AOTStaticLayout *layout, uintptr_t address)
+{
+    return address / layout->line_size % layout->set_count;
+}
+
+static void add_footprint(const AOTStaticLayout *layout, uint32_t *pressure,
+                          uintptr_t host_code, uint32_t code_size)
+{
+    uint32_t lines = DIV_ROUND_UP(code_size, layout->line_size);
+    uint32_t first_set = line_set(layout, host_code);
+
+    for (uint32_t i = 0; i < lines; i++) {
+        pressure[(first_set + i) % layout->set_count]++;
+    }
+}
+
+static uint64_t pressure_cost(const AOTStaticLayout *layout,
+                              const uint32_t *pressure)
+{
+    uint64_t cost = 0;
+
+    for (uint32_t i = 0; i < layout->set_count; i++) {
+        if (pressure[i] > layout->ways) {
+            uint64_t overflow = pressure[i] - layout->ways;
+
+            cost += overflow * overflow;
+        }
+    }
+    return cost;
+}
+
+static uint64_t candidate_cost(AOTStaticLayout *layout,
+                               uint32_t component, uintptr_t host_code,
+                               uint32_t code_size)
+{
+    const uint32_t *current = layout->pressure +
+                              component * layout->set_count;
+
+    memcpy(layout->scratch, current,
+           sizeof(*layout->scratch) * layout->set_count);
+    add_footprint(layout, layout->scratch, host_code, code_size);
+    return pressure_cost(layout, layout->scratch);
+}
+
+AOTStaticLayout *aot_static_layout_new(const AOTStaticLayoutNode *nodes,
+                                       uint32_t node_count,
+                                       uint32_t component_count,
+                                       uint32_t line_size,
+                                       uint32_t set_count,
+                                       uint32_t ways)
+{
+    AOTStaticLayout *layout;
+    size_t code_size = 0;
+
+    if (!line_size || !set_count || !ways) {
+        return NULL;
+    }
+
+    layout = g_new0(AOTStaticLayout, 1);
+    layout->nodes = g_malloc(sizeof(*nodes) * node_count);
+    memcpy(layout->nodes, nodes, sizeof(*nodes) * node_count);
+    layout->placed = g_new0(bool, node_count);
+    layout->pressure = g_new0(uint32_t,
+                              (size_t)component_count * set_count);
+    layout->scratch = g_new(uint32_t, set_count);
+    layout->node_count = node_count;
+    layout->component_count = component_count;
+    layout->line_size = line_size;
+    layout->set_count = set_count;
+    layout->ways = ways;
+
+    for (uint32_t i = 0; i < node_count; i++) {
+        code_size += nodes[i].code_size;
+    }
+    layout->padding_budget = ROUND_DOWN(code_size /
+                                        AOT_STATIC_LAYOUT_PADDING_PERCENT /
+                                        100, line_size);
+    return layout;
+}
+
+uintptr_t aot_static_layout_place(AOTStaticLayout *layout,
+                                  uint32_t node_index,
+                                  uintptr_t host_code,
+                                  size_t available_padding)
+{
+    AOTStaticLayoutNode *node;
+    uint32_t *pressure;
+    uintptr_t best_padding = 0;
+    uintptr_t max_padding;
+    uint64_t best_cost;
+
+    if (!layout || node_index >= layout->node_count ||
+        layout->placed[node_index]) {
+        return 0;
+    }
+    layout->placed[node_index] = true;
+    node = &layout->nodes[node_index];
+    if (node->component == AOT_STATIC_LAYOUT_NO_COMPONENT ||
+        node->component >= layout->component_count) {
+        return 0;
+    }
+
+    pressure = layout->pressure + node->component * layout->set_count;
+    best_cost = candidate_cost(layout, node->component, host_code,
+                               node->code_size);
+    max_padding = node->can_pad ?
+        MIN((uintptr_t)layout->line_size * layout->ways,
+            layout->padding_budget - layout->padding_used) : 0;
+    max_padding = MIN(max_padding, available_padding);
+
+    for (uintptr_t padding = layout->line_size;
+         padding <= max_padding; padding += layout->line_size) {
+        uint64_t cost = candidate_cost(layout, node->component,
+                                       host_code + padding,
+                                       node->code_size);
+
+        if (cost < best_cost) {
+            best_cost = cost;
+            best_padding = padding;
+        }
+    }
+
+    add_footprint(layout, pressure, host_code + best_padding,
+                  node->code_size);
+    layout->padding_used += best_padding;
+    return best_padding;
+}
+
+uint64_t aot_static_layout_cost(const AOTStaticLayout *layout,
+                                uint32_t component)
+{
+    if (!layout || component >= layout->component_count) {
+        return 0;
+    }
+    return pressure_cost(layout, layout->pressure +
+                         component * layout->set_count);
+}
+
+size_t aot_static_layout_padding_used(const AOTStaticLayout *layout)
+{
+    return layout ? layout->padding_used : 0;
+}
+
+void aot_static_layout_free(AOTStaticLayout *layout)
+{
+    if (!layout) {
+        return;
+    }
+    g_free(layout->pressure);
+    g_free(layout->scratch);
+    g_free(layout->placed);
+    g_free(layout->nodes);
+    g_free(layout);
+}
+
+static bool stored_matching_cflags(const aot_tb *tb, uint32_t cflags)
+{
+    return (tb->cflags & CF_PARALLEL) == (cflags & CF_PARALLEL);
+}
+
+static void stored_add_edge(AOTStaticLayoutEdge *edges, uint32_t *edge_count,
+                            GHashTable *tb_nodes, uint32_t from,
+                            target_ulong target, AOTStaticLayoutEdgeKind kind)
+{
+    gpointer value = g_hash_table_lookup(tb_nodes,
+                                         (gpointer)(uintptr_t)target);
+
+    if (!value) {
+        return;
+    }
+    edges[*edge_count].from = from;
+    edges[*edge_count].to = (uintptr_t)value - 1;
+    edges[*edge_count].kind = kind;
+    (*edge_count)++;
+}
+
+bool aot_static_layout_store(const aot_segment *segment, aot_tb *tbs,
+                             uint32_t cflags, target_ulong segment_base,
+                             uint32_t line_size, uint32_t set_count,
+                             uint32_t ways)
+{
+    AOTStaticLayoutNode *nodes;
+    AOTStaticLayoutEdge *edges;
+    AOTStaticLayout *layout = NULL;
+    GHashTable *tb_nodes;
+    uint32_t *tb_node;
+    uint32_t *first_tb;
+    uint32_t *tb_count;
+    uint32_t node_count = 0;
+    uint32_t next_node = 0;
+    uint32_t edge_count = 0;
+    uint32_t component_count;
+    uint32_t current_node = AOT_STATIC_LAYOUT_NO_COMPONENT;
+    uintptr_t cursor = 0;
+
+    if (!line_size || !set_count || !ways) {
+        return false;
+    }
+    for (uint32_t i = 0; i < segment->segment_tbs_num; i++) {
+        if (stored_matching_cflags(&tbs[i], cflags) && tbs[i].is_first_tb) {
+            node_count++;
+        }
+    }
+    if (!node_count) {
+        return true;
+    }
+
+    nodes = g_new0(AOTStaticLayoutNode, node_count);
+    edges = g_new(AOTStaticLayoutEdge, segment->segment_tbs_num * 2);
+    tb_node = g_new(uint32_t, segment->segment_tbs_num);
+    first_tb = g_new(uint32_t, node_count);
+    tb_count = g_new0(uint32_t, node_count);
+    tb_nodes = g_hash_table_new(g_direct_hash, g_direct_equal);
+
+    for (uint32_t i = 0; i < segment->segment_tbs_num; i++) {
+        aot_tb *tb = &tbs[i];
+        target_ulong guest;
+
+        tb_node[i] = AOT_STATIC_LAYOUT_NO_COMPONENT;
+        if (!stored_matching_cflags(tb, cflags)) {
+            continue;
+        }
+        guest = segment_base + tb->offset_in_segment;
+        if (tb->is_first_tb) {
+            assert(next_node < node_count);
+            current_node = next_node++;
+            first_tb[current_node] = i;
+            nodes[current_node].guest_pc = guest;
+            nodes[current_node].code_size = tb->tu_size;
+            nodes[current_node].component = AOT_STATIC_LAYOUT_NO_COMPONENT;
+            tb->layout_padding_lines = 0;
+            tb->layout_reserved = 0;
+        }
+        if (current_node == AOT_STATIC_LAYOUT_NO_COMPONENT ||
+            tb->tu_id != (uint32_t)nodes[current_node].guest_pc) {
+            continue;
+        }
+        tb_node[i] = current_node;
+        tb_count[current_node]++;
+        g_hash_table_insert(tb_nodes, (gpointer)(uintptr_t)guest,
+                            (gpointer)(uintptr_t)(current_node + 1));
+    }
+    assert(next_node == node_count);
+
+    for (uint32_t i = 0; i < segment->segment_tbs_num; i++) {
+        const aot_tb *tb = &tbs[i];
+        uint32_t from = tb_node[i];
+        target_ulong guest;
+
+        if (from == AOT_STATIC_LAYOUT_NO_COMPONENT) {
+            continue;
+        }
+        guest = segment_base + tb->offset_in_segment;
+        switch (tb->last_ir1_type) {
+        case IR1_TYPE_BRANCH:
+            if (tb->next_tb_pc_offset != -1) {
+                stored_add_edge(edges, &edge_count, tb_nodes, from,
+                                segment_base + tb->next_tb_pc_offset,
+                                AOT_LAYOUT_EDGE_FLOW);
+            }
+            if (tb->target_tb_pc_offset != -1) {
+                stored_add_edge(edges, &edge_count, tb_nodes, from,
+                                segment_base + tb->target_tb_pc_offset,
+                                AOT_LAYOUT_EDGE_FLOW);
+            }
+            break;
+        case IR1_TYPE_JUMP:
+            if (tb->target_tb_pc_offset != -1) {
+                stored_add_edge(edges, &edge_count, tb_nodes, from,
+                                segment_base + tb->target_tb_pc_offset,
+                                AOT_LAYOUT_EDGE_FLOW);
+            }
+            break;
+        case IR1_TYPE_CALL:
+            if (tb->target_tb_pc_offset != -1) {
+                stored_add_edge(edges, &edge_count, tb_nodes, from,
+                                segment_base + tb->target_tb_pc_offset,
+                                AOT_LAYOUT_EDGE_CALL);
+            }
+            stored_add_edge(edges, &edge_count, tb_nodes, from,
+                            guest + tb->size, AOT_LAYOUT_EDGE_FLOW);
+            break;
+        case IR1_TYPE_NORMAL:
+        case IR1_TYPE_CALLIN:
+            stored_add_edge(edges, &edge_count, tb_nodes, from,
+                            guest + tb->size, AOT_LAYOUT_EDGE_FLOW);
+            break;
+        default:
+            break;
+        }
+    }
+
+    component_count = aot_static_layout_find_components(nodes, node_count,
+                                                         edges, edge_count);
+    for (uint32_t i = 0; i < edge_count; i++) {
+        if (edges[i].kind == AOT_LAYOUT_EDGE_CALL) {
+            nodes[edges[i].to].can_pad = true;
+        }
+    }
+    if (component_count) {
+        layout = aot_static_layout_new(nodes, node_count, component_count,
+                                       line_size, set_count, ways);
+    }
+
+    for (uint32_t i = 0; i < node_count; i++) {
+        uintptr_t table;
+        uintptr_t code;
+        uintptr_t padding = 0;
+
+        cursor = ROUND_UP(cursor, line_size);
+        cursor += (uintptr_t)ROUND_UP(sizeof(TranslationBlock), line_size) *
+                  tb_count[i];
+        table = ROUND_UP(cursor, CODE_GEN_ALIGN);
+        code = ROUND_UP(table + sizeof(TBMini) * (tb_count[i] + 1),
+                        line_size);
+        if (layout) {
+            padding = aot_static_layout_place(layout, i, code, SIZE_MAX);
+        }
+        assert(!(padding % line_size));
+        assert(padding / line_size <= UINT8_MAX);
+        tbs[first_tb[i]].layout_padding_lines = padding / line_size;
+        cursor = ROUND_UP(code + padding + nodes[i].code_size,
+                          CODE_GEN_ALIGN);
+    }
+
+    aot_static_layout_free(layout);
+    g_hash_table_destroy(tb_nodes);
+    g_free(tb_count);
+    g_free(first_tb);
+    g_free(tb_node);
+    g_free(edges);
+    g_free(nodes);
+    return true;
+}
+
+bool aot_static_layout_store_header(aot_header *header,
+                                    aot_segment *segments)
+{
+    uint32_t line_size;
+    uint32_t set_count;
+    uint32_t ways;
+
+    if (!aot_static_layout_get_l1i_geometry(&line_size, &set_count, &ways) ||
+        !is_power_of_2(line_size) || !is_power_of_2(set_count) ||
+        ways > UINT8_MAX) {
+        return false;
+    }
+
+    for (uint32_t i = 0; i < header->segments_num; i++) {
+        aot_segment *segment = &segments[i];
+        aot_tb *tbs = (void *)header + segment->segment_tbs_offset;
+
+        if (!aot_static_layout_store(segment, tbs, 0,
+                                     segment->details.seg_begin, line_size,
+                                     set_count, ways) ||
+            !aot_static_layout_store(segment, tbs, CF_PARALLEL,
+                                     segment->details.seg_begin, line_size,
+                                     set_count, ways)) {
+            return false;
+        }
+    }
+
+    header->layout_line_log2 = ctz32(line_size);
+    header->layout_set_log2 = ctz32(set_count);
+    header->layout_ways = ways;
+    header->layout_magic = AOT_STATIC_LAYOUT_MAGIC;
+    return true;
+}
+
+bool aot_static_layout_header_matches(const aot_header *header,
+                                      uint32_t line_size,
+                                      uint32_t set_count, uint32_t ways)
+{
+    return header && header->layout_magic == AOT_STATIC_LAYOUT_MAGIC &&
+           line_size && set_count && ways && is_power_of_2(line_size) &&
+           is_power_of_2(set_count) &&
+           header->layout_line_log2 == ctz32(line_size) &&
+           header->layout_set_log2 == ctz32(set_count) &&
+           header->layout_ways == ways;
+}
+
+uintptr_t aot_static_layout_stored_padding(const aot_header *header,
+                                           const aot_tb *tb,
+                                           uint32_t line_size,
+                                           uint32_t set_count, uint32_t ways,
+                                           size_t available_padding)
+{
+    uintptr_t padding;
+
+    if (!tb || !aot_static_layout_header_matches(header, line_size,
+                                                  set_count, ways)) {
+        return 0;
+    }
+    padding = (uintptr_t)tb->layout_padding_lines * line_size;
+    return padding <= available_padding ? padding : 0;
+}

--- a/target/i386/latx/sbt/meson.build
+++ b/target/i386/latx/sbt/meson.build
@@ -6,6 +6,7 @@ i386_ss.add(when: 'CONFIG_LATX', if_true: files(
   'aot_link_seg.c',
   'aot_merge.c',
   'aot_recover_tb.c',
+  'aot_static_layout.c',
   'aot_smc_reload.c',
   'aot_lib.c',
   'aot_page.c',

--- a/target/i386/latx/sbt/tests/aot-cache-reader-test.c
+++ b/target/i386/latx/sbt/tests/aot-cache-reader-test.c
@@ -3,6 +3,7 @@
 #include <fcntl.h>
 
 #include "aot.h"
+#include "aot_static_layout.h"
 #include "aot_reader.h"
 #include "aot_lib.h"
 #include "file_ctx.h"
@@ -124,6 +125,23 @@ static void remove_cache(const char *name)
     }
 }
 
+static void write_layout_cache(const char *name, char *path)
+{
+    g_autofree char *contents = NULL;
+    gsize size;
+    aot_header *header;
+
+    write_cache(name, true, true, path);
+    g_assert(g_file_get_contents(path, &contents, &size, NULL));
+    g_assert(size >= sizeof(*header));
+    header = (aot_header *)contents;
+    header->layout_line_log2 = 6;
+    header->layout_set_log2 = 8;
+    header->layout_ways = 4;
+    header->layout_magic = AOT_STATIC_LAYOUT_MAGIC;
+    g_assert(g_file_set_contents(path, contents, size, NULL));
+}
+
 int main(void)
 {
     g_autofree char *cache_dir = NULL;
@@ -134,6 +152,7 @@ int main(void)
     char bad_footer_name[] = "bad-footer";
     char truncated_name[] = "truncated";
     char complete_name[] = "complete";
+    char layout_complete_name[] = "layout-complete";
     char fdopen_failure_name[] = "fdopen-failure";
     char cache_path[PATH_MAX];
     void *buffer;
@@ -172,6 +191,16 @@ int main(void)
     g_assert(lib_tree_remove(complete_name));
 
     reset_stream_counts();
+    buffer = NULL;
+    write_layout_cache(layout_complete_name, cache_path);
+    lib = aot_load(lib_name, layout_complete_name, &buffer);
+    g_assert(lib != NULL);
+    g_assert(buffer != NULL);
+    g_assert(aot_static_layout_header_matches(buffer, 64, 256, 4));
+    assert_stream_closed();
+    g_assert(lib_tree_remove(layout_complete_name));
+
+    reset_stream_counts();
     fail_fdopen = true;
     buffer = NULL;
     write_cache(fdopen_failure_name, true, true, cache_path);
@@ -184,6 +213,7 @@ int main(void)
     remove_cache(bad_footer_name);
     remove_cache(truncated_name);
     remove_cache(complete_name);
+    remove_cache(layout_complete_name);
     remove_cache(fdopen_failure_name);
     cache_dir = g_build_filename(test_dir, ".cache", "latx", NULL);
     g_assert(g_rmdir(cache_dir) == 0);

--- a/target/i386/latx/sbt/tests/aot-static-layout-test.c
+++ b/target/i386/latx/sbt/tests/aot-static-layout-test.c
@@ -164,6 +164,8 @@ static void test_static_aot_store(void)
     g_assert(tbs[4].layout_padding_lines == 0);
     g_assert(tbs[5].layout_padding_lines > 0);
     g_assert(tbs[5].layout_padding_lines <= 4);
+    g_assert(tbs[5].layout_component != AOT_LAYOUT_COMPONENT_NONE);
+    g_assert(tbs[5].layout_flags & AOT_LAYOUT_MOVABLE);
 }
 
 static void test_static_stored_padding(void)
@@ -184,6 +186,46 @@ static void test_static_stored_padding(void)
                                               127) == 0);
 }
 
+static void test_static_lazy_placement(void)
+{
+    AOTStaticLazyLayout *layout = aot_static_lazy_layout_new(64, 8, 4, 640);
+
+    g_assert(layout);
+    g_assert(aot_static_lazy_layout_place(layout, 0, false, 0x1000,
+                                          0, 64, SIZE_MAX) == 0);
+    g_assert(aot_static_lazy_layout_place(layout, 0, false, 0x2000,
+                                          0, 64, SIZE_MAX) == 0);
+    g_assert(aot_static_lazy_layout_place(layout, 0, false, 0x3000,
+                                          0, 64, SIZE_MAX) == 0);
+    g_assert(aot_static_lazy_layout_place(layout, 0, false, 0x4000,
+                                          0, 64, SIZE_MAX) == 0);
+    g_assert(aot_static_lazy_layout_place(layout, 0, false, 0x5000,
+                                          0, 64, SIZE_MAX) == 0);
+    g_assert(aot_static_lazy_layout_place(layout, 0, true, 0x6000,
+                                          0, 64, SIZE_MAX) == 64);
+    g_assert(aot_static_lazy_layout_place(layout, 0, true, 0x6000,
+                                          0, 64, SIZE_MAX) == 0);
+    aot_static_lazy_layout_free(layout);
+}
+
+static void test_static_lazy_out_of_order(void)
+{
+    AOTStaticLazyLayout *layout = aot_static_lazy_layout_new(64, 8, 4, 640);
+
+    g_assert(layout);
+    g_assert(aot_static_lazy_layout_place(layout, 7, false, 0x4000,
+                                          0, 64, SIZE_MAX) == 0);
+    g_assert(aot_static_lazy_layout_place(layout, 7, false, 0x1000,
+                                          0, 64, SIZE_MAX) == 0);
+    g_assert(aot_static_lazy_layout_place(layout, 7, false, 0x3000,
+                                          0, 64, SIZE_MAX) == 0);
+    g_assert(aot_static_lazy_layout_place(layout, 7, false, 0x2000,
+                                          0, 64, SIZE_MAX) == 0);
+    g_assert(aot_static_lazy_layout_place(layout, 7, true, 0x5000,
+                                          0, 64, 0) == 0);
+    aot_static_lazy_layout_free(layout);
+}
+
 int main(int argc, char **argv)
 {
     g_test_init(&argc, &argv, NULL);
@@ -199,5 +241,9 @@ int main(int argc, char **argv)
                     test_static_aot_store);
     g_test_add_func("/latx/aot-static-layout/stored-padding",
                     test_static_stored_padding);
+    g_test_add_func("/latx/aot-static-layout/lazy-placement",
+                    test_static_lazy_placement);
+    g_test_add_func("/latx/aot-static-layout/lazy-out-of-order",
+                    test_static_lazy_out_of_order);
     return g_test_run();
 }

--- a/target/i386/latx/sbt/tests/aot-static-layout-test.c
+++ b/target/i386/latx/sbt/tests/aot-static-layout-test.c
@@ -1,0 +1,203 @@
+/*
+ * SPDX-FileCopyrightText: 2021-2026 LAT Project Authors
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#include "qemu/osdep.h"
+
+#include "aot.h"
+#include "aot_static_layout.h"
+#include "exec/exec-all.h"
+
+static void test_static_components(void)
+{
+    AOTStaticLayoutNode nodes[] = {
+        { .guest_pc = 0x1000, .code_size = 64 },
+        { .guest_pc = 0x1100, .code_size = 64 },
+        { .guest_pc = 0x1200, .code_size = 64 },
+        { .guest_pc = 0x1300, .code_size = 64 },
+        { .guest_pc = 0x2000, .code_size = 64 },
+    };
+    AOTStaticLayoutEdge edges[] = {
+        { .from = 0, .to = 1, .kind = AOT_LAYOUT_EDGE_FLOW },
+        { .from = 1, .to = 2, .kind = AOT_LAYOUT_EDGE_FLOW },
+        { .from = 2, .to = 0, .kind = AOT_LAYOUT_EDGE_FLOW },
+        { .from = 1, .to = 4, .kind = AOT_LAYOUT_EDGE_CALL },
+    };
+    uint32_t count = aot_static_layout_find_components(nodes,
+                                                        G_N_ELEMENTS(nodes),
+                                                        edges,
+                                                        G_N_ELEMENTS(edges));
+
+    g_assert(count == 1);
+    g_assert(nodes[0].component == 0);
+    g_assert(nodes[1].component == 0);
+    g_assert(nodes[2].component == 0);
+    g_assert(nodes[3].component == AOT_STATIC_LAYOUT_NO_COMPONENT);
+    g_assert(nodes[4].component == 0);
+}
+
+static void test_static_set_placement(void)
+{
+    AOTStaticLayoutNode nodes[] = {
+        { .code_size = 64, .component = 0 },
+        { .code_size = 64, .component = 0 },
+        { .code_size = 64, .component = 0 },
+        { .code_size = 64, .component = 0 },
+        { .code_size = 64, .component = 0, .can_pad = true },
+        { .code_size = 64000,
+          .component = AOT_STATIC_LAYOUT_NO_COMPONENT },
+    };
+    AOTStaticLayout *layout = aot_static_layout_new(nodes,
+                                                     G_N_ELEMENTS(nodes),
+                                                     1, 64, 8, 4);
+
+    g_assert(layout);
+    for (uint32_t i = 0; i < 4; i++) {
+        g_assert(aot_static_layout_place(layout, i, 0, SIZE_MAX) == 0);
+    }
+    g_assert(aot_static_layout_place(layout, 4, 0, SIZE_MAX) == 64);
+    g_assert(aot_static_layout_cost(layout, 0) == 0);
+    g_assert(aot_static_layout_padding_used(layout) == 64);
+    g_assert(aot_static_layout_place(layout, 4, 0, SIZE_MAX) == 0);
+    aot_static_layout_free(layout);
+}
+
+static void test_static_budget(void)
+{
+    AOTStaticLayoutNode nodes[9] = { 0 };
+    AOTStaticLayout *layout;
+
+    for (uint32_t i = 0; i < 8; i++) {
+        nodes[i].code_size = 64;
+        nodes[i].component = 0;
+        nodes[i].can_pad = true;
+    }
+    nodes[8].code_size = 64000;
+    nodes[8].component = AOT_STATIC_LAYOUT_NO_COMPONENT;
+    layout = aot_static_layout_new(nodes, G_N_ELEMENTS(nodes), 1, 64, 8, 4);
+
+    for (uint32_t i = 0; i < 8; i++) {
+        aot_static_layout_place(layout, i, 0, SIZE_MAX);
+    }
+    g_assert(aot_static_layout_padding_used(layout) <= 640);
+    aot_static_layout_free(layout);
+}
+
+static void test_static_unavailable_padding(void)
+{
+    AOTStaticLayoutNode nodes[] = {
+        { .code_size = 64, .component = 0 },
+        { .code_size = 64, .component = 0 },
+        { .code_size = 64, .component = 0 },
+        { .code_size = 64, .component = 0 },
+        { .code_size = 64, .component = 0, .can_pad = true },
+        { .code_size = 64000,
+          .component = AOT_STATIC_LAYOUT_NO_COMPONENT },
+    };
+    AOTStaticLayout *layout = aot_static_layout_new(nodes,
+                                                     G_N_ELEMENTS(nodes),
+                                                     1, 64, 8, 4);
+
+    for (uint32_t i = 0; i < 4; i++) {
+        aot_static_layout_place(layout, i, 0, SIZE_MAX);
+    }
+    g_assert(aot_static_layout_place(layout, 4, 0, 0) == 0);
+    g_assert(aot_static_layout_cost(layout, 0) == 1);
+    g_assert(aot_static_layout_padding_used(layout) == 0);
+    aot_static_layout_free(layout);
+}
+
+static void init_aot_tb(aot_tb *tb, target_ulong guest, uint32_t tu_id,
+                        uint32_t code_size)
+{
+    memset(tb, 0, sizeof(*tb));
+    tb->offset_in_segment = guest;
+    tb->tu_id = tu_id;
+    tb->size = 16;
+    tb->next_tb_pc_offset = -1;
+    tb->target_tb_pc_offset = -1;
+    tb->tu_size = code_size;
+}
+
+static void test_static_aot_store(void)
+{
+    const target_ulong base = 0x400000;
+    const uint32_t line_size = 64;
+    const uint32_t cycle_size = 64 * 256;
+    const uint32_t tb_alloc_size = ROUND_UP(sizeof(TranslationBlock),
+                                            line_size);
+    const uint32_t code_size = cycle_size - tb_alloc_size - line_size;
+    aot_segment segment = {
+        .details.seg_begin = base,
+        .details.seg_end = base + 0x1000,
+        .segment_tbs_num = 6,
+    };
+    aot_tb tbs[6];
+
+    init_aot_tb(&tbs[0], 0x000, base + 0x000, code_size);
+    init_aot_tb(&tbs[1], 0x010, base + 0x000, 0);
+    init_aot_tb(&tbs[2], 0x100, base + 0x100, code_size);
+    init_aot_tb(&tbs[3], 0x200, base + 0x200, code_size);
+    init_aot_tb(&tbs[4], 0x300, base + 0x300, code_size);
+    init_aot_tb(&tbs[5], 0x400, base + 0x400, code_size);
+
+    tbs[0].last_ir1_type = IR1_TYPE_BRANCH;
+    tbs[0].target_tb_pc_offset = 0x100;
+    tbs[1].last_ir1_type = IR1_TYPE_CALL;
+    tbs[1].target_tb_pc_offset = 0x400;
+    tbs[2].last_ir1_type = IR1_TYPE_BRANCH;
+    tbs[2].target_tb_pc_offset = 0x200;
+    tbs[3].last_ir1_type = IR1_TYPE_BRANCH;
+    tbs[3].target_tb_pc_offset = 0x300;
+    tbs[4].last_ir1_type = IR1_TYPE_BRANCH;
+    tbs[4].target_tb_pc_offset = 0x400;
+    tbs[5].last_ir1_type = IR1_TYPE_BRANCH;
+    tbs[5].target_tb_pc_offset = 0x000;
+
+    g_assert(aot_static_layout_store(&segment, tbs, 0, base,
+                                     line_size, 256, 4));
+    g_assert(tbs[0].layout_padding_lines == 0);
+    g_assert(tbs[2].layout_padding_lines == 0);
+    g_assert(tbs[3].layout_padding_lines == 0);
+    g_assert(tbs[4].layout_padding_lines == 0);
+    g_assert(tbs[5].layout_padding_lines > 0);
+    g_assert(tbs[5].layout_padding_lines <= 4);
+}
+
+static void test_static_stored_padding(void)
+{
+    aot_header header = {
+        .layout_line_log2 = 6,
+        .layout_set_log2 = 8,
+        .layout_ways = 4,
+        .layout_magic = AOT_STATIC_LAYOUT_MAGIC,
+    };
+    aot_tb tb = { .layout_padding_lines = 2 };
+
+    g_assert(aot_static_layout_header_matches(&header, 64, 256, 4));
+    g_assert(!aot_static_layout_header_matches(&header, 64, 256, 8));
+    g_assert(aot_static_layout_stored_padding(&header, &tb, 64, 256, 4,
+                                              128) == 128);
+    g_assert(aot_static_layout_stored_padding(&header, &tb, 64, 256, 4,
+                                              127) == 0);
+}
+
+int main(int argc, char **argv)
+{
+    g_test_init(&argc, &argv, NULL);
+    g_test_add_func("/latx/aot-static-layout/components",
+                    test_static_components);
+    g_test_add_func("/latx/aot-static-layout/set-placement",
+                    test_static_set_placement);
+    g_test_add_func("/latx/aot-static-layout/budget",
+                    test_static_budget);
+    g_test_add_func("/latx/aot-static-layout/unavailable-padding",
+                    test_static_unavailable_padding);
+    g_test_add_func("/latx/aot-static-layout/aot-store",
+                    test_static_aot_store);
+    g_test_add_func("/latx/aot-static-layout/stored-padding",
+                    test_static_stored_padding);
+    return g_test_run();
+}


### PR DESCRIPTION
## Background

This work started from an unexpected result in the EFLAGS optimization effort: the translator emitted fewer LoongArch instructions, but several SPECint workloads did not become faster and some became slower. Since the translated instruction count had already decreased, we treated the remaining regression as a separate code-fetch and layout problem instead of concluding that EFLAGS elimination had no value.

PMU measurements showed that performance could change significantly when the generated LoongArch code moved in the AOT code buffer, even when the instruction sequence and count remained effectively unchanged. This drew attention to L1 instruction-cache set conflicts.

The validation host is a Loongson 3A6000 with a 64 KiB, 4-way L1I, 64-byte lines, and 256 sets. Its set-index cycle is 16 KiB and a line maps approximately as:

```c
set = (host_address / 64) % 256;
```

## Analysis of the existing layout

We compared the x86 ELF layout with AOT=2 LoongArch addresses for all 12 SPEC CPU2000 integer workloads:

```text
ELF functions:                       28,758
Functions represented in AOT:        5,602
Guest TU order inversions:                0
ELF cold functions/fragments:         1,167
Cold functions represented in AOT:        1
```

The existing AOT implementation already preserves guest TU order and naturally excludes nearly all compiler-marked cold code. The main lost property was larger address alignment: 16/32/64-byte alignment was preserved at 99.1%/98.6%/97.7%, while 512-byte alignment was preserved at 10.5% and 2/4 KiB alignment at 0%.

An early experiment restored 512-byte to 4 KiB boundaries for direct-call targets and improved SPECint. Causal ablations showed that the boundary itself was not beneficial: the original functions had at most 15 bytes of preceding padding, exact-512-only and 4-KiB-only variants regressed, and delaying padding to the following TU kept most of the gain even though the call target was no longer aligned. Sampling showed that downstream ordinary TUs, not the aligned entries, accounted for most saved misses. Sparse padding was changing the relative L1I-set placement of hot code groups.

## Summary

- build a static TU control-flow graph while storing an AOT cache
- identify loop working sets with strongly connected components and include their direct callees
- model the host L1I geometry from sysfs and minimize predicted set overflow
- add at most `ways * cacheline` bytes before safe direct-CALL entries, under a 1% per-segment padding budget
- persist the chosen padding and cache geometry in existing AOT metadata space
- apply the stored fixed plan in O(1) per movable entry during AOT=2 loading
- reuse stored component IDs during default AOT=1 lazy loading and score only five bounded placements against the pages already loaded by that thread
- keep page, TU, and TB order unchanged while supporting both AOT=2 and the default AOT=1

The feature is experimental, defaults off, and has one `LATX_AOT_STATIC_LAYOUT=0/1` switch.

## Rationale

The previous guest-address-alignment experiment improved SPECint, but causal ablations showed that 512-byte or 4KB guest alignment was not itself beneficial. Its padding happened to change downstream LoongArch code placement across L1I sets. This version replaces the guest-address proxy with an explicit static set-pressure model.

Only direct-CALL targets may receive padding. Allowing padding before arbitrary TUs caused a real vortex wait-path failure because the current AOT recovery path has implicit layout constraints at ordinary TU boundaries.

## Results

Loongson 3A6000, AOT=2, SPEC CPU2000 integer train, three-run medians, latest master `3de0d400f51`:

| Benchmark | Runtime change |
|---|---:|
| gzip | +0.482% |
| vpr | -0.141% |
| gcc | +0.362% |
| mcf | -0.006% |
| crafty | -0.522% |
| parser | -0.383% |
| eon | -1.788% |
| perlbmk | -0.436% |
| gap | -0.995% |
| vortex | -0.726% |
| bzip2 | -0.072% |
| twolf | -0.142% |

Geometric mean runtime: **-0.366%**. All 12 benchmarks passed.

Default AOT=1, same candidate binary and byte-identical AOT caches, switch off/on:

- geometric mean runtime: **-0.130%**
- summed runtime: approximately neutral (+0.049%)
- gap -2.54%, vortex -1.64%, twolf -1.01%
- eon +1.47%, crafty +0.85%, gcc +0.49%
- all 12 benchmarks passed

The AOT=1 path keeps per-thread, per-segment, per-CF_PARALLEL set pressure and clears it when the global TB flush count changes. Padding is restricted to direct-CALL entries, the same 1% stored budget, and 0-`ways` cache lines. Its score includes both set overflow and the number of added cache lines.

Default AOT=1 held-out SQLite, same binary and byte-identical caches, seven alternating off/on runs:

- median cycles about **-1.15%** in the final three-pair confirmation (an earlier seven-pair run was -1.43%)
- L1I misses about **-9.8%**
- host instruction overhead about **+0.08%**
- outputs matched exactly

Held-out official SQLite 3.53.4 x86_64 workloads, not used to tune the algorithm:

- 300,000-row in-memory SQL workload: median cycles about **-1.21%**
- 20 repeated `sqlite3_analyzer` runs: median cycles about **-0.95%**
- outputs matched master exactly

A deterministic random-padding control used the same safe boundaries, maximum padding, and global budget. In seven same-period alternating SQLite runs, the scored layout was about **2.17% faster** than the random layout with essentially identical host instruction counts.

The hardware evidence is mixed across programs: vortex reduced L1I misses, while SQLite improved cycles even when aggregate L1I misses did not. The PR therefore remains draft and does not claim that L1I set conflicts are the only layout-sensitive effect; branch-predictor and iTLB interactions remain follow-up work.

## Validation

- full incremental `ninja` build on LoongArch
- external static-layout validation harness: 8/8 pass
- `latx-aot-cache-reader`: pass, including disk write/mmap header round trip
- `latx-aot-file-publish`: pass
- `latx-aot-pe-load-address`: pass
- final-format AOT caches recorded 64-byte lines, 256 sets, 4 ways and the layout magic
- `LATX_AOT_STATIC_LAYOUT=2` exits with an error
- AOT=1 off/on use byte-identical caches and produce identical output
- `git diff --check`: pass
- checkpatch: 0 errors; only generic MAINTAINERS warnings for new files

## Known limitations

- existing AOT caches must be regenerated to contain a layout plan; normal committed builds already invalidate old caches through `AOT_VERSION`
- missing or mismatched host cache geometry disables the layout plan
- if highwater prevents one planned padding, the rest of that segment's plan is disabled to avoid applying a shifted partial plan
- the static model currently covers loop SCCs and their direct callees; it does not model indirect-call targets or branch-predictor indexing
- AOT=1 is positive in geometric mean but has benchmark-level regressions and remains experimental/default-off
- the feature remains default-off

## Configuration

```bash
LATX_AOT_STATIC_LAYOUT=0  # disabled, default
LATX_AOT_STATIC_LAYOUT=1  # enabled
```

---

## 背景

这项工作起源于EFLAGS优化中的一个反常结果：翻译器生成了更少的LoongArch指令，但部分SPECint程序没有变快，个别程序反而变慢。既然翻译指令数已经下降，我们没有据此否定EFLAGS消除，而是把剩余退化作为独立的取指和代码布局问题继续分析。

PMU测量显示，即使LoongArch指令序列和数量基本不变，只要代码在AOT code buffer中的位置改变，性能就可能明显变化，因此我们开始关注L1指令缓存set冲突。

验证机器Loongson 3A6000的L1I为64 KiB、4路、64字节cacheline、256个set，set索引周期为16 KiB：

```c
set = (host_address / 64) % 256;
```

## 对现有AOT布局的分析

我们比较了12个SPEC CPU2000 integer程序的x86 ELF布局和AOT=2恢复后的LoongArch地址：

```text
ELF函数总数：                    28,758
进入AOT的函数：                  5,602
Guest TU顺序逆转：                    0
ELF cold函数或片段：              1,167
进入AOT的cold函数或片段：             1
```

现有AOT已经保持guest TU顺序，并通过只缓存实际翻译代码自然过滤掉绝大多数cold代码。主要丢失的是较大的地址边界：16/32/64字节对齐分别保留99.1%/98.6%/97.7%，512字节只保留10.5%，2/4 KiB为0%。

早期实验恢复直接CALL目标的512字节到4 KiB边界后SPECint出现正收益，但因果消融证明边界本身不是原因：原函数前最多只有15字节填充，只处理exact-512或4 KiB都会退化，把padding延迟到下一个TU仍能保留大部分收益。采样显示减少miss的主要是后续普通TU，而不是被对齐的入口。真正的作用是稀疏padding改变了多个热点代码组之间的L1I set映射。

## 方案

AOT存储阶段利用已有TB元数据构造TU控制流图，通过强连通分量识别静态循环，并把循环及其直接callee作为静态工作集合。算法不依赖ELF符号，因此stripped程序也可以使用。

存储时已知最终LoongArch `tu_size`。每个组件维护256项set压力，代价为：

```c
overflow = max(0, resident_lines - associativity);
cost += overflow * overflow;
```

只有直接CALL目标允许padding。任意TU边界padding曾使vortex进入错误等待路径，说明普通TU边界仍有隐含布局约束。候选固定为0到`ways`条cacheline，在3A6000上是0、64、128、192、256字节；每个segment总预算为LoongArch AOT代码尺寸的1%。AOT=1评分还加入新增cacheline数量，避免为很小的冲突收益扩大代码跨度。

AOT文件保存L1I结构、布局magic、每段预算、每个TU的组件ID、安全CALL入口标志和AOT=2固定padding。

### AOT=2

AOT=2按固定顺序整段恢复，加载时只检查L1I结构、读取padding、检查highwater并应用，每个入口O(1)。某次计划padding无法应用时，停用该segment剩余计划，避免部分计划错位。

### AOT=1

AOT=1是默认模式，每次按需加载连续四页，不能复用AOT=2固定序列。它读取存储的静态组件ID，按线程、segment和`CF_PARALLEL`维护已加载代码的set压力。普通TU只登记footprint，安全CALL入口只评估五个有界位置；状态查询复用于整个四页批次，TB flush计数变化时清空，同一TU不会重复登记。

这属于运行时布局而不是运行时profile：只记录静态选中的代码已放在什么位置，不记录执行次数。

## 性能

以下负数表示更快。

### AOT=2 SPEC CPU2000 integer train

| Benchmark | 运行时间变化 |
|---|---:|
| gzip | +0.482% |
| vpr | -0.141% |
| gcc | +0.362% |
| mcf | -0.006% |
| crafty | -0.522% |
| parser | -0.383% |
| eon | -1.788% |
| perlbmk | -0.436% |
| gap | -0.995% |
| vortex | -0.726% |
| bzip2 | -0.072% |
| twolf | -0.142% |

```text
几何平均： -0.366%
总时间：   -0.260%
正确性：   12/12通过
```

### AOT=1 SPEC CPU2000 integer train

相同候选二进制、字节完全一致的AOT文件，只切换布局开关：

| Benchmark | 运行时间变化 |
|---|---:|
| gzip | -0.121% |
| vpr | +0.321% |
| gcc | +0.492% |
| mcf | +0.142% |
| crafty | +0.853% |
| parser | +0.330% |
| eon | +1.472% |
| perlbmk | +0.483% |
| gap | -2.539% |
| vortex | -1.637% |
| bzip2 | -0.282% |
| twolf | -1.008% |

```text
几何平均： -0.130%
总时间：   +0.049%，基本持平
正确性：   12/12通过
```

### Held-out SQLite

官方SQLite 3.53.4 Linux x86_64工具未参与算法设计或参数选择，A/B输出哈希一致：

```text
AOT=2 30万行内存数据库：      cycles约-1.21%
AOT=2 20次sqlite3_analyzer：  cycles约-0.95%
AOT=1 30万行内存数据库：      cycles约-1.15%（之前7组为-1.43%）
AOT=1 L1I miss：              约-9.8%
AOT=1 host指令开销：          约+0.08%
```

### 随机padding否证

固定种子随机对照使用相同安全入口、最大padding和1%预算，但不使用set评分。同一时段7组SQLite交替中，评分方案cycles中位数约3.355B，随机方案约3.429B，评分方案快约2.17%，host指令数一致。这说明收益不能只用任意padding解释。

## 验证

- LoongArch完整增量`ninja`构建；
- 现有AOT文件发布、cache reader和PE load-address测试；
- 外部harness覆盖静态图、SCC、set压力、预算、highwater、持久化元数据、lazy placement、重复placement和页面乱序加载，8/8通过；
- AOT元数据写入和mmap回读；
- 新格式缓存执行AOT=1和AOT=2；
- 两种模式均完成off/on和SPECint正确性；
- SQLite输出哈希和随机padding否证；
- `git diff --check`及产品提交checkpatch。

## 配置

```bash
LATX_AOT_STATIC_LAYOUT=0  # 关闭，默认
LATX_AOT_STATIC_LAYOUT=1  # 开启
```

## 已知限制

- 静态模型覆盖循环SCC和直接callee，不预测间接CALL目标。
- L1I miss不能解释全部运行时间变化，布局还可能影响BTB、分支历史索引、iTLB和前端时序。
- AOT=1几何平均略有正收益，但存在单项退化，暂不适合默认开启。
- Lazy状态按线程维护，其他翻译线程放置的代码不会进入当前线程组件压力。
- SMC reload复用原TB地址；TB flush会清空状态。长期线程中已卸载segment对应TLS状态仍是后续清理方向。
- 无法读取host cache结构或结构不匹配时忽略计划。
- 只有直接CALL目标允许padding，任意TU边界目前不是安全位置。
