### PR TITLE
latx: add opt-in Quicktrans fast translator

### DIFF
--- a/accel/tcg/cpu-exec.c
+++ b/accel/tcg/cpu-exec.c
@@ -276,15 +276,29 @@ cpu_tb_exec(CPUState *cpu, TranslationBlock *itb, int *tb_exit)
     if (rettb) {
         uint64_t lazypc = 0;
         if (tbexit) {
+#ifdef CONFIG_LATX_FAST_TRANSLATOR
+            if (!latx_tb_exit_resolve_pc(rettb->canlink[1], rettb->pc,
+                                         rettb->lazypc[1], &lazypc)) {
+                goto latx_skip_lazypc_update;
+            }
+#else
+            lazypc = rettb->pc + rettb->lazypc[1];
+#endif
             if (rettb->canlink[1]) {
                 ret |= (uint64_t)rettb;
             }
-            lazypc = rettb->pc + rettb->lazypc[1];
         } else {
+#ifdef CONFIG_LATX_FAST_TRANSLATOR
+            if (!latx_tb_exit_resolve_pc(rettb->canlink[0], rettb->pc,
+                                         rettb->lazypc[0], &lazypc)) {
+                goto latx_skip_lazypc_update;
+            }
+#else
+            lazypc = rettb->pc + rettb->lazypc[0];
+#endif
             if (rettb->canlink[0]) {
                 ret |= (uint64_t)rettb;
             }
-            lazypc = rettb->pc + rettb->lazypc[0];
 #if defined(CONFIG_LATX_KZT)
             if (latx_kzt_runtime_enabled() && lazypc >= reserved_va) {
                 uintptr_t alt_pc = (uintptr_t)getAlternate((void *)(uintptr_t)lazypc);
@@ -295,6 +309,10 @@ cpu_tb_exec(CPUState *cpu, TranslationBlock *itb, int *tb_exit)
 #endif
         }
         env->eip = lazypc;
+#ifdef CONFIG_LATX_FAST_TRANSLATOR
+latx_skip_lazypc_update:
+        ;
+#endif
     }
 
 #ifdef CONFIG_LATX_MONITOR_SHARED_MEM

--- a/accel/tcg/translate-all.c
+++ b/accel/tcg/translate-all.c
@@ -481,7 +481,9 @@ static int cpu_restore_state_from_tb(CPUState *cpu, TranslationBlock *tb,
     }
 #endif
 #ifdef CONFIG_LATX_INSTS_PATTERN
-    opt_instptn_fix(cpu, tb, i);
+    if (tb->s_data && tb->s_data->ir1) {
+        opt_instptn_fix(cpu, tb, i);
+    }
 #endif
 #ifdef CONFIG_PROFILER
     qatomic_set(&prof->restore_time,

--- a/accel/tcg/translate-all.c
+++ b/accel/tcg/translate-all.c
@@ -3128,6 +3128,36 @@ int walk_memory_regions(void *priv, walk_memory_regions_fn fn)
     return rc;
 }
 
+int walk_memory_regions_range_locked(void *priv, target_ulong start,
+                                     target_ulong end,
+                                     walk_memory_regions_fn fn)
+{
+    PageFlagsNode *p;
+    target_ulong last;
+    int rc = 0;
+
+    assert_memory_lock();
+    if (start >= end) {
+        return 0;
+    }
+
+    last = end - 1;
+    for (p = pageflags_find(start, last);
+         p != NULL;
+         p = pageflags_next(p, start, last)) {
+        target_ulong region_start = MAX(start, p->itree.start);
+        target_ulong region_end = p->itree.last >= last
+                                  ? end : p->itree.last + 1;
+
+        rc = fn(priv, region_start, region_end, p->flags);
+        if (rc != 0) {
+            break;
+        }
+    }
+
+    return rc;
+}
+
 static int dump_region(void *priv, target_ulong start,
                        target_ulong end, unsigned long prot)
 {

--- a/configure
+++ b/configure
@@ -373,6 +373,7 @@ latx_kzt="no"
 latx_new_world="no"
 latx_profiler="no"
 latx_perf="no"
+latx_fast_translator="no"
 latx_superblock="no"
 latx_tunnel_lib="no"
 latx_flag_reduction="no"
@@ -1187,6 +1188,8 @@ for opt do
   ;;
   --enable-latx-perf) latx_perf="yes"
   ;;
+  --enable-latx-fast-translator) latx_fast_translator="yes"
+  ;;
   --enable-latx-superblock) latx_superblock="yes"
   ;;
   --enable-latx-insts-pattern) latx_insts_pattern="yes"
@@ -1978,6 +1981,8 @@ Optional only for LATX:
   --optimize-O3           Open testing optimization
   ====== Profiler Optional ======
   --enable-latx-profiler  enable profiler and print when process exit
+  --enable-latx-fast-translator
+                          compile the Quicktrans fast translation path
 
 Optional features, enabled with --enable-FEATURE and
 disabled with --disable-FEATURE, default is enabled if available
@@ -5575,6 +5580,10 @@ if test "$cpu" = "s390x" ; then
   fi
 fi
 
+if test "$latx_fast_translator" = "yes"; then
+    git_submodules="${git_submodules} target/i386/latx/quicktrans"
+fi
+
 # Check that the C++ compiler exists and works with the C compiler.
 # All the QEMU_CXXFLAGS are based on QEMU_CFLAGS. Keep this at the end to don't miss any other that could be added.
 if has $cxx; then
