### PR TITLE
LATX: Report x86_64 to steam launchers

### DIFF
--- a/linux-user/uname.c
+++ b/linux-user/uname.c
@@ -25,34 +25,11 @@
 
 /* return highest utsname machine name for emulated instruction set
  *
- * NB: the default emulated CPU ("any") might not match any existing CPU, e.g.
- * on ARM it has all features turned on, so there is no perfect arch string to
- * return here */
+ * Note: Steam's i386 launcher selects its webhelper class from uname.machine
+ * and Steam webhelper is 64-bit program */
 const char *cpu_to_uname_machine(void *cpu_env)
 {
-#if defined(TARGET_ARM) && !defined(TARGET_AARCH64)
-
-    /* utsname machine name on linux arm is CPU arch name + endianness, e.g.
-     * armv7l; to get a list of CPU arch names from the linux source, use:
-     *     grep arch_name: -A1 linux/arch/arm/mm/proc-*.S
-     * see arch/arm/kernel/setup.c: setup_processor()
-     */
-
-    /* in theory, endianness is configurable on some ARM CPUs, but this isn't
-     * used in user mode emulation */
-#ifdef TARGET_WORDS_BIGENDIAN
-#define utsname_suffix "b"
-#else
-#define utsname_suffix "l"
-#endif
-    if (arm_feature(cpu_env, ARM_FEATURE_V7))
-        return "armv7" utsname_suffix;
-    if (arm_feature(cpu_env, ARM_FEATURE_V6))
-        return "armv6" utsname_suffix;
-    /* earliest emulated CPU is ARMv5TE; qemu can emulate the 1026, but not its
-     * Jazelle support */
-    return "armv5te" utsname_suffix;
-#elif defined(TARGET_I386) && !defined(TARGET_X86_64)
+#if defined(TARGET_I386) && !defined(TARGET_X86_64)
     /* see arch/x86/kernel/cpu/bugs.c: check_bugs(), 386, 486, 586, 686 */
     CPUState *cpu = env_cpu((CPUX86State *)cpu_env);
     int family = object_property_get_int(OBJECT(cpu), "family", NULL);
@@ -61,6 +38,9 @@ const char *cpu_to_uname_machine(void *cpu_env)
     }
     if (family == 5) {
         return "i586";
+    }
+    if (strstr(exec_path, "ubuntu12_32/steam")) {
+      return "x86_64";
     }
     return "i686";
 #else


### PR DESCRIPTION
## Summary / 变更说明

- Steam's i386 client uses `uname.machine` when selecting its webhelper
  class. The LATX i386 target reported `i686`, so it did not select the
  x86_64 webhelper that LATX can execute and instead timed out waiting for
  webhelper initialization.
- The i386 LATX default is now `x86_64` for steam; the x86_64 target is unchanged.

## Validation / 验证

- `ninja -C build64 latx-x86_64`: passed on LoongArch64.
- `ninja -C build32 latx-i386`: passed on LoongArch64.

## Checklist / 检查项

- [x] I have read `CONTRIBUTING.md`. / 我已阅读 `CONTRIBUTING.md`。
- [x] Every commit contains a DCO sign-off (`git commit -s`). /
      每个提交都包含 DCO 签署（`git commit -s`）。
- [x] I have included relevant build and test results, or explained why they
      are not applicable. /
      我已提供相关构建和测试结果，或说明了不适用的原因。