@@ -5685,6 +5694,9 @@ if test "$latx" = "yes" ; then
     echo "CONFIG_LATX_KZT=y" >> $config_host_mak
   fi
   echo "CONFIG_LATX=y" >> $config_host_mak
+  if test "$latx_fast_translator" = "yes" ; then
+    echo "CONFIG_LATX_FAST_TRANSLATOR=y" >> $config_host_mak
+  fi
   if test "$debug" = "yes" ; then
     echo "CONFIG_LATX_DEBUG=y" >> $config_host_mak
   else

--- a/include/exec/cpu-all.h
+++ b/include/exec/cpu-all.h
@@ -286,6 +286,12 @@ typedef int (*walk_memory_regions_fn)(void *, target_ulong,
                                       target_ulong, unsigned long);
 int walk_memory_regions(void *, walk_memory_regions_fn);
 
+/*
+ * Walk mapped regions overlapping [start, end).  The mmap lock must be held.
+ */
+int walk_memory_regions_range_locked(void *, target_ulong, target_ulong,
+                                     walk_memory_regions_fn);
+
 bool test_flags(target_ulong address, int flags);
 target_ulong get_first_page(target_ulong start, target_ulong end);
 int page_get_flags(target_ulong address);

--- a/include/exec/exec-all.h
+++ b/include/exec/exec-all.h
@@ -26,6 +26,9 @@
 #include "cpu.h"
 #ifdef CONFIG_LATX
 #include "optimize-config.h"
+#ifdef CONFIG_LATX_FAST_TRANSLATOR
+#include "exec/latx-tb-exit.h"
+#endif
 #endif
 #include "exec/tb-context.h"
 #ifdef CONFIG_TCG

--- a/include/exec/latx-tb-exit.h
+++ b/include/exec/latx-tb-exit.h
@@ -1,0 +1,24 @@
+/*
+ * LATX translated block exit state helpers.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#ifndef EXEC_LATX_TB_EXIT_H
+#define EXEC_LATX_TB_EXIT_H
+
+#define LATX_CANLINK_EIP_STORED (-1)
+
+static inline bool latx_tb_exit_resolve_pc(int8_t canlink, uint64_t tb_pc,
+                                           int64_t lazypc,
+                                           uint64_t *next_pc)
+{
+    if (canlink == LATX_CANLINK_EIP_STORED) {
+        return false;
+    }
+
+    *next_pc = tb_pc + lazypc;
+    return true;
+}
+
+#endif /* EXEC_LATX_TB_EXIT_H */

--- a/latxbuild/build64.sh
+++ b/latxbuild/build64.sh
@@ -5,6 +5,7 @@ make_configure=0
 opt_level=1
 low_mem_mode=""
 avx_support=""
+fast_translator=""
 
 help() {
     echo "Usage:"
@@ -20,11 +21,12 @@ help() {
     echo "                  -l 1 : l0 + close CONFIG_LATX_SPLIT_TB, CONFIG_LATX_TU, CONFIG_LATX_JRRA"
     echo "                  -l 2 : l1 + set 64MB code cache, close CONFIG_LATX_INSTS_PATTERN"
     echo "  -a              AVX Instruction Translation Support"
+    echo "  -f              compile the Quicktrans fast translation path"
     echo "  -h              help"
 }
 
 parseArgs() {
-    while getopts "cO:l:h,a" opt; do
+    while getopts "cO:l:h,af" opt; do
         case ${opt} in
         c)
             make_configure=1
@@ -37,6 +39,9 @@ parseArgs() {
             ;;
         a)
             avx_support="--enable-latx-avx-opt"
+            ;;
+        f)
+            fast_translator="--enable-latx-fast-translator"
             ;;
         h)
             help
@@ -68,19 +73,19 @@ make_cmd() {
         if [ "$opt_level" = "0" ] ; then
             ../configure --target-list=x86_64-linux-user --enable-latx \
                 --disable-debug-info --optimize-O0 --static --extra-ldflags=-ldl \
-                --disable-docs ${low_mem_mode} ${avx_support}
+                --disable-docs ${low_mem_mode} ${avx_support} ${fast_translator}
         elif [ "$opt_level" = "1" ] ; then
             ../configure --target-list=x86_64-linux-user --enable-latx \
                 --disable-debug-info --optimize-O1 --extra-ldflags=-ldl --enable-kzt \
-                --disable-docs ${low_mem_mode} ${avx_support}
+                --disable-docs ${low_mem_mode} ${avx_support} ${fast_translator}
         elif [ "$opt_level" = "2" ] ; then
             ../configure --target-list=x86_64-linux-user --enable-latx \
                 --disable-debug-info --optimize-O2 --static --extra-ldflags=-ldl \
-                --disable-docs ${low_mem_mode} ${avx_support}
+                --disable-docs ${low_mem_mode} ${avx_support} ${fast_translator}
         elif [ "$opt_level" = "3" ] ; then
             ../configure --target-list=x86_64-linux-user --enable-latx \
                 --disable-debug-info --optimize-O3 --static --extra-ldflags=-ldl \
-                --disable-docs ${low_mem_mode} ${avx_support}
+                --disable-docs ${low_mem_mode} ${avx_support} ${fast_translator}
         else
             echo "invalid options"
         fi

--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -14157,6 +14157,59 @@ static abi_long do_prctl_futex_hash(CPUArchState *env, abi_ulong operation,
     }
 }
 
+typedef struct PrctlSetVmaData {
+    const char *name;
+    abi_ulong end;
+    abi_ulong next;
+    abi_ulong anon_start;
+    bool in_anon;
+    bool stopped;
+    abi_long ret;
+} PrctlSetVmaData;
+
+static void prctl_set_vma_flush_anon(PrctlSetVmaData *data, abi_ulong end)
+{
+    if (data->in_anon) {
+        guest_vma_name_apply_locked(data->anon_start, end, data->name);
+        data->in_anon = false;
+    }
+}
+
+static int prctl_set_vma_region(void *opaque, target_ulong start,
+                                target_ulong end, unsigned long flags)
+{
+    PrctlSetVmaData *data = opaque;
+
+    if (data->next < start) {
+        prctl_set_vma_flush_anon(data, data->next);
+        data->ret = -TARGET_ENOMEM;
+        data->next = start;
+    }
+
+    if ((flags & (PAGE_VALID | PAGE_ANON)) ==
+        (PAGE_VALID | PAGE_ANON)) {
+        if (!data->in_anon) {
+            data->anon_start = start;
+            data->in_anon = true;
+        }
+    } else {
+        prctl_set_vma_flush_anon(data, start);
+        if (flags & PAGE_VALID) {
+            data->ret = -TARGET_EBADF;
+            data->stopped = true;
+            return 1;
+        }
+        data->ret = -TARGET_ENOMEM;
+    }
+
+    data->next = end;
+    if (end == data->end) {
+        prctl_set_vma_flush_anon(data, end);
+        return 1;
+    }
+    return 0;
+}
+
 static abi_long do_prctl_set_vma(abi_ulong operation, abi_ulong start,
                                  abi_ulong len,
                                  abi_ulong name_addr)
@@ -14165,10 +14218,7 @@ static abi_long do_prctl_set_vma(abi_ulong operation, abi_ulong start,
     const char *name = NULL;
     abi_ulong rounded_len;
     abi_ulong end;
-    abi_ulong addr;
-    abi_ulong anon_start = 0;
-    bool in_anon = false;
-    abi_long ret;
+    PrctlSetVmaData data;
     size_t name_len;
 
     if (operation != PR_SET_VMA_ANON_NAME) {
@@ -14205,35 +14255,21 @@ static abi_long do_prctl_set_vma(abi_ulong operation, abi_ulong start,
         return 0;
     }
     end = start + rounded_len;
-    ret = 0;
+    data = (PrctlSetVmaData) {
+        .name = name,
+        .end = end,
+        .next = start,
+    };
 
     mmap_lock();
-    for (addr = start; addr < end; addr += TARGET_PAGE_SIZE) {
-        int flags = page_get_flags(addr);
-
-        if ((flags & (PAGE_VALID | PAGE_ANON)) ==
-            (PAGE_VALID | PAGE_ANON)) {
-            if (!in_anon) {
-                anon_start = addr;
-                in_anon = true;
-            }
-            continue;
-        }
-        if (in_anon) {
-            guest_vma_name_apply_locked(anon_start, addr, name);
-            in_anon = false;
-        }
-        if (flags & PAGE_VALID) {
-            ret = -TARGET_EBADF;
-            break;
-        }
-        ret = -TARGET_ENOMEM;
-    }
-    if (in_anon) {
-        guest_vma_name_apply_locked(anon_start, addr, name);
+    walk_memory_regions_range_locked(&data, start, end,
+                                     prctl_set_vma_region);
+    if (!data.stopped && data.next < end) {
+        prctl_set_vma_flush_anon(&data, data.next);
+        data.ret = -TARGET_ENOMEM;
     }
     mmap_unlock();
-    return ret;
+    return data.ret;
 }
 
 /* Called with the linux-user mmap lock held. */

--- a/meson.build
+++ b/meson.build
@@ -568,6 +568,25 @@ foreach target : target_dirs
   arch_srcs += t.sources()
   arch_deps += t.dependencies()
 
+  if 'CONFIG_LATX_FAST_TRANSLATOR' in config_host and \
+     target == 'x86_64-linux-user'
+    quicktrans_latx_library = static_library(
+      'quicktrans_latx_' + target,
+      quicktrans_latx_library_sources + [syscall_nr_generated] + genh,
+      build_by_default: false,
+      c_args: c_args + quicktrans_latx_c_args + [
+        '-DQUICKTRANS_ENABLE_LEGACY_LATX_TRANSLATOR',
+        '-DQUICKTRANS_LATU',
+        '-include', 'target/i386/latx/include/quicktrans-host-compat.h',
+      ],
+      include_directories: target_inc + quicktrans_latx_include_directories,
+    )
+    arch_deps += declare_dependency(
+      link_with: quicktrans_latx_library,
+      include_directories: quicktrans_latx_include_directories,
+    )
+  endif
+
   target_common = common_ss.apply(config_target, strict: false)
   objects = common_all.extract_objects(target_common.sources())
   deps = target_common.dependencies()

--- a/target/i386/latx/include/latx-static-codes.h
+++ b/target/i386/latx/include/latx-static-codes.h
@@ -1,0 +1,12 @@
+/*
+ * Compatibility surface for Quicktrans on this single-context LATX host.
+ */
+#ifndef LATX_STATIC_CODES_H
+#define LATX_STATIC_CODES_H
+
+#include "translate.h"
+
+/* This host has one native-to-BT return-0 entry, not a per-context table. */
+#define GET_SC_TABLE(_mtcc_id, _entry) (context_switch_native_to_bt_ret_0)
+
+#endif

--- a/target/i386/latx/include/qemu/cacheinfo.h
+++ b/target/i386/latx/include/qemu/cacheinfo.h
@@ -1,0 +1,7 @@
+/* Compatibility header for Quicktrans sources from newer QEMU trees. */
+#ifndef QEMU_CACHEINFO_H
+#define QEMU_CACHEINFO_H
+
+#include "exec/cpu-all.h"
+
+#endif

--- a/target/i386/latx/include/quicktrans-host-compat.h
+++ b/target/i386/latx/include/quicktrans-host-compat.h
@@ -1,0 +1,8 @@
+/* Compatibility contract for the pre-extraction LATX host ABI. */
+#ifndef LATX_QUICKTRANS_HOST_COMPAT_H
+#define LATX_QUICKTRANS_HOST_COMPAT_H
+
+/* The host option predates Quicktrans' spelling. */
+#define option_soft_fpu option_softfpu
+
+#endif

--- a/target/i386/latx/include/tcg/insn-start-words.h
+++ b/target/i386/latx/include/tcg/insn-start-words.h
@@ -1,0 +1,7 @@
+/* Compatibility header for Quicktrans sources from newer QEMU trees. */
+#ifndef LATX_QUICKTRANS_INSN_START_WORDS_H
+#define LATX_QUICKTRANS_INSN_START_WORDS_H
+
+#include "tcg/tcg.h"
+
+#endif

--- a/target/i386/latx/include/tcg/tcg-internal.h
+++ b/target/i386/latx/include/tcg/tcg-internal.h
@@ -1,0 +1,7 @@
+/* Compatibility header for Quicktrans sources from newer QEMU trees. */
+#ifndef LATX_QUICKTRANS_TCG_INTERNAL_H
+#define LATX_QUICKTRANS_TCG_INTERNAL_H
+
+#include "tcg/tcg.h"
+
+#endif

--- a/target/i386/latx/include/translate.h
+++ b/target/i386/latx/include/translate.h
@@ -1696,6 +1696,11 @@ void generate_xcomisx(IR2_OPND, IR2_OPND, bool, bool, uint8_t);
 
 void tr_generate_exit_tb(IR1_INST *branch, int succ_id);
 void tr_generate_exit_tb_to_next(IR1_INST *ir1);
+#ifdef CONFIG_LATX_FAST_TRANSLATOR
+int latx_indirect_goto_macro_emit_for_fast(void *code_addr);
+int latx_ret_indirect_goto_macro_emit_for_fast(void *code_addr,
+                                               int rsp_adjust);
+#endif
 #ifdef CONFIG_LATX_XCOMISX_OPT
 void tr_generate_exit_stub_tb(IR1_INST *branch, int succ_id, void *func, IR1_INST *stub);
 #endif

--- a/target/i386/latx/include/tu.h
+++ b/target/i386/latx/include/tu.h
@@ -111,6 +111,9 @@ int tu_relocat_target_branch(TranslationBlock * tb);
 void tu_relocat_next_branch(TranslationBlock * tb);
 void bcc_ins_recover(TranslationBlock *tb);
 uint bcc_ins_convert(uint convert_insn);
+#ifdef CONFIG_LATX_FAST_TRANSLATOR
+bool tu_bcc_jmp_retrying(void);
+#endif
 #ifdef CONFIG_LATX_DEBUG
 void print_ir1(TranslationBlock* tb);
 void print_tu_tb(TranslationBlock *tb);

--- a/target/i386/latx/latx-config.c
+++ b/target/i386/latx/latx-config.c
@@ -18,8 +18,38 @@
 #include "translate.h"
 #include "latx-config.h"
 #include "syscall-tunnel.h"
+#if defined(CONFIG_LATX_FAST_TRANSLATOR) && defined(TARGET_X86_64)
+#include "quicktrans/detail/fast-translator.h"
+#endif
 #if defined(CONFIG_LATX_KZT)
 #include "wrappertbbridge.h"
+#endif
+
+#if defined(CONFIG_LATX_FAST_TRANSLATOR) && defined(TARGET_X86_64)
+static bool latx_env_enabled(const char *name)
+{
+    const char *value = getenv(name);
+
+    return value && value[0] && strcmp(value, "0") &&
+           strcasecmp(value, "false") && strcasecmp(value, "off");
+}
+
+static void latx_quicktrans_report_failure(const QuickTransFailure *failure,
+                                           const char *old_decode)
+{
+    fprintf(stderr,
+            "[Quicktrans] fallback pc=0x%" PRIx64
+            " stage=%s reason=%s index=%d id=%u kind=%d bytes=",
+            failure->pc,
+            quicktrans_failure_stage_name(failure->stage),
+            quicktrans_failure_reason_name(failure->reason),
+            failure->instruction_index, failure->instruction_id,
+            failure->template_kind);
+    for (int i = 0; i < failure->byte_count; i++) {
+        fprintf(stderr, "%02x", failure->bytes[i]);
+    }
+    fprintf(stderr, " old_decoder=%s\n", old_decode);
+}
 #endif
 
 #ifdef CONFIG_LATX_TU
@@ -79,6 +109,11 @@ void target_disasm(struct TranslationBlock *tb, int max_insns)
 int target_latx_host(CPUArchState *env, struct TranslationBlock *tb,
                      int max_insns)
 {
+#if defined(CONFIG_LATX_FAST_TRANSLATOR) && defined(TARGET_X86_64)
+    bool quicktrans_enabled = latx_env_enabled("LATX_FAST_TRANSLATOR");
+    bool quicktrans_fallback = false;
+    QuickTransFailure quicktrans_failure;
+#endif
     counter_tb_tr += 1;
 
     trace_xtm_tr_tb((void *)tb, (void *)tb->tc.ptr,
@@ -105,9 +140,37 @@ int target_latx_host(CPUArchState *env, struct TranslationBlock *tb,
     is_tbbridge = latx_kzt_runtime_enabled() &&
                   kzt_tbbridge_contains(tb->pc);
 #endif
+#if defined(CONFIG_LATX_FAST_TRANSLATOR) && defined(TARGET_X86_64)
+    if (quicktrans_enabled && !is_tbbridge) {
+        int code_size = 0;
+        int search_size = 0;
+
+        if (latx_fast_decode_translate_tb_primary_ex(
+                env, tb, max_insns, &code_size, &search_size,
+                &quicktrans_failure)) {
+            return code_size + search_size;
+        }
+        quicktrans_fallback = true;
+        if (latx_env_enabled("LATX_FAST_TRANSLATOR_STRICT")) {
+            latx_quicktrans_report_failure(&quicktrans_failure, "not-run");
+            abort();
+        }
+
+        /* The old decoder starts again from the beginning of this TB. */
+        tb->icount = 0;
+        tb->size = 0;
+    }
+#endif
     if (!is_tbbridge) {
         tr_disasm(tb, max_insns);
     }
+#if defined(CONFIG_LATX_FAST_TRANSLATOR) && defined(TARGET_X86_64)
+    if (quicktrans_fallback &&
+        latx_env_enabled("LATX_FAST_TRANSLATOR_TRACE_MISSES")) {
+        latx_quicktrans_report_failure(&quicktrans_failure,
+                                       tb->icount ? "accepted" : "rejected");
+    }
+#endif
     /* return code_size and skip translate */
     if (!tb->icount && !is_tbbridge) {
         return 0;

--- a/target/i386/latx/latx-options.c
+++ b/target/i386/latx/latx-options.c
@@ -248,8 +248,13 @@ void options_init(void)
 #endif /*CONFIG_LATX_AVX_OPT*/
 
 #ifdef CONFIG_LATX_AOT
+#ifdef CONFIG_LATX_FAST_TRANSLATOR
+    option_aot = 0;
+    option_load_aot = 0;
+#else
     option_aot = 1;
     option_load_aot = 1;
+#endif
     option_aot_wine = 0;
     option_debug_aot = 0;
 #endif

--- a/target/i386/latx/meson.build
+++ b/target/i386/latx/meson.build
@@ -75,6 +75,10 @@ i386_ss.add(when: 'CONFIG_LATX', if_true: files(
   'latx-signal.c',
 ) + latx_string_utils + latx_runtime)
 
+i386_ss.add(when: 'CONFIG_LATX_FAST_TRANSLATOR', if_true: files(
+  'quicktrans-host.c',
+))
+
 lazydis_lib = static_library('lazydis',
                          build_by_default: false,
                          sources: files('latx-disassemble-trace/zydis.c'),
@@ -92,6 +96,49 @@ i386_ss.add(when: 'CONFIG_LATX_DEBUG', if_true: files(
 
 if cs_latx_debug or cs_git
     i386_ss.add(when: 'CONFIG_LATX', if_true: capstone_git)
+endif
+
+if 'CONFIG_LATX_FAST_TRANSLATOR' in config_host
+  subdir('quicktrans/meson/latx')
+
+  r = run_command(
+    'python3',
+    quicktrans_latx_generate_fast_la_emit,
+    quicktrans_latx_inst_template,
+    quicktrans_latx_ir2_assemble,
+    quicktrans_latx_fast_la_emit_h,
+    check: true)
+  message('generate-fast-la-emit.py ->', r.stdout().strip(),
+          r.stderr().strip())
+
+  r = run_command(
+    'python3',
+    quicktrans_latx_check_fast_la_opcodes,
+    quicktrans_latx_fast_translator_check_sources,
+    quicktrans_latx_fast_la_emit_h,
+    quicktrans_latx_format_table_h,
+    check: true)
+  message('check-fast-la-opcodes.py ->', r.stdout().strip(),
+          r.stderr().strip())
+
+  r = run_command(
+    'python3',
+    quicktrans_latx_check_fast_la_emit,
+    quicktrans_latx_inst_template,
+    quicktrans_latx_ir2_assemble,
+    join_paths(quicktrans_root, 'include/quicktrans/detail'),
+    check: true)
+  message('check-fast-la-emit.py ->', r.stdout().strip(),
+          r.stderr().strip())
+
+  r = run_command(
+    'python3',
+    quicktrans_latx_check_fast_template_constraints,
+    quicktrans_latx_fast_decoder_template,
+    quicktrans_latx_constraints_source,
+    check: true)
+  message('check-fast-template-constraints.py ->', r.stdout().strip(),
+          r.stderr().strip())
 endif
 
 r = run_command('python3', 'convert.py', check: true)

--- a/target/i386/latx/optimization/tu.c
+++ b/target/i386/latx/optimization/tu.c
@@ -687,6 +687,13 @@ uint bcc_ins_convert(uint convert_insn)
 
 static bool bcc_jmp_fail;
 
+#ifdef CONFIG_LATX_FAST_TRANSLATOR
+bool tu_bcc_jmp_retrying(void)
+{
+    return bcc_jmp_fail;
+}
+#endif
+
 int tu_relocat_target_branch(TranslationBlock * tb)
 {
     TranslationBlock *target_tb = tb->s_data->next_tb[TU_TB_INDEX_TARGET];

--- a/target/i386/latx/quicktrans-host.c
+++ b/target/i386/latx/quicktrans-host.c
@@ -1,0 +1,258 @@
+/*
+ * SPDX-FileCopyrightText: 2026 LAT Project Authors
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#include "qemu/osdep.h"
+#include "lsenv.h"
+#include "reg-alloc.h"
+#include "latx-options.h"
+#include "translate.h"
+#include "latx-native-asm.h"
+
+#ifdef CONFIG_LATX_FAST_TRANSLATOR
+
+static void qt_host_emit_u32(void **code_addr, uint32_t insn)
+{
+    *(uint32_t *)*code_addr = insn;
+    *code_addr = (uint8_t *)*code_addr + 4;
+}
+
+static inline uint32_t qt_host_reg(IR2_OPND opnd)
+{
+    return opnd._reg_num & 0x1f;
+}
+
+static inline uint32_t qt_host_gpr3(uint32_t opcode, IR2_OPND rd,
+                                    IR2_OPND rj, IR2_OPND rk)
+{
+    return opcode | qt_host_reg(rd) | (qt_host_reg(rj) << 5) |
+           (qt_host_reg(rk) << 10);
+}
+
+static inline uint32_t qt_host_gpr3_imm12(uint32_t opcode, IR2_OPND rd,
+                                          IR2_OPND rj, int imm)
+{
+    return opcode | qt_host_reg(rd) | (qt_host_reg(rj) << 5) |
+           (((uint32_t)imm & 0xfff) << 10);
+}
+
+static inline uint32_t qt_host_gpr2_imm20(uint32_t opcode, IR2_OPND rd,
+                                          int imm)
+{
+    return opcode | qt_host_reg(rd) | (((uint32_t)imm & 0xfffff) << 5);
+}
+
+static inline uint32_t qt_host_gpr2_imm6(uint32_t opcode, IR2_OPND rd,
+                                         IR2_OPND rj, int imm)
+{
+    return opcode | qt_host_reg(rd) | (qt_host_reg(rj) << 5) |
+           (((uint32_t)imm & 0x3f) << 10);
+}
+
+static inline uint32_t qt_host_bstrpick_w(IR2_OPND rd, IR2_OPND rj,
+                                          int msb, int lsb)
+{
+    return 0x00608000 | qt_host_reg(rd) | (qt_host_reg(rj) << 5) |
+           (((uint32_t)lsb & 0x1f) << 10) |
+           (((uint32_t)msb & 0x1f) << 16);
+}
+
+static inline uint32_t qt_host_bstrpick_d(IR2_OPND rd, IR2_OPND rj,
+                                          int msb, int lsb)
+{
+    return 0x00c00000 | qt_host_reg(rd) | (qt_host_reg(rj) << 5) |
+           (((uint32_t)lsb & 0x3f) << 10) |
+           (((uint32_t)msb & 0x3f) << 16);
+}
+
+static inline uint32_t qt_host_alsl_d(IR2_OPND rd, IR2_OPND rj,
+                                      IR2_OPND rk, int imm)
+{
+    return 0x002c0000 | qt_host_reg(rd) | (qt_host_reg(rj) << 5) |
+           (qt_host_reg(rk) << 10) | (((uint32_t)imm & 0x3) << 15);
+}
+
+static inline uint32_t qt_host_jirl(IR2_OPND rd, IR2_OPND rj, int off)
+{
+    return 0x4c000000 | qt_host_reg(rd) | (qt_host_reg(rj) << 5) |
+           (((uint32_t)off & 0xffff) << 10);
+}
+
+static inline uint32_t qt_host_b26(int off)
+{
+    return 0x50000000 | (((uint32_t)off & 0xffff) << 10) |
+           (((uint32_t)off >> 16) & 0x3ff);
+}
+
+static inline uint32_t qt_host_branch2(uint32_t opcode, IR2_OPND rj,
+                                       IR2_OPND rd, int off)
+{
+    return opcode | qt_host_reg(rd) | (qt_host_reg(rj) << 5) |
+           (((uint32_t)off & 0xffff) << 10);
+}
+
+static void qt_host_emit_li64(void **code_addr, IR2_OPND rd, uint64_t value)
+{
+    uint32_t lo32 = value;
+    uint32_t hi32 = value >> 32;
+
+    qt_host_emit_u32(code_addr,
+        qt_host_gpr2_imm20(0x14000000, rd, lo32 >> 12));
+    qt_host_emit_u32(code_addr,
+        qt_host_gpr3_imm12(0x03800000, rd, rd, lo32));
+    qt_host_emit_u32(code_addr,
+        qt_host_gpr2_imm20(0x16000000, rd, hi32));
+    qt_host_emit_u32(code_addr,
+        qt_host_gpr3_imm12(0x03000000, rd, rd, hi32 >> 20));
+}
+
+static void qt_host_emit_fixed_far_jump(void **code_addr, ADDR target,
+                                        IR2_OPND scratch)
+{
+    ptrdiff_t offset = ((uintptr_t)target - (uintptr_t)*code_addr) >> 2;
+
+#ifdef CONFIG_LATX_LARGE_CC
+    if (offset == sextract64(offset, 0, 26)) {
+        qt_host_emit_u32(code_addr, qt_host_b26(offset));
+        qt_host_emit_u32(code_addr,
+            qt_host_gpr3_imm12(0x03400000, zero_ir2_opnd,
+                               zero_ir2_opnd, 0));
+    } else {
+        ptrdiff_t lower = (int16_t)offset;
+        ptrdiff_t upper = (offset - lower) >> 16;
+
+        qt_host_emit_u32(code_addr,
+            qt_host_gpr2_imm20(0x1e000000, scratch, upper));
+        qt_host_emit_u32(code_addr, qt_host_jirl(zero_ir2_opnd, scratch,
+                                                 lower));
+    }
+#else
+    lsassert(offset == sextract64(offset, 0, 26));
+    qt_host_emit_u32(code_addr, qt_host_b26(offset));
+#endif
+}
+
+static int qt_host_emit_indirect_goto(void *code_addr)
+{
+    void *start = code_addr;
+    IR2_OPND next_x86_addr = ra_alloc_dbt_arg2();
+    IR2_OPND next_tb = V0_RENAME_OPND;
+    IR2_OPND jmp_entry = ir2_opnd_new(IR2_OPND_GPR, la_t0);
+    IR2_OPND far_tmp = ir2_opnd_new(IR2_OPND_GPR, la_t1);
+    IR2_OPND jmp_cache_addr = ra_alloc_static0();
+
+    qt_host_emit_u32(&code_addr,
+        qt_host_gpr2_imm6(0x00450000, next_tb, next_x86_addr,
+                          TB_JMP_CACHE_BITS));
+    qt_host_emit_u32(&code_addr,
+        qt_host_gpr3(0x00158000, next_tb, next_x86_addr, next_tb));
+    qt_host_emit_u32(&code_addr,
+        qt_host_bstrpick_d(next_tb, next_tb, TB_JMP_CACHE_BITS - 1, 0));
+
+#ifdef CONFIG_LATX_FAST_JMPCACHE
+#ifdef CONFIG_LATX_GLUE_MASK
+#error "Quicktrans indirect exit does not support CONFIG_LATX_GLUE_MASK"
+#endif
+    qt_host_emit_u32(&code_addr,
+        qt_host_alsl_d(next_tb, next_tb, jmp_cache_addr, 3));
+    qt_host_emit_u32(&code_addr,
+        qt_host_gpr3_imm12(0x28c00000, jmp_entry, next_tb, 0));
+    qt_host_emit_u32(&code_addr,
+        qt_host_branch2(0x5c000000, jmp_entry, next_x86_addr, 3));
+    qt_host_emit_u32(&code_addr,
+        qt_host_gpr3_imm12(0x28c00000, next_tb, next_tb, 8));
+    qt_host_emit_u32(&code_addr,
+        qt_host_jirl(zero_ir2_opnd, next_tb, 0));
+#else
+    qt_host_emit_u32(&code_addr,
+        qt_host_gpr2_imm6(0x00410000, next_tb, next_tb, 3));
+    qt_host_emit_u32(&code_addr,
+        qt_host_gpr3(0x380c0000, next_tb, next_tb, jmp_cache_addr));
+    qt_host_emit_u32(&code_addr,
+        qt_host_branch2(0x58000000, next_tb, zero_ir2_opnd, 8));
+    qt_host_emit_u32(&code_addr,
+        qt_host_gpr3_imm12(0x28c00000, jmp_entry, next_tb,
+                           offsetof(TranslationBlock, pc)));
+    qt_host_emit_u32(&code_addr,
+        qt_host_branch2(0x5c000000, jmp_entry, next_x86_addr, 6));
+    qt_host_emit_u32(&code_addr,
+        qt_host_gpr3_imm12(0x28c00000, jmp_entry, next_tb,
+                           offsetof(TranslationBlock, cflags)));
+    qt_host_emit_u32(&code_addr,
+        qt_host_bstrpick_w(jmp_entry, jmp_entry, 18, 18));
+    qt_host_emit_u32(&code_addr,
+        qt_host_branch2(0x5c000000, jmp_entry, zero_ir2_opnd, 3));
+    qt_host_emit_u32(&code_addr,
+        qt_host_gpr3_imm12(0x28c00000, jmp_entry, next_tb,
+                           offsetof(TranslationBlock, tc) +
+                           offsetof(struct tb_tc, ptr)));
+    qt_host_emit_u32(&code_addr,
+        qt_host_jirl(zero_ir2_opnd, jmp_entry, 0));
+#endif
+
+#ifdef CONFIG_LATX_KZT
+    {
+        IR2_OPND reserved = ir2_opnd_new(IR2_OPND_GPR, la_t2);
+        IR2_OPND helper_addr = ir2_opnd_new(IR2_OPND_GPR, la_t3);
+        int skip_offset = 1 + 8 + 4 + 1 + 1 + 1 + 8;
+
+        qt_host_emit_li64(&code_addr, reserved, (ADDR)reserved_va);
+        qt_host_emit_u32(&code_addr,
+            qt_host_branch2(0x68000000, next_x86_addr, reserved,
+                            skip_offset));
+        for (int i = 0; i < 8; ++i) {
+            qt_host_emit_u32(&code_addr,
+                qt_host_gpr3_imm12(0x29c00000, ra_alloc_gpr(i + 8),
+                                   env_ir2_opnd,
+                                   lsenv_offset_of_gpr(lsenv, i + 8)));
+        }
+        qt_host_emit_li64(&code_addr, helper_addr,
+                          (ADDR)kzt_get_alternate_pc);
+        qt_host_emit_u32(&code_addr,
+            qt_host_gpr3(0x00150000, a0_ir2_opnd, next_x86_addr,
+                         zero_ir2_opnd));
+        qt_host_emit_u32(&code_addr,
+            qt_host_jirl(ra_ir2_opnd, helper_addr, 0));
+        qt_host_emit_u32(&code_addr,
+            qt_host_gpr3(0x00150000, next_x86_addr, a0_ir2_opnd,
+                         zero_ir2_opnd));
+        for (int i = 0; i < 8; ++i) {
+            qt_host_emit_u32(&code_addr,
+                qt_host_gpr3_imm12(0x28c00000, ra_alloc_gpr(i + 8),
+                                   env_ir2_opnd,
+                                   lsenv_offset_of_gpr(lsenv, i + 8)));
+        }
+    }
+#endif
+
+    qt_host_emit_fixed_far_jump(&code_addr,
+                                 context_switch_native_to_bt_ret_0,
+                                 far_tmp);
+    return ((uintptr_t)code_addr - (uintptr_t)start) >> 2;
+}
+
+int latx_indirect_goto_macro_emit_for_fast(void *code_addr)
+{
+    return qt_host_emit_indirect_goto(code_addr);
+}
+
+int latx_ret_indirect_goto_macro_emit_for_fast(void *code_addr,
+                                               int rsp_adjust)
+{
+    void *start = code_addr;
+    IR2_OPND rsp = ra_alloc_gpr(esp_index);
+    IR2_OPND return_addr = ra_alloc_dbt_arg2();
+
+    lsassert(rsp_adjust == sextract64(rsp_adjust, 0, 12));
+    qt_host_emit_u32(&code_addr,
+        qt_host_gpr3_imm12(0x28c00000, return_addr, rsp, 0));
+    qt_host_emit_u32(&code_addr,
+        qt_host_gpr3_imm12(0x02c00000, rsp, rsp, rsp_adjust));
+    code_addr = (uint8_t *)code_addr + qt_host_emit_indirect_goto(code_addr) * 4;
+
+    return ((uintptr_t)code_addr - (uintptr_t)start) >> 2;
+}
+
+#endif /* CONFIG_LATX_FAST_TRANSLATOR */


### PR DESCRIPTION
## Summary / 变更说明

- 将 Quicktrans 快速翻译路径接入 LAT 的 x86_64 翻译入口。
- 增加编译开关 `--enable-latx-fast-translator`。默认不编译 Quicktrans；使用 `./latxbuild/build64.sh -f` 时才编译。
- 编译 Quicktrans 后，运行时仍需设置 `LATX_FAST_TRANSLATOR=1` 才会启用快速翻译。
- Quicktrans 无法解码或翻译某条指令时，重新从当前 TB 开头调用 LAT 原来的 `tr_disasm()` 解码和翻译。
- `LATX_FAST_TRANSLATOR_STRICT=1` 下，Quicktrans 翻译失败时立即停止，便于查找尚未支持的指令。
- `LATX_FAST_TRANSLATOR_TRACE_MISSES=1` 下，打印 Quicktrans 的失败位置、阶段和原因，并说明老解码器能否接受该指令。
- 编译快速翻译路径时，将 `option_aot` 和 `option_load_aot` 的默认值设为 `0`，避免默认生成或加载 Quicktrans 尚未支持的 AOT 代码。
- 为当前 LAT 分支缺少的 Quicktrans 宿主接口增加兼容处理。依赖这些接口的间接跳转等指令返回“不支持”，随后交给老翻译路径处理。
- 增加 Quicktrans 子模块及其头文件生成、校验和构建规则。
- 没有修改 `target/i386/latx/translator/` 中原有的指令翻译函数。

## Validation / 验证

执行了以下构建和测试：

- 在 x86 主机执行 `make -j2`，确认 `latx-base-test` 已正确编译。
- 在 LoongArch 主机执行默认构建：

  ```bash
  ./latxbuild/build64.sh -c
  构建通过，Quicktrans 未加入构建。
- 在 LoongArch 主机执行快速翻译构建：
  ./latxbuild/build64.sh -c -f
  完整构建通过，Quicktrans 生成器和一致性检查均通过。
- 在 Quicktrans 仓库执行：
  make test
  所有测试通过。
- 使用 smoke-exit 验证快速翻译入口，日志确认指令实际进入 Quicktrans，程序正常退出。
- 使用独立的临时 HOME 运行快速翻译版本。未设置 LATX_AOT 时没有生成 AOT 文件，确认 option_aot 和 option_load_aot 默认关闭。
- 执行 latx-base-test daily 测试：
  LATX_FAST_TRANSLATOR=1 ./run-tests.py \
      --latx /mnt/disk_a/lat-github/lat/build64/latx-x86_64 \
      --tier daily -j 2
  结果：
  - 总计：820
  - 通过：818
  - 预期失败：1，instr-fma，测试已注明 FMA3 VEX 指令尚未完全支持
  - 失败：1，instr-retf
  instr-retf 在关闭 Quicktrans 后仍以相同方式失败，输出为
  FAIL:retfq_target 和 FAIL:retfq_rsp，确认它是目标分支原有问题，不是本次修改引入。
- git diff --check 通过。
Checklist / 检查项
- I have read CONTRIBUTING.md. / 我已阅读 CONTRIBUTING.md。
- Every commit contains a DCO sign-off (git commit -s). /
  每个提交都包含 DCO 签署（git commit -s）。
  当前提交尚未包含 Signed-off-by。需要由提交作者确认并使用
  git commit --amend --signoff 补充 DCO 签署。
- I have included relevant build or test results, or explained why they
  are not applicable. /
  我已提供相关构建或测试结果，或说明了不适用的原因。