### PR TITLE
LATX, opt: Add configurable Jcc instruction patterns

### DIFF
--- a/linux-user/exit.c
+++ b/linux-user/exit.c
@@ -36,6 +36,10 @@ extern void __gcov_dump(void);
 #include "latx-perf.h"
 #endif
 
+#ifdef CONFIG_LATX_INSTS_PATTERN
+#include "insts-pattern.h"
+#endif
+
 void preexit_cleanup(CPUArchState *env, int code)
 {
 #ifdef CONFIG_LATX_PERF
@@ -43,6 +47,9 @@ void preexit_cleanup(CPUArchState *env, int code)
 #endif
 #ifdef CONFIG_LATX_PERF
     latx_print_all_timers();
+#endif
+#ifdef CONFIG_LATX_INSTS_PATTERN
+    instptn_stats_dump();
 #endif
 
 #ifdef CONFIG_GPROF

--- a/linux-user/main.c
+++ b/linux-user/main.c
@@ -58,6 +58,9 @@ int mydebug = 1;
 #include "latx-options.h"
 #include "latx-runtime.h"
 #include "aot.h"
+#ifdef CONFIG_LATX_INSTS_PATTERN
+#include "insts-pattern.h"
+#endif
 #include <openssl/evp.h>
 #endif
 #ifdef CONFIG_LATX_PERF
@@ -227,6 +230,13 @@ void fork_end(int child)
     path_fork_end(child);
     fd_trans_fork_end();
     if (child) {
+#ifdef CONFIG_LATX_INSTS_PATTERN
+        /*
+         * Statistics describe translations performed by this host process.
+         * Do not let the child report the parent's pre-fork history.
+         */
+        instptn_stats_reset();
+#endif
         CPUState *cpu, *next_cpu;
         /* Child processes created by fork() only have a single thread.
            Discard information about the parent threads.  */
@@ -630,6 +640,18 @@ static void handle_arg_optimize(const char *arg)
     options_parse_opt(arg);
 }
 
+#ifdef CONFIG_LATX_INSTS_PATTERN
+static void handle_arg_latx_instptn_mask(const char *arg)
+{
+    options_parse_instptn_mask(arg);
+}
+
+static void handle_arg_latx_instptn_stats(const char *arg)
+{
+    options_parse_instptn_stats(arg);
+}
+#endif
+
 static void handle_arg_latx_vpaes(const char *arg)
 {
     option_vpaes = strtol(arg, NULL, 0);
@@ -904,6 +926,14 @@ static const struct qemu_argument arg_table[] = {
 #ifdef CONFIG_LATX
     {"latx-optimize",   "LATX_OPTIMIZE",      false, handle_arg_optimize,
     "",           "specify enabled optimize type"},
+#ifdef CONFIG_LATX_INSTS_PATTERN
+    {"latx-instptn-mask", "LATX_INSTPTN_MASK", true,
+    handle_arg_latx_instptn_mask, "mask",
+    "set the 64-bit instruction pattern option mask"},
+    {"latx-instptn-stats", "LATX_INSTPTN_STATS", true,
+    handle_arg_latx_instptn_stats, "0|1",
+    "dump instruction pattern counters at process exit"},
+#endif
     {"latx-vpaes",      "LATX_VPAES",         true,  handle_arg_latx_vpaes,
     "",           "enable vpaes AES translation"},
     {"latx-smc",        "LATX_SMC",         true,   handle_arg_latx_smc,
@@ -1449,6 +1479,11 @@ int main(int argc, char **argv, char **envp)
     options_set(target_argv);
 
     if (!latx_options_finalize()) {
+#if defined(CONFIG_LATX_INSTS_PATTERN)
+        if (option_instptn_mask_error || option_instptn_stats_error) {
+            return EXIT_FAILURE;
+        }
+#endif
 #if defined(CONFIG_LATX_KZT)
         error_report("invalid KZT configuration: %s; KZT disabled",
                      kzt_groups_last_error());

--- a/target/i386/latx/include/insts-pattern.h
+++ b/target/i386/latx/include/insts-pattern.h
@@ -106,6 +106,8 @@ typedef struct InstPtnStats {
 
 typedef int scan_elem_t;
 
+#ifdef CONFIG_LATX_INSTS_PATTERN
+
 extern InstPtnStats instptn_stats[INSTPTN_OPT_COUNT];
 
 static inline bool instptn_option_enabled(InstPtnOption option)
@@ -125,6 +127,8 @@ void instptn_stats_record_eflags_fallback_opcode(InstPtnOpcode opcode);
 void instptn_stats_record_codegen_opcode(InstPtnOpcode opcode,
                                          uint64_t ir2_emitted,
                                          uint64_t host_emitted);
+
+#endif
 
 void insts_pattern_scan_con(TranslationBlock *tb, IR1_INST *ir1, int index, scan_elem_t *scan_buf);
 bool insts_pattern_scan_jcc_end(TranslationBlock *tb, IR1_INST *ir1, int index, scan_elem_t *scan_buf);
@@ -207,6 +211,8 @@ bool insts_pattern_scan_jcc_end(TranslationBlock *tb, IR1_INST *ir1, int index, 
 #define instptn_check_neg_cmovcc_0() INSTPTN_CHECK_XX_0(NEG_CMOVCC)
 
 #define instptn_check_shr_jcc_0() INSTPTN_CHECK_XX_0(SHR_JCC)
+#define instptn_check_sar_jcc_0() INSTPTN_CHECK_XX_0(SAR_JCC)
+#define instptn_check_shr_je_0() INSTPTN_CHECK_XX_0(SHR_JE)
 #define instptn_check_and_jcc_0() INSTPTN_CHECK_XX_0(AND_JCC)
 #define instptn_check_add_jcc_0() INSTPTN_CHECK_XX_0(ADD_JCC)
 #else
@@ -242,6 +248,8 @@ bool insts_pattern_scan_jcc_end(TranslationBlock *tb, IR1_INST *ir1, int index, 
 #define instptn_check_neg_cmovcc_0()
 
 #define instptn_check_shr_jcc_0()
+#define instptn_check_sar_jcc_0()
+#define instptn_check_shr_je_0()
 #define instptn_check_and_jcc_0()
 #define instptn_check_add_jcc_0()
 #endif

--- a/target/i386/latx/include/insts-pattern.h
+++ b/target/i386/latx/include/insts-pattern.h
@@ -216,6 +216,7 @@ bool insts_pattern_scan_jcc_end(TranslationBlock *tb, IR1_INST *ir1, int index, 
 #define instptn_check_and_jcc_0() INSTPTN_CHECK_XX_0(AND_JCC)
 #define instptn_check_add_jcc_0() INSTPTN_CHECK_XX_0(ADD_JCC)
 #define instptn_check_or_jcc_0() INSTPTN_CHECK_XX_0(OR_JCC)
+#define instptn_check_or_xx_jcc_0() INSTPTN_CHECK_XX_0(OR_XX_JCC)
 #else
 #define instptn_check_void(option)
 #define instptn_check_false(option)
@@ -254,6 +255,7 @@ bool insts_pattern_scan_jcc_end(TranslationBlock *tb, IR1_INST *ir1, int index, 
 #define instptn_check_and_jcc_0()
 #define instptn_check_add_jcc_0()
 #define instptn_check_or_jcc_0()
+#define instptn_check_or_xx_jcc_0()
 #endif
 
 bool try_translate_instptn(IR1_INST *pir1);

--- a/target/i386/latx/include/insts-pattern.h
+++ b/target/i386/latx/include/insts-pattern.h
@@ -215,6 +215,7 @@ bool insts_pattern_scan_jcc_end(TranslationBlock *tb, IR1_INST *ir1, int index, 
 #define instptn_check_shr_je_0() INSTPTN_CHECK_XX_0(SHR_JE)
 #define instptn_check_and_jcc_0() INSTPTN_CHECK_XX_0(AND_JCC)
 #define instptn_check_add_jcc_0() INSTPTN_CHECK_XX_0(ADD_JCC)
+#define instptn_check_or_jcc_0() INSTPTN_CHECK_XX_0(OR_JCC)
 #else
 #define instptn_check_void(option)
 #define instptn_check_false(option)
@@ -252,6 +253,7 @@ bool insts_pattern_scan_jcc_end(TranslationBlock *tb, IR1_INST *ir1, int index, 
 #define instptn_check_shr_je_0()
 #define instptn_check_and_jcc_0()
 #define instptn_check_add_jcc_0()
+#define instptn_check_or_jcc_0()
 #endif
 
 bool try_translate_instptn(IR1_INST *pir1);

--- a/target/i386/latx/include/insts-pattern.h
+++ b/target/i386/latx/include/insts-pattern.h
@@ -15,44 +15,114 @@
 #include "common.h"
 #include "ir1.h"
 #include "ir2.h"
+#include "latx-options.h"
 
 #define INSTPTN_BUF_SIZE 4
 
-#define INSTPTN_OPC_NONE        0x000000
-#define INSTPTN_OPC_NOP         0x000001
-#define INSTPTN_OPC_NOP_DIV     0x000002
-#define INSTPTN_OPC_CMP_JCC     0x000010
-#define INSTPTN_OPC_TEST_JCC    0x000020
-#define INSTPTN_OPC_BT_JCC      0x000040
-#define INSTPTN_OPC_CQO_IDIV    0x000080
-#define INSTPTN_OPC_CMP_SBB     0x000100
-#define INSTPTN_OPC_COMISD_JCC  0x000200
-#define INSTPTN_OPC_COMISS_JCC  0x000400
-#define INSTPTN_OPC_UCOMISD_JCC 0x000800
-#define INSTPTN_OPC_UCOMISS_JCC 0x001000
-#define INSTPTN_OPC_XOR_DIV     0x002000
-#define INSTPTN_OPC_CDQ_IDIV    0x004000
+/*
+ * Options are indexed independently from InstPtnOpcode.  Preserve the first
+ * 26 indices so the default mask remains bit-for-bit compatible with the old
+ * (INSTPTN_OPC_* >> 4) encoding.
+ */
+typedef enum InstPtnOption {
+    INSTPTN_OPT_CMP_JCC,
+    INSTPTN_OPT_TEST_JCC,
+    INSTPTN_OPT_BT_JCC,
+    INSTPTN_OPT_CQO_IDIV,
+    INSTPTN_OPT_CMP_SBB,
+    INSTPTN_OPT_COMISD_JCC,
+    INSTPTN_OPT_COMISS_JCC,
+    INSTPTN_OPT_UCOMISD_JCC,
+    INSTPTN_OPT_UCOMISS_JCC,
+    INSTPTN_OPT_XOR_DIV,
+    INSTPTN_OPT_CDQ_IDIV,
+    INSTPTN_OPT_CMP_XX_JCC,
+    INSTPTN_OPT_TEST_XX_JCC,
+    INSTPTN_OPT_BT_XX_JCC,
+    INSTPTN_OPT_COMISD_XX_JCC,
+    INSTPTN_OPT_COMISS_XX_JCC,
+    INSTPTN_OPT_UCOMISD_XX_JCC,
+    INSTPTN_OPT_UCOMISS_XX_JCC,
+    INSTPTN_OPT_CMP_XXCC,
+    INSTPTN_OPT_TEST_XXCC,
+    INSTPTN_OPT_UCOMISD_SETA,
+    INSTPTN_OPT_SUB_JCC,
+    INSTPTN_OPT_MOVAPS_VST_X4,
+    INSTPTN_OPT_NEG_CMOVCC,
+    INSTPTN_OPT_SHR_JCC,
+    INSTPTN_OPT_AND_JCC,
 
-#define INSTPTN_OPC_CMP_XX_JCC     0x008000
-#define INSTPTN_OPC_TEST_XX_JCC    0x010000
-#define INSTPTN_OPC_BT_XX_JCC      0x020000
-#define INSTPTN_OPC_COMISD_XX_JCC  0x040000
-#define INSTPTN_OPC_COMISS_XX_JCC  0x080000
-#define INSTPTN_OPC_UCOMISD_XX_JCC 0x100000
-#define INSTPTN_OPC_UCOMISS_XX_JCC 0x200000
+    /* Reserved for PERF-001 through PERF-006 and PERF-009. */
+    INSTPTN_OPT_ADD_JCC,
+    INSTPTN_OPT_OR_JCC,
+    INSTPTN_OPT_XOR_JCC,
+    INSTPTN_OPT_SAR_JCC,
+    INSTPTN_OPT_DEC_JCC,
+    INSTPTN_OPT_CMP_JS_JNS,
+    INSTPTN_OPT_SUB_JS_JNS,
+    INSTPTN_OPT_AND_JE,
+    INSTPTN_OPT_SHR_JE,
+    INSTPTN_OPT_OR_XX_JCC,
 
-#define INSTPTN_OPC_CMP_XXCC    0x400000
-#define INSTPTN_OPC_TEST_XXCC   0x800000
+    INSTPTN_OPT_COUNT,
+} InstPtnOption;
 
-#define INSTPTN_OPC_UCOMISD_SETA   0x1000000
-#define INSTPTN_OPC_SUB_JCC        0x2000000
-#define INSTPTN_OPC_MOVAPS_VST_X4  0x4000000
-#define INSTPTN_OPC_NEG_CMOVCC     0x8000000
+#define INSTPTN_OPT_FIRST_RESERVED INSTPTN_OPT_ADD_JCC
+#define INSTPTN_OPTION_BIT(opt) (UINT64_C(1) << (opt))
+#define INSTPTN_DEFAULT_OPTIONS \
+    (INSTPTN_OPTION_BIT(INSTPTN_OPT_FIRST_RESERVED) - UINT64_C(1))
+#define INSTPTN_ALL_OPTIONS \
+    (INSTPTN_OPTION_BIT(INSTPTN_OPT_COUNT) - UINT64_C(1))
 
-#define INSTPTN_OPC_SHR_JCC        0x10000000
-#define INSTPTN_OPC_AND_JCC        0x20000000
+_Static_assert(INSTPTN_OPT_COUNT < 64,
+               "instruction pattern option mask exceeds uint64_t");
+_Static_assert(INSTPTN_DEFAULT_OPTIONS == UINT64_C(0x3ffffff),
+               "legacy instruction pattern default mask changed");
+
+typedef enum InstPtnRejectReason {
+    /* Existing scanners report a reason only after identifying an option. */
+    INSTPTN_REJECT_DISABLED,
+    INSTPTN_REJECT_NON_ADJACENT,
+    INSTPTN_REJECT_UNSUPPORTED_CC,
+    INSTPTN_REJECT_UNSUPPORTED_OPERAND,
+    INSTPTN_REJECT_ZERO_SHIFT_COUNT,
+    /* Used by later patterns when these conditions reject a known option. */
+    INSTPTN_REJECT_FLAGS_LIVE,
+    INSTPTN_REJECT_CLOBBER,
+    INSTPTN_REJECT_FAULT_OR_HELPER,
+    INSTPTN_REJECT_TEMP_LIFETIME,
+    INSTPTN_REJECT_OTHER,
+    INSTPTN_REJECT_COUNT,
+} InstPtnRejectReason;
+
+typedef struct InstPtnStats {
+    uint64_t matches;
+    uint64_t rejects[INSTPTN_REJECT_COUNT];
+    uint64_t eflags_fallbacks;
+    uint64_t ir2_emitted;
+    uint64_t host_emitted;
+} InstPtnStats;
 
 typedef int scan_elem_t;
+
+extern InstPtnStats instptn_stats[INSTPTN_OPT_COUNT];
+
+static inline bool instptn_option_enabled(InstPtnOption option)
+{
+    return option >= 0 && option < INSTPTN_OPT_COUNT &&
+           (option_instptn & INSTPTN_OPTION_BIT(option));
+}
+
+void instptn_stats_reset(void);
+void instptn_stats_dump(void);
+void instptn_stats_record_match_opcode(InstPtnOpcode opcode);
+void instptn_stats_record_reject(InstPtnOption option,
+                                 InstPtnRejectReason reason);
+void instptn_stats_record_eflags_fallback(InstPtnOption option);
+void instptn_stats_record_eflags_fallback_opcode(InstPtnOpcode opcode);
+void instptn_stats_record_codegen_opcode(InstPtnOpcode opcode,
+                                         uint64_t ir2_emitted,
+                                         uint64_t host_emitted);
 
 void insts_pattern_scan_con(TranslationBlock *tb, IR1_INST *ir1, int index, scan_elem_t *scan_buf);
 bool insts_pattern_scan_jcc_end(TranslationBlock *tb, IR1_INST *ir1, int index, scan_elem_t *scan_buf);
@@ -67,8 +137,15 @@ bool insts_pattern_scan_jcc_end(TranslationBlock *tb, IR1_INST *ir1, int index, 
         do { \
             if (option_instptn) { \
                 insts_pattern_scan_con(tb, inst, index, _prex##_scaned_cond); \
-                if (scan_head)  \
+                if (scan_head) { \
+                    InstPtnOpcode _opc_before = (inst)->instptn.opc; \
                     scan_head = insts_pattern_scan_jcc_end(tb, inst, index, _prex##_scaned_jcc_end); \
+                    if (_opc_before == INSTPTN_OPC_NONE && \
+                        (inst)->instptn.opc != INSTPTN_OPC_NONE) { \
+                        instptn_stats_record_match_opcode( \
+                            (inst)->instptn.opc); \
+                    } \
+                } \
             } \
         } while (0)
 
@@ -91,7 +168,11 @@ bool insts_pattern_scan_jcc_end(TranslationBlock *tb, IR1_INST *ir1, int index, 
 } while (0)
 
 #define INSTPTN_CHECK_XX_0(OPC) do {   \
-    if (!(option_instptn & (INSTPTN_OPC_##OPC >> 4))) return 0;      \
+    if (!instptn_option_enabled(INSTPTN_OPT_##OPC)) { \
+        instptn_stats_record_reject(INSTPTN_OPT_##OPC, \
+                                    INSTPTN_REJECT_DISABLED); \
+        return 0; \
+    } \
 } while (0)
 
 #define instptn_check_cmp_jcc_0() INSTPTN_CHECK_XX_0(CMP_JCC)

--- a/target/i386/latx/include/insts-pattern.h
+++ b/target/i386/latx/include/insts-pattern.h
@@ -98,6 +98,7 @@ typedef enum InstPtnRejectReason {
 typedef struct InstPtnStats {
     uint64_t matches;
     uint64_t rejects[INSTPTN_REJECT_COUNT];
+    uint64_t eflags_eliminations;
     uint64_t eflags_fallbacks;
     uint64_t ir2_emitted;
     uint64_t host_emitted;
@@ -118,6 +119,7 @@ void instptn_stats_dump(void);
 void instptn_stats_record_match_opcode(InstPtnOpcode opcode);
 void instptn_stats_record_reject(InstPtnOption option,
                                  InstPtnRejectReason reason);
+void instptn_stats_record_eflags_eliminated(InstPtnOption option);
 void instptn_stats_record_eflags_fallback(InstPtnOption option);
 void instptn_stats_record_eflags_fallback_opcode(InstPtnOpcode opcode);
 void instptn_stats_record_codegen_opcode(InstPtnOpcode opcode,
@@ -206,6 +208,7 @@ bool insts_pattern_scan_jcc_end(TranslationBlock *tb, IR1_INST *ir1, int index, 
 
 #define instptn_check_shr_jcc_0() INSTPTN_CHECK_XX_0(SHR_JCC)
 #define instptn_check_and_jcc_0() INSTPTN_CHECK_XX_0(AND_JCC)
+#define instptn_check_add_jcc_0() INSTPTN_CHECK_XX_0(ADD_JCC)
 #else
 #define instptn_check_void(option)
 #define instptn_check_false(option)
@@ -240,6 +243,7 @@ bool insts_pattern_scan_jcc_end(TranslationBlock *tb, IR1_INST *ir1, int index, 
 
 #define instptn_check_shr_jcc_0()
 #define instptn_check_and_jcc_0()
+#define instptn_check_add_jcc_0()
 #endif
 
 bool try_translate_instptn(IR1_INST *pir1);

--- a/target/i386/latx/include/insts-pattern.h
+++ b/target/i386/latx/include/insts-pattern.h
@@ -217,6 +217,7 @@ bool insts_pattern_scan_jcc_end(TranslationBlock *tb, IR1_INST *ir1, int index, 
 #define instptn_check_add_jcc_0() INSTPTN_CHECK_XX_0(ADD_JCC)
 #define instptn_check_or_jcc_0() INSTPTN_CHECK_XX_0(OR_JCC)
 #define instptn_check_xor_jcc_0() INSTPTN_CHECK_XX_0(XOR_JCC)
+#define instptn_check_dec_jcc_0() INSTPTN_CHECK_XX_0(DEC_JCC)
 #define instptn_check_or_xx_jcc_0() INSTPTN_CHECK_XX_0(OR_XX_JCC)
 #else
 #define instptn_check_void(option)
@@ -257,6 +258,7 @@ bool insts_pattern_scan_jcc_end(TranslationBlock *tb, IR1_INST *ir1, int index, 
 #define instptn_check_add_jcc_0()
 #define instptn_check_or_jcc_0()
 #define instptn_check_xor_jcc_0()
+#define instptn_check_dec_jcc_0()
 #define instptn_check_or_xx_jcc_0()
 #endif
 

--- a/target/i386/latx/include/insts-pattern.h
+++ b/target/i386/latx/include/insts-pattern.h
@@ -216,6 +216,7 @@ bool insts_pattern_scan_jcc_end(TranslationBlock *tb, IR1_INST *ir1, int index, 
 #define instptn_check_and_jcc_0() INSTPTN_CHECK_XX_0(AND_JCC)
 #define instptn_check_add_jcc_0() INSTPTN_CHECK_XX_0(ADD_JCC)
 #define instptn_check_or_jcc_0() INSTPTN_CHECK_XX_0(OR_JCC)
+#define instptn_check_xor_jcc_0() INSTPTN_CHECK_XX_0(XOR_JCC)
 #define instptn_check_or_xx_jcc_0() INSTPTN_CHECK_XX_0(OR_XX_JCC)
 #else
 #define instptn_check_void(option)
@@ -255,6 +256,7 @@ bool insts_pattern_scan_jcc_end(TranslationBlock *tb, IR1_INST *ir1, int index, 
 #define instptn_check_and_jcc_0()
 #define instptn_check_add_jcc_0()
 #define instptn_check_or_jcc_0()
+#define instptn_check_xor_jcc_0()
 #define instptn_check_or_xx_jcc_0()
 #endif
 

--- a/target/i386/latx/include/insts-pattern.h
+++ b/target/i386/latx/include/insts-pattern.h
@@ -182,6 +182,7 @@ bool insts_pattern_scan_jcc_end(TranslationBlock *tb, IR1_INST *ir1, int index, 
 } while (0)
 
 #define instptn_check_cmp_jcc_0() INSTPTN_CHECK_XX_0(CMP_JCC)
+#define instptn_check_cmp_js_jns_0() INSTPTN_CHECK_XX_0(CMP_JS_JNS)
 #define instptn_check_test_jcc_0() INSTPTN_CHECK_XX_0(TEST_JCC)
 #define instptn_check_bt_jcc_0() INSTPTN_CHECK_XX_0(BT_JCC)
 #define instptn_check_cqo_idiv_0() INSTPTN_CHECK_XX_0(CQO_IDIV)
@@ -206,6 +207,7 @@ bool insts_pattern_scan_jcc_end(TranslationBlock *tb, IR1_INST *ir1, int index, 
 
 #define instptn_check_ucomisd_seta_0() INSTPTN_CHECK_XX_0(UCOMISD_SETA)
 #define instptn_check_sub_jcc_0() INSTPTN_CHECK_XX_0(SUB_JCC)
+#define instptn_check_sub_js_jns_0() INSTPTN_CHECK_XX_0(SUB_JS_JNS)
 
 #define instptn_check_movaps_vst_x4_0() INSTPTN_CHECK_XX_0(MOVAPS_VST_X4)
 #define instptn_check_neg_cmovcc_0() INSTPTN_CHECK_XX_0(NEG_CMOVCC)
@@ -214,6 +216,7 @@ bool insts_pattern_scan_jcc_end(TranslationBlock *tb, IR1_INST *ir1, int index, 
 #define instptn_check_sar_jcc_0() INSTPTN_CHECK_XX_0(SAR_JCC)
 #define instptn_check_shr_je_0() INSTPTN_CHECK_XX_0(SHR_JE)
 #define instptn_check_and_jcc_0() INSTPTN_CHECK_XX_0(AND_JCC)
+#define instptn_check_and_je_0() INSTPTN_CHECK_XX_0(AND_JE)
 #define instptn_check_add_jcc_0() INSTPTN_CHECK_XX_0(ADD_JCC)
 #define instptn_check_or_jcc_0() INSTPTN_CHECK_XX_0(OR_JCC)
 #define instptn_check_xor_jcc_0() INSTPTN_CHECK_XX_0(XOR_JCC)
@@ -223,6 +226,7 @@ bool insts_pattern_scan_jcc_end(TranslationBlock *tb, IR1_INST *ir1, int index, 
 #define instptn_check_void(option)
 #define instptn_check_false(option)
 #define instptn_check_cmp_jcc_0()
+#define instptn_check_cmp_js_jns_0()
 #define instptn_check_test_jcc_0()
 #define instptn_check_bt_jcc_0()
 #define instptn_check_cqo_idiv_0()
@@ -247,6 +251,7 @@ bool insts_pattern_scan_jcc_end(TranslationBlock *tb, IR1_INST *ir1, int index, 
 
 #define instptn_check_ucomisd_seta_0()
 #define instptn_check_sub_jcc_0()
+#define instptn_check_sub_js_jns_0()
 
 #define instptn_check_movaps_vst_x4_0()
 #define instptn_check_neg_cmovcc_0()
@@ -255,6 +260,7 @@ bool insts_pattern_scan_jcc_end(TranslationBlock *tb, IR1_INST *ir1, int index, 
 #define instptn_check_sar_jcc_0()
 #define instptn_check_shr_je_0()
 #define instptn_check_and_jcc_0()
+#define instptn_check_and_je_0()
 #define instptn_check_add_jcc_0()
 #define instptn_check_or_jcc_0()
 #define instptn_check_xor_jcc_0()

--- a/target/i386/latx/include/ir1.h
+++ b/target/i386/latx/include/ir1.h
@@ -144,6 +144,7 @@ typedef enum InstPtnOpcode {
     INSTPTN_OPC_SHR_JE,
     INSTPTN_OPC_OR_JCC,
     INSTPTN_OPC_OR_XX_JCC,
+    INSTPTN_OPC_XOR_JCC,
 } InstPtnOpcode;
 #endif
 

--- a/target/i386/latx/include/ir1.h
+++ b/target/i386/latx/include/ir1.h
@@ -143,6 +143,7 @@ typedef enum InstPtnOpcode {
     INSTPTN_OPC_SAR_JCC,
     INSTPTN_OPC_SHR_JE,
     INSTPTN_OPC_OR_JCC,
+    INSTPTN_OPC_OR_XX_JCC,
 } InstPtnOpcode;
 #endif
 

--- a/target/i386/latx/include/ir1.h
+++ b/target/i386/latx/include/ir1.h
@@ -145,6 +145,7 @@ typedef enum InstPtnOpcode {
     INSTPTN_OPC_OR_JCC,
     INSTPTN_OPC_OR_XX_JCC,
     INSTPTN_OPC_XOR_JCC,
+    INSTPTN_OPC_DEC_JCC,
 } InstPtnOpcode;
 #endif
 

--- a/target/i386/latx/include/ir1.h
+++ b/target/i386/latx/include/ir1.h
@@ -140,6 +140,8 @@ typedef enum InstPtnOpcode {
 
     INSTPTN_OPC_EXTENSION_BASE = 0x20000001,
     INSTPTN_OPC_ADD_JCC        = INSTPTN_OPC_EXTENSION_BASE,
+    INSTPTN_OPC_SAR_JCC,
+    INSTPTN_OPC_SHR_JE,
 } InstPtnOpcode;
 #endif
 

--- a/target/i386/latx/include/ir1.h
+++ b/target/i386/latx/include/ir1.h
@@ -142,6 +142,7 @@ typedef enum InstPtnOpcode {
     INSTPTN_OPC_ADD_JCC        = INSTPTN_OPC_EXTENSION_BASE,
     INSTPTN_OPC_SAR_JCC,
     INSTPTN_OPC_SHR_JE,
+    INSTPTN_OPC_OR_JCC,
 } InstPtnOpcode;
 #endif
 

--- a/target/i386/latx/include/ir1.h
+++ b/target/i386/latx/include/ir1.h
@@ -139,6 +139,7 @@ typedef enum InstPtnOpcode {
     INSTPTN_OPC_AND_JCC        = 0x20000000,
 
     INSTPTN_OPC_EXTENSION_BASE = 0x20000001,
+    INSTPTN_OPC_ADD_JCC        = INSTPTN_OPC_EXTENSION_BASE,
 } InstPtnOpcode;
 #endif
 

--- a/target/i386/latx/include/ir1.h
+++ b/target/i386/latx/include/ir1.h
@@ -95,6 +95,53 @@ typedef dt_x86_insn_group IR1_OPCODE_TYPE;
 
 #define MAX_IR1_NUM_PER_TB TCG_MAX_INSNS
 
+#ifdef CONFIG_LATX_INSTS_PATTERN
+/*
+ * Pattern opcodes identify the translation selected for an IR1 instruction.
+ *
+ * Keep the legacy numeric values stable: some debug and AOT paths retain IR1
+ * metadata while a TB is being processed.  These values are identifiers, not
+ * option bits.  New opcodes may be allocated sequentially starting at
+ * INSTPTN_OPC_EXTENSION_BASE instead of consuming another power of two.
+ */
+typedef enum InstPtnOpcode {
+    INSTPTN_OPC_NONE        = 0x000000,
+    INSTPTN_OPC_NOP         = 0x000001,
+    INSTPTN_OPC_NOP_DIV     = 0x000002,
+    INSTPTN_OPC_CMP_JCC     = 0x000010,
+    INSTPTN_OPC_TEST_JCC    = 0x000020,
+    INSTPTN_OPC_BT_JCC      = 0x000040,
+    INSTPTN_OPC_CQO_IDIV    = 0x000080,
+    INSTPTN_OPC_CMP_SBB     = 0x000100,
+    INSTPTN_OPC_COMISD_JCC  = 0x000200,
+    INSTPTN_OPC_COMISS_JCC  = 0x000400,
+    INSTPTN_OPC_UCOMISD_JCC = 0x000800,
+    INSTPTN_OPC_UCOMISS_JCC = 0x001000,
+    INSTPTN_OPC_XOR_DIV     = 0x002000,
+    INSTPTN_OPC_CDQ_IDIV    = 0x004000,
+
+    INSTPTN_OPC_CMP_XX_JCC     = 0x008000,
+    INSTPTN_OPC_TEST_XX_JCC    = 0x010000,
+    INSTPTN_OPC_BT_XX_JCC      = 0x020000,
+    INSTPTN_OPC_COMISD_XX_JCC  = 0x040000,
+    INSTPTN_OPC_COMISS_XX_JCC  = 0x080000,
+    INSTPTN_OPC_UCOMISD_XX_JCC = 0x100000,
+    INSTPTN_OPC_UCOMISS_XX_JCC = 0x200000,
+
+    INSTPTN_OPC_CMP_XXCC       = 0x400000,
+    INSTPTN_OPC_TEST_XXCC      = 0x800000,
+
+    INSTPTN_OPC_UCOMISD_SETA   = 0x1000000,
+    INSTPTN_OPC_SUB_JCC        = 0x2000000,
+    INSTPTN_OPC_MOVAPS_VST_X4  = 0x4000000,
+    INSTPTN_OPC_NEG_CMOVCC     = 0x8000000,
+    INSTPTN_OPC_SHR_JCC        = 0x10000000,
+    INSTPTN_OPC_AND_JCC        = 0x20000000,
+
+    INSTPTN_OPC_EXTENSION_BASE = 0x20000001,
+} InstPtnOpcode;
+#endif
+
 typedef struct IR1_INST {
     struct la_dt_insn *info;
     /**
@@ -142,7 +189,7 @@ typedef struct IR1_INST {
 #endif
 #ifdef CONFIG_LATX_INSTS_PATTERN
     struct {
-        int opc;
+        InstPtnOpcode opc;
         struct IR1_INST * next; /* index of IR1 list */
     } instptn;
 #endif

--- a/target/i386/latx/include/ir1.h
+++ b/target/i386/latx/include/ir1.h
@@ -146,6 +146,9 @@ typedef enum InstPtnOpcode {
     INSTPTN_OPC_OR_XX_JCC,
     INSTPTN_OPC_XOR_JCC,
     INSTPTN_OPC_DEC_JCC,
+    INSTPTN_OPC_CMP_JS_JNS,
+    INSTPTN_OPC_SUB_JS_JNS,
+    INSTPTN_OPC_AND_JE,
 } InstPtnOpcode;
 #endif
 

--- a/target/i386/latx/include/latx-options.h
+++ b/target/i386/latx/include/latx-options.h
@@ -22,7 +22,10 @@
 #endif
 
 #ifdef CONFIG_LATX_INSTS_PATTERN
-extern int option_instptn;
+extern uint64_t option_instptn;
+extern int option_instptn_stats;
+extern char *option_instptn_mask_error;
+extern char *option_instptn_stats_error;
 #endif
 #ifdef CONFIG_LATX_FLAG_REDUCTION
 extern int option_flag_reduction;
@@ -149,6 +152,14 @@ extern unsigned long long counter_mips_tr;
 #define ENVSUP_LATX
 #endif
 
+#if defined(CONFIG_LATX) && defined(CONFIG_LATX_INSTS_PATTERN)
+#define ENVSUP_INSTPTN \
+    ENVFUN(LATX_INSTPTN_MASK, handle_arg_latx_instptn_mask) \
+    ENVFUN(LATX_INSTPTN_STATS, handle_arg_latx_instptn_stats)
+#else
+#define ENVSUP_INSTPTN
+#endif
+
 #if defined(CONFIG_LATX) && defined(CONFIG_LATX_AVX_OPT)
 #define ENVSUP_AVX \
     ENVFUN(LATX_AVX_CPUID, handle_arg_latx_avx_cpuid)
@@ -229,6 +240,7 @@ extern unsigned long long counter_mips_tr;
 
 #define ENVS \
     ENVSUP_LATX \
+    ENVSUP_INSTPTN \
     ENVSUP_AVX \
     ENVSUP_KZT \
     ENVSUP_AOT \
@@ -240,6 +252,10 @@ extern unsigned long long counter_mips_tr;
 void options_init(void);
 bool latx_options_finalize(void);
 void options_parse_opt(const char *opt);
+#ifdef CONFIG_LATX_INSTS_PATTERN
+void options_parse_instptn_mask(const char *arg);
+void options_parse_instptn_stats(const char *arg);
+#endif
 void options_parse_imm_reg(const char *bits);
 void options_parse_dump(const char *bits);
 void options_parse_show_tb(const char *pc);

--- a/target/i386/latx/latx-options.c
+++ b/target/i386/latx/latx-options.c
@@ -56,7 +56,10 @@ int option_tunnel_lib;
 #endif
 
 #ifdef CONFIG_LATX_INSTS_PATTERN
-int option_instptn = 0x3ffffff;
+uint64_t option_instptn = INSTPTN_DEFAULT_OPTIONS;
+int option_instptn_stats;
+char *option_instptn_mask_error;
+char *option_instptn_stats_error;
 #endif
 
 int close_latx_parallel;
@@ -243,6 +246,14 @@ void options_init(void)
     counter_ir1_tr = 0;
     counter_mips_tr = 0;
 
+#ifdef CONFIG_LATX_INSTS_PATTERN
+    option_instptn = INSTPTN_DEFAULT_OPTIONS;
+    option_instptn_stats = 0;
+    g_clear_pointer(&option_instptn_mask_error, g_free);
+    g_clear_pointer(&option_instptn_stats_error, g_free);
+    instptn_stats_reset();
+#endif
+
 #ifdef CONFIG_LATX_AVX_OPT
     option_avx_cpuid = 1;
 #endif /*CONFIG_LATX_AVX_OPT*/
@@ -289,6 +300,11 @@ void options_init(void)
 
 bool latx_options_finalize(void)
 {
+#ifdef CONFIG_LATX_INSTS_PATTERN
+    if (option_instptn_mask_error || option_instptn_stats_error) {
+        return false;
+    }
+#endif
 #if defined(CONFIG_LATX_KZT)
     if (option_kzt_log_error) {
         kzt_groups_reject_configuration(option_kzt_log_error, true);
@@ -313,6 +329,41 @@ bool latx_options_finalize(void)
 #endif
     return true;
 }
+
+#ifdef CONFIG_LATX_INSTS_PATTERN
+void options_parse_instptn_mask(const char *arg)
+{
+    uint64_t mask;
+
+    g_clear_pointer(&option_instptn_mask_error, g_free);
+    if (!arg || qemu_strtou64(arg, NULL, 0, &mask) ||
+        (mask & ~INSTPTN_ALL_OPTIONS)) {
+        option_instptn_mask_error = g_strdup_printf(
+            "LATX_INSTPTN_MASK must be a valid instruction "
+            "pattern mask (got '%s')", arg ? arg : "");
+        error_report("%s", option_instptn_mask_error);
+        return;
+    }
+    option_instptn = mask;
+}
+
+void options_parse_instptn_stats(const char *arg)
+{
+    int enabled;
+
+    g_clear_pointer(&option_instptn_stats_error, g_free);
+    if (!arg || qemu_strtoi(arg, NULL, 0, &enabled) ||
+        (enabled != 0 && enabled != 1)) {
+        option_instptn_stats_error = g_strdup_printf(
+            "LATX_INSTPTN_STATS must be exactly 0 or 1 (got '%s')",
+            arg ? arg : "");
+        error_report("%s", option_instptn_stats_error);
+        return;
+    }
+
+    option_instptn_stats = enabled;
+}
+#endif
 
 #define OPTIONS_IMM_REG 0
 #define OPTIONS_IMM_RIP 1

--- a/target/i386/latx/optimization/insts-pattern.c
+++ b/target/i386/latx/optimization/insts-pattern.c
@@ -176,6 +176,9 @@ static bool instptn_opcode_to_option(InstPtnOpcode opcode,
     case INSTPTN_OPC_OR_JCC:
         *option = INSTPTN_OPT_OR_JCC;
         break;
+    case INSTPTN_OPC_XOR_JCC:
+        *option = INSTPTN_OPT_XOR_JCC;
+        break;
     case INSTPTN_OPC_OR_XX_JCC:
         *option = INSTPTN_OPT_OR_XX_JCC;
         break;
@@ -1083,6 +1086,43 @@ bool insts_pattern_scan_jcc_end(TranslationBlock *tb, IR1_INST *pir1, int pir1_i
             return false;
         default:
             INSTPTN_REJECT_AND_RETURN(or_option,
+                                      INSTPTN_REJECT_UNSUPPORTED_CC, false);
+        }
+    case WRAP(XOR):
+        SCAN_CHECK(scan, 0);
+        ir1_jcc = SCAN_IR1(tb, scan, 0);
+        opnd0 = ir1_get_opnd(pir1, 0);
+        opnd1 = ir1_get_opnd(pir1, 1);
+        if ((!ir1_opnd_is_gpr(opnd0) && !ir1_opnd_is_mem(opnd0)) ||
+            (!ir1_opnd_is_gpr(opnd1) && !ir1_opnd_is_mem(opnd1) &&
+             !ir1_opnd_is_imm(opnd1))) {
+            INSTPTN_REJECT_AND_RETURN(
+                INSTPTN_OPT_XOR_JCC,
+                INSTPTN_REJECT_UNSUPPORTED_OPERAND, false);
+        }
+        if (ir1_is_prefix_lock(pir1)) {
+            INSTPTN_REJECT_AND_RETURN(
+                INSTPTN_OPT_XOR_JCC,
+                INSTPTN_REJECT_FAULT_OR_HELPER, false);
+        }
+        switch (ir1_opcode(ir1_jcc)) {
+        case WRAP(JE):
+        case WRAP(JNE):
+        case WRAP(JS):
+        case WRAP(JNS):
+            if (pir1_index + 1 == SCAN_IDX(scan, 0)) {
+                instptn_check_xor_jcc_0();
+                pir1->instptn.opc = INSTPTN_OPC_XOR_JCC;
+                pir1->instptn.next = ir1_jcc;
+                ir1_jcc->instptn.opc = INSTPTN_OPC_NOP;
+            } else {
+                instptn_stats_record_reject(
+                    INSTPTN_OPT_XOR_JCC,
+                    INSTPTN_REJECT_NON_ADJACENT);
+            }
+            return false;
+        default:
+            INSTPTN_REJECT_AND_RETURN(INSTPTN_OPT_XOR_JCC,
                                       INSTPTN_REJECT_UNSUPPORTED_CC, false);
         }
 #ifdef CONFIG_LATX_XCOMISX_OPT

--- a/target/i386/latx/optimization/insts-pattern.c
+++ b/target/i386/latx/optimization/insts-pattern.c
@@ -176,6 +176,9 @@ static bool instptn_opcode_to_option(InstPtnOpcode opcode,
     case INSTPTN_OPC_OR_JCC:
         *option = INSTPTN_OPT_OR_JCC;
         break;
+    case INSTPTN_OPC_OR_XX_JCC:
+        *option = INSTPTN_OPT_OR_XX_JCC;
+        break;
     default:
         return false;
     }
@@ -1034,18 +1037,21 @@ bool insts_pattern_scan_jcc_end(TranslationBlock *tb, IR1_INST *pir1, int pir1_i
     case WRAP(OR):
         SCAN_CHECK(scan, 0);
         ir1_jcc = SCAN_IR1(tb, scan, 0);
+        bool adjacent = pir1_index + 1 == SCAN_IDX(scan, 0);
+        InstPtnOption or_option = adjacent ? INSTPTN_OPT_OR_JCC :
+                                            INSTPTN_OPT_OR_XX_JCC;
         opnd0 = ir1_get_opnd(pir1, 0);
         opnd1 = ir1_get_opnd(pir1, 1);
         if ((!ir1_opnd_is_gpr(opnd0) && !ir1_opnd_is_mem(opnd0)) ||
             (!ir1_opnd_is_gpr(opnd1) && !ir1_opnd_is_mem(opnd1) &&
              !ir1_opnd_is_imm(opnd1))) {
             INSTPTN_REJECT_AND_RETURN(
-                INSTPTN_OPT_OR_JCC,
+                or_option,
                 INSTPTN_REJECT_UNSUPPORTED_OPERAND, false);
         }
         if (ir1_is_prefix_lock(pir1)) {
             INSTPTN_REJECT_AND_RETURN(
-                INSTPTN_OPT_OR_JCC,
+                or_option,
                 INSTPTN_REJECT_FAULT_OR_HELPER, false);
         }
         switch (ir1_opcode(ir1_jcc)) {
@@ -1053,7 +1059,7 @@ bool insts_pattern_scan_jcc_end(TranslationBlock *tb, IR1_INST *pir1, int pir1_i
         case WRAP(JNE):
         case WRAP(JS):
         case WRAP(JNS):
-            if (pir1_index + 1 == SCAN_IDX(scan, 0)) {
+            if (adjacent) {
                 instptn_check_or_jcc_0();
                 pir1->instptn.opc = INSTPTN_OPC_OR_JCC;
                 pir1->instptn.next = ir1_jcc;
@@ -1062,10 +1068,21 @@ bool insts_pattern_scan_jcc_end(TranslationBlock *tb, IR1_INST *pir1, int pir1_i
                 instptn_stats_record_reject(
                     INSTPTN_OPT_OR_JCC,
                     INSTPTN_REJECT_NON_ADJACENT);
+                if (!ir1_opnd_is_gpr(opnd0)) {
+                    INSTPTN_REJECT_AND_RETURN(
+                        INSTPTN_OPT_OR_XX_JCC,
+                        INSTPTN_REJECT_FAULT_OR_HELPER, false);
+                }
+                instptn_check_or_xx_jcc_0();
+                pir1->instptn.opc = INSTPTN_OPC_OR_XX_JCC;
+                pir1->instptn.next = ir1_jcc;
+                ir1_jcc->instptn.opc = INSTPTN_OPC_OR_XX_JCC;
+                ir1_jcc->instptn.next = pir1;
+                tb->has_jcc_end_ptn = true;
             }
             return false;
         default:
-            INSTPTN_REJECT_AND_RETURN(INSTPTN_OPT_OR_JCC,
+            INSTPTN_REJECT_AND_RETURN(or_option,
                                       INSTPTN_REJECT_UNSUPPORTED_CC, false);
         }
 #ifdef CONFIG_LATX_XCOMISX_OPT

--- a/target/i386/latx/optimization/insts-pattern.c
+++ b/target/i386/latx/optimization/insts-pattern.c
@@ -179,6 +179,9 @@ static bool instptn_opcode_to_option(InstPtnOpcode opcode,
     case INSTPTN_OPC_XOR_JCC:
         *option = INSTPTN_OPT_XOR_JCC;
         break;
+    case INSTPTN_OPC_DEC_JCC:
+        *option = INSTPTN_OPT_DEC_JCC;
+        break;
     case INSTPTN_OPC_OR_XX_JCC:
         *option = INSTPTN_OPT_OR_XX_JCC;
         break;
@@ -998,6 +1001,38 @@ bool insts_pattern_scan_jcc_end(TranslationBlock *tb, IR1_INST *pir1, int pir1_i
             return false;
         default:
             INSTPTN_REJECT_AND_RETURN(INSTPTN_OPT_AND_JCC,
+                                      INSTPTN_REJECT_UNSUPPORTED_CC, false);
+        }
+    case WRAP(DEC):
+        SCAN_CHECK(scan, 0);
+        ir1_jcc = SCAN_IR1(tb, scan, 0);
+        opnd0 = ir1_get_opnd(pir1, 0);
+        if (!ir1_opnd_is_gpr(opnd0)) {
+            INSTPTN_REJECT_AND_RETURN(
+                INSTPTN_OPT_DEC_JCC,
+                INSTPTN_REJECT_UNSUPPORTED_OPERAND, false);
+        }
+        if (ir1_is_prefix_lock(pir1)) {
+            INSTPTN_REJECT_AND_RETURN(
+                INSTPTN_OPT_DEC_JCC,
+                INSTPTN_REJECT_FAULT_OR_HELPER, false);
+        }
+        switch (ir1_opcode(ir1_jcc)) {
+        case WRAP(JE):
+        case WRAP(JNE):
+            if (pir1_index + 1 == SCAN_IDX(scan, 0)) {
+                instptn_check_dec_jcc_0();
+                pir1->instptn.opc = INSTPTN_OPC_DEC_JCC;
+                pir1->instptn.next = ir1_jcc;
+                ir1_jcc->instptn.opc = INSTPTN_OPC_NOP;
+            } else {
+                instptn_stats_record_reject(
+                    INSTPTN_OPT_DEC_JCC,
+                    INSTPTN_REJECT_NON_ADJACENT);
+            }
+            return false;
+        default:
+            INSTPTN_REJECT_AND_RETURN(INSTPTN_OPT_DEC_JCC,
                                       INSTPTN_REJECT_UNSUPPORTED_CC, false);
         }
     case WRAP(ADD):

--- a/target/i386/latx/optimization/insts-pattern.c
+++ b/target/i386/latx/optimization/insts-pattern.c
@@ -164,6 +164,9 @@ static bool instptn_opcode_to_option(InstPtnOpcode opcode,
     case INSTPTN_OPC_AND_JCC:
         *option = INSTPTN_OPT_AND_JCC;
         break;
+    case INSTPTN_OPC_ADD_JCC:
+        *option = INSTPTN_OPT_ADD_JCC;
+        break;
     default:
         return false;
     }
@@ -195,6 +198,15 @@ void instptn_stats_record_reject(InstPtnOption option,
         return;
     }
     qatomic_inc(&instptn_stats[option].rejects[reason]);
+}
+
+void instptn_stats_record_eflags_eliminated(InstPtnOption option)
+{
+    if (!option_instptn_stats || option < 0 ||
+        option >= INSTPTN_OPT_COUNT) {
+        return;
+    }
+    qatomic_inc(&instptn_stats[option].eflags_eliminations);
 }
 
 void instptn_stats_record_eflags_fallback(InstPtnOption option)
@@ -241,10 +253,11 @@ void instptn_stats_dump(void)
     for (int i = 0; i < INSTPTN_OPT_COUNT; i++) {
         InstPtnStats *stats = &instptn_stats[i];
         uint64_t matches = qatomic_read(&stats->matches);
+        uint64_t eliminated = qatomic_read(&stats->eflags_eliminations);
         uint64_t eflags = qatomic_read(&stats->eflags_fallbacks);
         uint64_t ir2 = qatomic_read(&stats->ir2_emitted);
         uint64_t host = qatomic_read(&stats->host_emitted);
-        bool populated = matches || eflags || ir2 || host;
+        bool populated = matches || eliminated || eflags || ir2 || host;
 
         for (int reason = 0; reason < INSTPTN_REJECT_COUNT; reason++) {
             populated |= qatomic_read(&stats->rejects[reason]) != 0;
@@ -255,9 +268,10 @@ void instptn_stats_dump(void)
 
         fprintf(stderr,
                 "[LATX][instptn] %s match=%" PRIu64
+                " eflags-eliminated=%" PRIu64
                 " eflags-fallback=%" PRIu64
                 " ir2=%" PRIu64 " host=%" PRIu64 "\n",
-                instptn_option_names[i], matches, eflags,
+                instptn_option_names[i], matches, eliminated, eflags,
                 ir2, host);
         for (int reason = 0; reason < INSTPTN_REJECT_COUNT; reason++) {
             uint64_t rejects = qatomic_read(&stats->rejects[reason]);
@@ -905,6 +919,43 @@ bool insts_pattern_scan_jcc_end(TranslationBlock *tb, IR1_INST *pir1, int pir1_i
             return false;
         default:
             INSTPTN_REJECT_AND_RETURN(INSTPTN_OPT_AND_JCC,
+                                      INSTPTN_REJECT_UNSUPPORTED_CC, false);
+        }
+    case WRAP(ADD):
+        SCAN_CHECK(scan, 0);
+        ir1_jcc = SCAN_IR1(tb, scan, 0);
+        opnd0 = ir1_get_opnd(pir1, 0);
+        opnd1 = ir1_get_opnd(pir1, 1);
+        if ((!ir1_opnd_is_gpr(opnd0) && !ir1_opnd_is_mem(opnd0)) ||
+            (!ir1_opnd_is_gpr(opnd1) && !ir1_opnd_is_mem(opnd1) &&
+             !ir1_opnd_is_imm(opnd1))) {
+            INSTPTN_REJECT_AND_RETURN(
+                INSTPTN_OPT_ADD_JCC,
+                INSTPTN_REJECT_UNSUPPORTED_OPERAND, false);
+        }
+        if (ir1_is_prefix_lock(pir1)) {
+            INSTPTN_REJECT_AND_RETURN(
+                INSTPTN_OPT_ADD_JCC,
+                INSTPTN_REJECT_FAULT_OR_HELPER, false);
+        }
+        switch (ir1_opcode(ir1_jcc)) {
+        case WRAP(JE):
+        case WRAP(JNE):
+        case WRAP(JS):
+        case WRAP(JNS):
+            if (pir1_index + 1 == SCAN_IDX(scan, 0)) {
+                instptn_check_add_jcc_0();
+                pir1->instptn.opc = INSTPTN_OPC_ADD_JCC;
+                pir1->instptn.next = ir1_jcc;
+                ir1_jcc->instptn.opc = INSTPTN_OPC_NOP;
+            } else {
+                instptn_stats_record_reject(
+                    INSTPTN_OPT_ADD_JCC,
+                    INSTPTN_REJECT_NON_ADJACENT);
+            }
+            return false;
+        default:
+            INSTPTN_REJECT_AND_RETURN(INSTPTN_OPT_ADD_JCC,
                                       INSTPTN_REJECT_UNSUPPORTED_CC, false);
         }
 #ifdef CONFIG_LATX_XCOMISX_OPT

--- a/target/i386/latx/optimization/insts-pattern.c
+++ b/target/i386/latx/optimization/insts-pattern.c
@@ -167,6 +167,12 @@ static bool instptn_opcode_to_option(InstPtnOpcode opcode,
     case INSTPTN_OPC_ADD_JCC:
         *option = INSTPTN_OPT_ADD_JCC;
         break;
+    case INSTPTN_OPC_SAR_JCC:
+        *option = INSTPTN_OPT_SAR_JCC;
+        break;
+    case INSTPTN_OPC_SHR_JE:
+        *option = INSTPTN_OPT_SHR_JE;
+        break;
     default:
         return false;
     }
@@ -721,6 +727,8 @@ bool insts_pattern_scan_jcc_end(TranslationBlock *tb, IR1_INST *pir1, int pir1_i
     IR1_INST *ir1_jcc = NULL;
     IR1_OPND *opnd0 = NULL;
     IR1_OPND *opnd1 = NULL;
+    InstPtnOption shift_option;
+    InstPtnOpcode shift_opcode;
     switch (ir1_opcode(pir1)) {
         case WRAP(CMP):
         SCAN_CHECK(scan, 0);
@@ -867,39 +875,85 @@ bool insts_pattern_scan_jcc_end(TranslationBlock *tb, IR1_INST *pir1, int pir1_i
             INSTPTN_REJECT_AND_RETURN(INSTPTN_OPT_SUB_JCC,
                                       INSTPTN_REJECT_UNSUPPORTED_CC, false);
         }
-    case WRAP(SHR):
+    case WRAP(SAR):
         SCAN_CHECK(scan, 0);
         ir1_jcc = SCAN_IR1(tb, scan, 0);
+        opnd0 = ir1_get_opnd(pir1, 0);
         opnd1 = ir1_get_opnd(pir1, 1);
         if (!ir1_opnd_is_imm(opnd1)) {
             INSTPTN_REJECT_AND_RETURN(
-                INSTPTN_OPT_SHR_JCC,
+                INSTPTN_OPT_SAR_JCC,
                 INSTPTN_REJECT_UNSUPPORTED_OPERAND, false);
         }
         if ((ir1_opnd_uimm(opnd1) &
-             (ir1_opnd_size(ir1_get_opnd(pir1, 0)) == 64 ? 63 : 31)) == 0) {
+             (ir1_opnd_size(opnd0) == 64 ? 63 : 31)) == 0) {
             INSTPTN_REJECT_AND_RETURN(
-                INSTPTN_OPT_SHR_JCC,
+                INSTPTN_OPT_SAR_JCC,
                 INSTPTN_REJECT_ZERO_SHIFT_COUNT, false);
         }
         switch (ir1_opcode(ir1_jcc)) {
+        case WRAP(JE):
         case WRAP(JNE):
+        case WRAP(JS):
+        case WRAP(JNS):
             if (pir1_index + 1 == SCAN_IDX(scan, 0)) {
-                instptn_check_shr_jcc_0();
-                pir1->instptn.opc  = INSTPTN_OPC_SHR_JCC;
+                instptn_check_sar_jcc_0();
+                pir1->instptn.opc = INSTPTN_OPC_SAR_JCC;
                 pir1->instptn.next = ir1_jcc;
-                ir1_jcc->instptn.opc  = INSTPTN_OPC_NOP;
-                // ir1_jcc->instptn.next = NULL;
+                ir1_jcc->instptn.opc = INSTPTN_OPC_NOP;
             } else {
                 instptn_stats_record_reject(
-                    INSTPTN_OPT_SHR_JCC,
+                    INSTPTN_OPT_SAR_JCC,
                     INSTPTN_REJECT_NON_ADJACENT);
             }
             return false;
         default:
+            INSTPTN_REJECT_AND_RETURN(INSTPTN_OPT_SAR_JCC,
+                                      INSTPTN_REJECT_UNSUPPORTED_CC, false);
+        }
+    case WRAP(SHR):
+        SCAN_CHECK(scan, 0);
+        ir1_jcc = SCAN_IR1(tb, scan, 0);
+        switch (ir1_opcode(ir1_jcc)) {
+        case WRAP(JE):
+            shift_option = INSTPTN_OPT_SHR_JE;
+            shift_opcode = INSTPTN_OPC_SHR_JE;
+            break;
+        case WRAP(JNE):
+            shift_option = INSTPTN_OPT_SHR_JCC;
+            shift_opcode = INSTPTN_OPC_SHR_JCC;
+            break;
+        default:
             INSTPTN_REJECT_AND_RETURN(INSTPTN_OPT_SHR_JCC,
                                       INSTPTN_REJECT_UNSUPPORTED_CC, false);
         }
+        opnd0 = ir1_get_opnd(pir1, 0);
+        opnd1 = ir1_get_opnd(pir1, 1);
+        if (!ir1_opnd_is_imm(opnd1)) {
+            INSTPTN_REJECT_AND_RETURN(
+                shift_option,
+                INSTPTN_REJECT_UNSUPPORTED_OPERAND, false);
+        }
+        if ((ir1_opnd_uimm(opnd1) &
+             (ir1_opnd_size(opnd0) == 64 ? 63 : 31)) == 0) {
+            INSTPTN_REJECT_AND_RETURN(
+                shift_option,
+                INSTPTN_REJECT_ZERO_SHIFT_COUNT, false);
+        }
+        if (pir1_index + 1 == SCAN_IDX(scan, 0)) {
+            if (shift_option == INSTPTN_OPT_SHR_JE) {
+                instptn_check_shr_je_0();
+            } else {
+                instptn_check_shr_jcc_0();
+            }
+            pir1->instptn.opc = shift_opcode;
+            pir1->instptn.next = ir1_jcc;
+            ir1_jcc->instptn.opc = INSTPTN_OPC_NOP;
+        } else {
+            instptn_stats_record_reject(
+                shift_option, INSTPTN_REJECT_NON_ADJACENT);
+        }
+        return false;
     case WRAP(AND):
         SCAN_CHECK(scan, 0);
         ir1_jcc = SCAN_IR1(tb, scan, 0);

--- a/target/i386/latx/optimization/insts-pattern.c
+++ b/target/i386/latx/optimization/insts-pattern.c
@@ -762,6 +762,19 @@ bool insts_pattern_scan_jcc_end(TranslationBlock *tb, IR1_INST *pir1, int pir1_i
                 tb->has_jcc_end_ptn = true;
             }
             return false;
+        case WRAP(JS):
+        case WRAP(JNS):
+            if (pir1_index + 1 == SCAN_IDX(scan, 0)) {
+                instptn_check_cmp_jcc_0();
+                pir1->instptn.opc = INSTPTN_OPC_CMP_JCC;
+                pir1->instptn.next = ir1_jcc;
+                ir1_jcc->instptn.opc = INSTPTN_OPC_NOP;
+            } else {
+                instptn_stats_record_reject(
+                    INSTPTN_OPT_CMP_JCC,
+                    INSTPTN_REJECT_NON_ADJACENT);
+            }
+            return false;
         default:
             INSTPTN_REJECT_AND_RETURN(
                 pir1_index + 1 == SCAN_IDX(scan, 0) ?
@@ -862,6 +875,8 @@ bool insts_pattern_scan_jcc_end(TranslationBlock *tb, IR1_INST *pir1, int pir1_i
         case WRAP(JGE):
         case WRAP(JLE):
         case WRAP(JG):
+        case WRAP(JS):
+        case WRAP(JNS):
             if (pir1_index + 1 == SCAN_IDX(scan, 0)) {
                 instptn_check_sub_jcc_0();
                 pir1->instptn.opc  = INSTPTN_OPC_SUB_JCC;
@@ -961,6 +976,7 @@ bool insts_pattern_scan_jcc_end(TranslationBlock *tb, IR1_INST *pir1, int pir1_i
         SCAN_CHECK(scan, 0);
         ir1_jcc = SCAN_IR1(tb, scan, 0);
         switch (ir1_opcode(ir1_jcc)) {
+        case WRAP(JE):
         case WRAP(JNE):
             if (pir1_index + 1 == SCAN_IDX(scan, 0)) {
                 instptn_check_and_jcc_0();

--- a/target/i386/latx/optimization/insts-pattern.c
+++ b/target/i386/latx/optimization/insts-pattern.c
@@ -23,6 +23,253 @@
 } while (0)
 #define SCAN_IDX(buf, i)        (buf[i])
 #define SCAN_IR1(tb, buf, i)    (tb_ir1_inst(tb, SCAN_IDX(buf, i)))
+#define INSTPTN_REJECT_AND_RETURN(option, reason, value) do { \
+    instptn_stats_record_reject((option), (reason)); \
+    return (value); \
+} while (0)
+
+InstPtnStats instptn_stats[INSTPTN_OPT_COUNT];
+
+static const char *const instptn_option_names[INSTPTN_OPT_COUNT] = {
+    [INSTPTN_OPT_CMP_JCC] = "cmp-jcc",
+    [INSTPTN_OPT_TEST_JCC] = "test-jcc",
+    [INSTPTN_OPT_BT_JCC] = "bt-jcc",
+    [INSTPTN_OPT_CQO_IDIV] = "cqo-idiv",
+    [INSTPTN_OPT_CMP_SBB] = "cmp-sbb",
+    [INSTPTN_OPT_COMISD_JCC] = "comisd-jcc",
+    [INSTPTN_OPT_COMISS_JCC] = "comiss-jcc",
+    [INSTPTN_OPT_UCOMISD_JCC] = "ucomisd-jcc",
+    [INSTPTN_OPT_UCOMISS_JCC] = "ucomiss-jcc",
+    [INSTPTN_OPT_XOR_DIV] = "xor-div",
+    [INSTPTN_OPT_CDQ_IDIV] = "cdq-idiv",
+    [INSTPTN_OPT_CMP_XX_JCC] = "cmp-xx-jcc",
+    [INSTPTN_OPT_TEST_XX_JCC] = "test-xx-jcc",
+    [INSTPTN_OPT_BT_XX_JCC] = "bt-xx-jcc",
+    [INSTPTN_OPT_COMISD_XX_JCC] = "comisd-xx-jcc",
+    [INSTPTN_OPT_COMISS_XX_JCC] = "comiss-xx-jcc",
+    [INSTPTN_OPT_UCOMISD_XX_JCC] = "ucomisd-xx-jcc",
+    [INSTPTN_OPT_UCOMISS_XX_JCC] = "ucomiss-xx-jcc",
+    [INSTPTN_OPT_CMP_XXCC] = "cmp-xxcc",
+    [INSTPTN_OPT_TEST_XXCC] = "test-xxcc",
+    [INSTPTN_OPT_UCOMISD_SETA] = "ucomisd-seta",
+    [INSTPTN_OPT_SUB_JCC] = "sub-jcc",
+    [INSTPTN_OPT_MOVAPS_VST_X4] = "movaps-vst-x4",
+    [INSTPTN_OPT_NEG_CMOVCC] = "neg-cmovcc",
+    [INSTPTN_OPT_SHR_JCC] = "shr-jcc",
+    [INSTPTN_OPT_AND_JCC] = "and-jcc",
+    [INSTPTN_OPT_ADD_JCC] = "add-jcc",
+    [INSTPTN_OPT_OR_JCC] = "or-jcc",
+    [INSTPTN_OPT_XOR_JCC] = "xor-jcc",
+    [INSTPTN_OPT_SAR_JCC] = "sar-jcc",
+    [INSTPTN_OPT_DEC_JCC] = "dec-jcc",
+    [INSTPTN_OPT_CMP_JS_JNS] = "cmp-js-jns",
+    [INSTPTN_OPT_SUB_JS_JNS] = "sub-js-jns",
+    [INSTPTN_OPT_AND_JE] = "and-je",
+    [INSTPTN_OPT_SHR_JE] = "shr-je",
+    [INSTPTN_OPT_OR_XX_JCC] = "or-xx-jcc",
+};
+
+static const char *const instptn_reject_names[INSTPTN_REJECT_COUNT] = {
+    [INSTPTN_REJECT_DISABLED] = "disabled",
+    [INSTPTN_REJECT_NON_ADJACENT] = "non-adjacent",
+    [INSTPTN_REJECT_UNSUPPORTED_CC] = "unsupported-cc",
+    [INSTPTN_REJECT_UNSUPPORTED_OPERAND] = "unsupported-operand",
+    [INSTPTN_REJECT_ZERO_SHIFT_COUNT] = "zero-shift-count",
+    [INSTPTN_REJECT_FLAGS_LIVE] = "flags-live",
+    [INSTPTN_REJECT_CLOBBER] = "clobber",
+    [INSTPTN_REJECT_FAULT_OR_HELPER] = "fault-or-helper",
+    [INSTPTN_REJECT_TEMP_LIFETIME] = "temp-lifetime",
+    [INSTPTN_REJECT_OTHER] = "other",
+};
+
+static bool instptn_opcode_to_option(InstPtnOpcode opcode,
+                                     InstPtnOption *option)
+{
+    switch (opcode) {
+    case INSTPTN_OPC_CMP_JCC:
+        *option = INSTPTN_OPT_CMP_JCC;
+        break;
+    case INSTPTN_OPC_TEST_JCC:
+        *option = INSTPTN_OPT_TEST_JCC;
+        break;
+    case INSTPTN_OPC_BT_JCC:
+        *option = INSTPTN_OPT_BT_JCC;
+        break;
+    case INSTPTN_OPC_CQO_IDIV:
+        *option = INSTPTN_OPT_CQO_IDIV;
+        break;
+    case INSTPTN_OPC_CMP_SBB:
+        *option = INSTPTN_OPT_CMP_SBB;
+        break;
+    case INSTPTN_OPC_COMISD_JCC:
+        *option = INSTPTN_OPT_COMISD_JCC;
+        break;
+    case INSTPTN_OPC_COMISS_JCC:
+        *option = INSTPTN_OPT_COMISS_JCC;
+        break;
+    case INSTPTN_OPC_UCOMISD_JCC:
+        *option = INSTPTN_OPT_UCOMISD_JCC;
+        break;
+    case INSTPTN_OPC_UCOMISS_JCC:
+        *option = INSTPTN_OPT_UCOMISS_JCC;
+        break;
+    case INSTPTN_OPC_XOR_DIV:
+        *option = INSTPTN_OPT_XOR_DIV;
+        break;
+    case INSTPTN_OPC_CDQ_IDIV:
+        *option = INSTPTN_OPT_CDQ_IDIV;
+        break;
+    case INSTPTN_OPC_CMP_XX_JCC:
+        *option = INSTPTN_OPT_CMP_XX_JCC;
+        break;
+    case INSTPTN_OPC_TEST_XX_JCC:
+        *option = INSTPTN_OPT_TEST_XX_JCC;
+        break;
+    case INSTPTN_OPC_BT_XX_JCC:
+        *option = INSTPTN_OPT_BT_XX_JCC;
+        break;
+    case INSTPTN_OPC_COMISD_XX_JCC:
+        *option = INSTPTN_OPT_COMISD_XX_JCC;
+        break;
+    case INSTPTN_OPC_COMISS_XX_JCC:
+        *option = INSTPTN_OPT_COMISS_XX_JCC;
+        break;
+    case INSTPTN_OPC_UCOMISD_XX_JCC:
+        *option = INSTPTN_OPT_UCOMISD_XX_JCC;
+        break;
+    case INSTPTN_OPC_UCOMISS_XX_JCC:
+        *option = INSTPTN_OPT_UCOMISS_XX_JCC;
+        break;
+    case INSTPTN_OPC_CMP_XXCC:
+        *option = INSTPTN_OPT_CMP_XXCC;
+        break;
+    case INSTPTN_OPC_TEST_XXCC:
+        *option = INSTPTN_OPT_TEST_XXCC;
+        break;
+    case INSTPTN_OPC_UCOMISD_SETA:
+        *option = INSTPTN_OPT_UCOMISD_SETA;
+        break;
+    case INSTPTN_OPC_SUB_JCC:
+        *option = INSTPTN_OPT_SUB_JCC;
+        break;
+    case INSTPTN_OPC_MOVAPS_VST_X4:
+        *option = INSTPTN_OPT_MOVAPS_VST_X4;
+        break;
+    case INSTPTN_OPC_NEG_CMOVCC:
+        *option = INSTPTN_OPT_NEG_CMOVCC;
+        break;
+    case INSTPTN_OPC_SHR_JCC:
+        *option = INSTPTN_OPT_SHR_JCC;
+        break;
+    case INSTPTN_OPC_AND_JCC:
+        *option = INSTPTN_OPT_AND_JCC;
+        break;
+    default:
+        return false;
+    }
+    return true;
+}
+
+void instptn_stats_reset(void)
+{
+    memset(instptn_stats, 0, sizeof(instptn_stats));
+}
+
+void instptn_stats_record_match_opcode(InstPtnOpcode opcode)
+{
+    InstPtnOption option;
+
+    if (!option_instptn_stats ||
+        !instptn_opcode_to_option(opcode, &option)) {
+        return;
+    }
+    qatomic_inc(&instptn_stats[option].matches);
+}
+
+void instptn_stats_record_reject(InstPtnOption option,
+                                 InstPtnRejectReason reason)
+{
+    if (!option_instptn_stats || option < 0 ||
+        option >= INSTPTN_OPT_COUNT || reason < 0 ||
+        reason >= INSTPTN_REJECT_COUNT) {
+        return;
+    }
+    qatomic_inc(&instptn_stats[option].rejects[reason]);
+}
+
+void instptn_stats_record_eflags_fallback(InstPtnOption option)
+{
+    if (!option_instptn_stats || option < 0 ||
+        option >= INSTPTN_OPT_COUNT) {
+        return;
+    }
+    qatomic_inc(&instptn_stats[option].eflags_fallbacks);
+}
+
+void instptn_stats_record_eflags_fallback_opcode(InstPtnOpcode opcode)
+{
+    InstPtnOption option;
+
+    if (!instptn_opcode_to_option(opcode, &option)) {
+        return;
+    }
+    instptn_stats_record_eflags_fallback(option);
+}
+
+void instptn_stats_record_codegen_opcode(InstPtnOpcode opcode,
+                                         uint64_t ir2_emitted,
+                                         uint64_t host_emitted)
+{
+    InstPtnOption option;
+
+    if (!option_instptn_stats ||
+        !instptn_opcode_to_option(opcode, &option)) {
+        return;
+    }
+    qatomic_add(&instptn_stats[option].ir2_emitted, ir2_emitted);
+    qatomic_add(&instptn_stats[option].host_emitted, host_emitted);
+}
+
+void instptn_stats_dump(void)
+{
+    if (!option_instptn_stats) {
+        return;
+    }
+
+    fprintf(stderr, "[LATX][instptn] pid=%d mask=0x%" PRIx64 "\n",
+            getpid(), option_instptn);
+    for (int i = 0; i < INSTPTN_OPT_COUNT; i++) {
+        InstPtnStats *stats = &instptn_stats[i];
+        uint64_t matches = qatomic_read(&stats->matches);
+        uint64_t eflags = qatomic_read(&stats->eflags_fallbacks);
+        uint64_t ir2 = qatomic_read(&stats->ir2_emitted);
+        uint64_t host = qatomic_read(&stats->host_emitted);
+        bool populated = matches || eflags || ir2 || host;
+
+        for (int reason = 0; reason < INSTPTN_REJECT_COUNT; reason++) {
+            populated |= qatomic_read(&stats->rejects[reason]) != 0;
+        }
+        if (!populated) {
+            continue;
+        }
+
+        fprintf(stderr,
+                "[LATX][instptn] %s match=%" PRIu64
+                " eflags-fallback=%" PRIu64
+                " ir2=%" PRIu64 " host=%" PRIu64 "\n",
+                instptn_option_names[i], matches, eflags,
+                ir2, host);
+        for (int reason = 0; reason < INSTPTN_REJECT_COUNT; reason++) {
+            uint64_t rejects = qatomic_read(&stats->rejects[reason]);
+
+            if (rejects) {
+                fprintf(stderr,
+                        "[LATX][instptn]   reject.%s=%" PRIu64 "\n",
+                        instptn_reject_names[reason], rejects);
+            }
+        }
+    }
+}
 
 // static inline void pattern_invalid(IR1_INST *scan_buf[PTN_BUF_SIZE], int num)
 // {
@@ -179,7 +426,9 @@ static int inst_pattern(TranslationBlock *tb,
             opnd0 = ir1_get_opnd(ir1, 0);
             opnd1 = ir1_get_opnd(ir1, 1);
             if (!ir1_opnd_is_same_reg(opnd0, opnd1)) {
-                return 0;
+                INSTPTN_REJECT_AND_RETURN(INSTPTN_OPT_CMP_SBB,
+                                          INSTPTN_REJECT_UNSUPPORTED_OPERAND,
+                                          0);
             }
             pir1->instptn.opc  = INSTPTN_OPC_CMP_SBB;
             pir1->instptn.next = ir1;
@@ -215,7 +464,8 @@ static int inst_pattern(TranslationBlock *tb,
             // ir1->instptn.next = NULL;
             return 1;
         default:
-            return 0;
+            INSTPTN_REJECT_AND_RETURN(INSTPTN_OPT_CMP_XXCC,
+                                      INSTPTN_REJECT_UNSUPPORTED_CC, 0);
         }
     }
     case WRAP(TEST): {
@@ -234,7 +484,9 @@ static int inst_pattern(TranslationBlock *tb,
             opnd0 = ir1_get_opnd(pir1, 0);
             opnd1 = ir1_get_opnd(pir1, 1);
             if (!ir1_opnd_is_same_reg(opnd0, opnd1)) {
-                return 1;
+                INSTPTN_REJECT_AND_RETURN(
+                    INSTPTN_OPT_TEST_XXCC,
+                    INSTPTN_REJECT_UNSUPPORTED_OPERAND, 1);
             }
             __attribute__((fallthrough));
         case WRAP(SETE):
@@ -259,7 +511,8 @@ static int inst_pattern(TranslationBlock *tb,
             // ir1->instptn.next = NULL;
             return 1;
         default:
-            return 0;
+            INSTPTN_REJECT_AND_RETURN(INSTPTN_OPT_TEST_XXCC,
+                                      INSTPTN_REJECT_UNSUPPORTED_CC, 0);
         }
     }
     case WRAP(CQO):
@@ -270,19 +523,21 @@ static int inst_pattern(TranslationBlock *tb,
         switch (ir1_opcode(ir1)) {
         case WRAP(IDIV):
             opnd0 = ir1_get_opnd(ir1, 0);
-            if (!ir1_opnd_is_gpr(opnd0))
-                return 0;
-            if (ir1_opnd_size(opnd0) != 64)
-                return 0;
-            if (is_contain_edx(opnd0))
-                return 0;
+            if (!ir1_opnd_is_gpr(opnd0) ||
+                ir1_opnd_size(opnd0) != 64 ||
+                is_contain_edx(opnd0)) {
+                INSTPTN_REJECT_AND_RETURN(
+                    INSTPTN_OPT_CQO_IDIV,
+                    INSTPTN_REJECT_UNSUPPORTED_OPERAND, 0);
+            }
             pir1->instptn.opc  = INSTPTN_OPC_CQO_IDIV;
             pir1->instptn.next = ir1;
             ir1->instptn.opc  = INSTPTN_OPC_NOP_DIV;
             // ir1->instptn.next = NULL;
             return 1;
         default:
-            return 0;
+            INSTPTN_REJECT_AND_RETURN(INSTPTN_OPT_CQO_IDIV,
+                                      INSTPTN_REJECT_OTHER, 0);
         }
     case WRAP(XOR):
         SCAN_CHECK(scan, 0);
@@ -300,8 +555,11 @@ static int inst_pattern(TranslationBlock *tb,
                 (opnd0->reg == dt_X86_REG_RDX && opnd1->reg == dt_X86_REG_RDX &&
                 ir1_opnd_size(ir1_get_opnd(ir1, 0)) == 64 &&
                 ir1_opnd_is_gpr(ir1_get_opnd(ir1, 0))))) {
-                    if (is_contain_edx(opnd0))
-                        return 0;
+                    if (is_contain_edx(opnd0)) {
+                        INSTPTN_REJECT_AND_RETURN(
+                            INSTPTN_OPT_XOR_DIV,
+                            INSTPTN_REJECT_UNSUPPORTED_OPERAND, 0);
+                    }
                     pir1->instptn.opc  = INSTPTN_OPC_XOR_DIV;
                     pir1->instptn.next = ir1;
                     ir1->instptn.opc  = INSTPTN_OPC_NOP_DIV;
@@ -309,7 +567,8 @@ static int inst_pattern(TranslationBlock *tb,
                     return 1;
                 }
         }
-        return 0;
+        INSTPTN_REJECT_AND_RETURN(INSTPTN_OPT_XOR_DIV,
+                                  INSTPTN_REJECT_UNSUPPORTED_OPERAND, 0);
     case WRAP(CDQ):
         SCAN_CHECK(scan, 0);
         instptn_check_cdq_idiv_0();
@@ -318,19 +577,21 @@ static int inst_pattern(TranslationBlock *tb,
         switch (ir1_opcode(ir1)) {
         case WRAP(IDIV):
             opnd0 = ir1_get_opnd(ir1, 0);
-            if (!ir1_opnd_is_gpr(opnd0))
-                return 0;
-            if (ir1_opnd_size(opnd0) != 32)
-                return 0;
-            if (is_contain_edx(opnd0))
-                return 0;
+            if (!ir1_opnd_is_gpr(opnd0) ||
+                ir1_opnd_size(opnd0) != 32 ||
+                is_contain_edx(opnd0)) {
+                INSTPTN_REJECT_AND_RETURN(
+                    INSTPTN_OPT_CDQ_IDIV,
+                    INSTPTN_REJECT_UNSUPPORTED_OPERAND, 0);
+            }
             pir1->instptn.opc  = INSTPTN_OPC_CDQ_IDIV;
             pir1->instptn.next = ir1;
             ir1->instptn.opc  = INSTPTN_OPC_NOP_DIV;
             // ir1->instptn.next = NULL;
             return 1;
         default:
-            return 0;
+            INSTPTN_REJECT_AND_RETURN(INSTPTN_OPT_CDQ_IDIV,
+                                      INSTPTN_REJECT_OTHER, 0);
         }
     case WRAP(UCOMISD):
         SCAN_CHECK(scan, 0);
@@ -345,7 +606,8 @@ static int inst_pattern(TranslationBlock *tb,
             // ir1->instptn.next = NULL;
             return 1;
         default:
-            return 0;
+            INSTPTN_REJECT_AND_RETURN(INSTPTN_OPT_UCOMISD_SETA,
+                                      INSTPTN_REJECT_UNSUPPORTED_CC, 0);
         }
 #ifdef CONFIG_LATX_SMC_OPT
     case WRAP(MOVAPS):
@@ -386,7 +648,9 @@ static int inst_pattern(TranslationBlock *tb,
                 ir1->instptn.opc  = INSTPTN_OPC_NOP;
                 return 1;
             default:
-                return 0;
+                INSTPTN_REJECT_AND_RETURN(
+                    INSTPTN_OPT_NEG_CMOVCC,
+                    INSTPTN_REJECT_UNSUPPORTED_CC, 0);
         }
     }
     default:
@@ -406,6 +670,7 @@ void insts_pattern_scan_con(TranslationBlock *tb, IR1_INST *ir1, int index, scan
     }
 
     if (inst_pattern(tb, ir1, scan_buf)) {
+        instptn_stats_record_match_opcode(ir1->instptn.opc);
         scan_clear(scan_buf);
     } else {
         scan_push(scan_buf, index);
@@ -473,7 +738,10 @@ bool insts_pattern_scan_jcc_end(TranslationBlock *tb, IR1_INST *pir1, int pir1_i
             }
             return false;
         default:
-            return false;
+            INSTPTN_REJECT_AND_RETURN(
+                pir1_index + 1 == SCAN_IDX(scan, 0) ?
+                    INSTPTN_OPT_CMP_JCC : INSTPTN_OPT_CMP_XX_JCC,
+                INSTPTN_REJECT_UNSUPPORTED_CC, false);
         }
     case WRAP(TEST):
         SCAN_CHECK(scan, 0);
@@ -486,7 +754,10 @@ bool insts_pattern_scan_jcc_end(TranslationBlock *tb, IR1_INST *pir1, int pir1_i
             opnd0 = ir1_get_opnd(pir1, 0);
             opnd1 = ir1_get_opnd(pir1, 1);
             if (!ir1_opnd_is_same_reg(opnd0, opnd1)) {
-                return false;
+                INSTPTN_REJECT_AND_RETURN(
+                    pir1_index + 1 == SCAN_IDX(scan, 0) ?
+                        INSTPTN_OPT_TEST_JCC : INSTPTN_OPT_TEST_XX_JCC,
+                    INSTPTN_REJECT_UNSUPPORTED_OPERAND, false);
             }
             __attribute__((fallthrough));
         case WRAP(JE):
@@ -513,13 +784,20 @@ bool insts_pattern_scan_jcc_end(TranslationBlock *tb, IR1_INST *pir1, int pir1_i
             }
             return false;
         default:
-            return false;
+            INSTPTN_REJECT_AND_RETURN(
+                pir1_index + 1 == SCAN_IDX(scan, 0) ?
+                    INSTPTN_OPT_TEST_JCC : INSTPTN_OPT_TEST_XX_JCC,
+                INSTPTN_REJECT_UNSUPPORTED_CC, false);
         }
     case WRAP(BT):
         SCAN_CHECK(scan, 0);
         opnd0 = ir1_get_opnd(pir1, 0);
-        if (!ir1_opnd_is_gpr(opnd0))
-            return false;
+        if (!ir1_opnd_is_gpr(opnd0)) {
+            INSTPTN_REJECT_AND_RETURN(
+                pir1_index + 1 == SCAN_IDX(scan, 0) ?
+                    INSTPTN_OPT_BT_JCC : INSTPTN_OPT_BT_XX_JCC,
+                INSTPTN_REJECT_UNSUPPORTED_OPERAND, false);
+        }
         ir1_jcc = SCAN_IR1(tb, scan, 0);
         switch (ir1_opcode(ir1_jcc)) {
         case WRAP(JB):
@@ -540,7 +818,10 @@ bool insts_pattern_scan_jcc_end(TranslationBlock *tb, IR1_INST *pir1, int pir1_i
             }
             return false;
         default:
-            return false;
+            INSTPTN_REJECT_AND_RETURN(
+                pir1_index + 1 == SCAN_IDX(scan, 0) ?
+                    INSTPTN_OPT_BT_JCC : INSTPTN_OPT_BT_XX_JCC,
+                INSTPTN_REJECT_UNSUPPORTED_CC, false);
         }
     case WRAP(SUB):
         SCAN_CHECK(scan, 0);
@@ -562,17 +843,31 @@ bool insts_pattern_scan_jcc_end(TranslationBlock *tb, IR1_INST *pir1, int pir1_i
                 pir1->instptn.next = ir1_jcc;
                 ir1_jcc->instptn.opc  = INSTPTN_OPC_NOP;
                 // ir1_jcc->instptn.next = NULL;
+            } else {
+                instptn_stats_record_reject(
+                    INSTPTN_OPT_SUB_JCC,
+                    INSTPTN_REJECT_NON_ADJACENT);
             }
             return false;
         default:
-            return false;
+            INSTPTN_REJECT_AND_RETURN(INSTPTN_OPT_SUB_JCC,
+                                      INSTPTN_REJECT_UNSUPPORTED_CC, false);
         }
     case WRAP(SHR):
         SCAN_CHECK(scan, 0);
         ir1_jcc = SCAN_IR1(tb, scan, 0);
         opnd1 = ir1_get_opnd(pir1, 1);
-        if (!ir1_opnd_is_imm(opnd1))
-            return false;
+        if (!ir1_opnd_is_imm(opnd1)) {
+            INSTPTN_REJECT_AND_RETURN(
+                INSTPTN_OPT_SHR_JCC,
+                INSTPTN_REJECT_UNSUPPORTED_OPERAND, false);
+        }
+        if ((ir1_opnd_uimm(opnd1) &
+             (ir1_opnd_size(ir1_get_opnd(pir1, 0)) == 64 ? 63 : 31)) == 0) {
+            INSTPTN_REJECT_AND_RETURN(
+                INSTPTN_OPT_SHR_JCC,
+                INSTPTN_REJECT_ZERO_SHIFT_COUNT, false);
+        }
         switch (ir1_opcode(ir1_jcc)) {
         case WRAP(JNE):
             if (pir1_index + 1 == SCAN_IDX(scan, 0)) {
@@ -581,10 +876,15 @@ bool insts_pattern_scan_jcc_end(TranslationBlock *tb, IR1_INST *pir1, int pir1_i
                 pir1->instptn.next = ir1_jcc;
                 ir1_jcc->instptn.opc  = INSTPTN_OPC_NOP;
                 // ir1_jcc->instptn.next = NULL;
+            } else {
+                instptn_stats_record_reject(
+                    INSTPTN_OPT_SHR_JCC,
+                    INSTPTN_REJECT_NON_ADJACENT);
             }
             return false;
         default:
-            return false;
+            INSTPTN_REJECT_AND_RETURN(INSTPTN_OPT_SHR_JCC,
+                                      INSTPTN_REJECT_UNSUPPORTED_CC, false);
         }
     case WRAP(AND):
         SCAN_CHECK(scan, 0);
@@ -597,10 +897,15 @@ bool insts_pattern_scan_jcc_end(TranslationBlock *tb, IR1_INST *pir1, int pir1_i
                 pir1->instptn.next = ir1_jcc;
                 ir1_jcc->instptn.opc  = INSTPTN_OPC_NOP;
                 // ir1_jcc->instptn.next = NULL;
+            } else {
+                instptn_stats_record_reject(
+                    INSTPTN_OPT_AND_JCC,
+                    INSTPTN_REJECT_NON_ADJACENT);
             }
             return false;
         default:
-            return false;
+            INSTPTN_REJECT_AND_RETURN(INSTPTN_OPT_AND_JCC,
+                                      INSTPTN_REJECT_UNSUPPORTED_CC, false);
         }
 #ifdef CONFIG_LATX_XCOMISX_OPT
     case WRAP(COMISD):
@@ -633,7 +938,10 @@ bool insts_pattern_scan_jcc_end(TranslationBlock *tb, IR1_INST *pir1, int pir1_i
             }
             return false;
         default:
-            return false;
+            INSTPTN_REJECT_AND_RETURN(
+                pir1_index + 1 == SCAN_IDX(scan, 0) ?
+                    INSTPTN_OPT_COMISD_JCC : INSTPTN_OPT_COMISD_XX_JCC,
+                INSTPTN_REJECT_UNSUPPORTED_CC, false);
         }
     case WRAP(COMISS):
         SCAN_CHECK(scan, 0);
@@ -665,7 +973,10 @@ bool insts_pattern_scan_jcc_end(TranslationBlock *tb, IR1_INST *pir1, int pir1_i
             }
             return false;
         default:
-            return false;
+            INSTPTN_REJECT_AND_RETURN(
+                pir1_index + 1 == SCAN_IDX(scan, 0) ?
+                    INSTPTN_OPT_COMISS_JCC : INSTPTN_OPT_COMISS_XX_JCC,
+                INSTPTN_REJECT_UNSUPPORTED_CC, false);
         }
     case WRAP(UCOMISD):
         SCAN_CHECK(scan, 0);
@@ -697,7 +1008,11 @@ bool insts_pattern_scan_jcc_end(TranslationBlock *tb, IR1_INST *pir1, int pir1_i
             }
             return false;
         default:
-            return false;
+            INSTPTN_REJECT_AND_RETURN(
+                pir1_index + 1 == SCAN_IDX(scan, 0) ?
+                    INSTPTN_OPT_UCOMISD_JCC :
+                    INSTPTN_OPT_UCOMISD_XX_JCC,
+                INSTPTN_REJECT_UNSUPPORTED_CC, false);
         }
     case WRAP(UCOMISS):
         SCAN_CHECK(scan, 0);
@@ -729,7 +1044,11 @@ bool insts_pattern_scan_jcc_end(TranslationBlock *tb, IR1_INST *pir1, int pir1_i
             }
             return false;
         default:
-            return false;
+            INSTPTN_REJECT_AND_RETURN(
+                pir1_index + 1 == SCAN_IDX(scan, 0) ?
+                    INSTPTN_OPT_UCOMISS_JCC :
+                    INSTPTN_OPT_UCOMISS_XX_JCC,
+                INSTPTN_REJECT_UNSUPPORTED_CC, false);
         }
 #endif
     case WRAP(MOV): {

--- a/target/i386/latx/optimization/insts-pattern.c
+++ b/target/i386/latx/optimization/insts-pattern.c
@@ -173,6 +173,9 @@ static bool instptn_opcode_to_option(InstPtnOpcode opcode,
     case INSTPTN_OPC_SHR_JE:
         *option = INSTPTN_OPT_SHR_JE;
         break;
+    case INSTPTN_OPC_OR_JCC:
+        *option = INSTPTN_OPT_OR_JCC;
+        break;
     default:
         return false;
     }
@@ -1010,6 +1013,43 @@ bool insts_pattern_scan_jcc_end(TranslationBlock *tb, IR1_INST *pir1, int pir1_i
             return false;
         default:
             INSTPTN_REJECT_AND_RETURN(INSTPTN_OPT_ADD_JCC,
+                                      INSTPTN_REJECT_UNSUPPORTED_CC, false);
+        }
+    case WRAP(OR):
+        SCAN_CHECK(scan, 0);
+        ir1_jcc = SCAN_IR1(tb, scan, 0);
+        opnd0 = ir1_get_opnd(pir1, 0);
+        opnd1 = ir1_get_opnd(pir1, 1);
+        if ((!ir1_opnd_is_gpr(opnd0) && !ir1_opnd_is_mem(opnd0)) ||
+            (!ir1_opnd_is_gpr(opnd1) && !ir1_opnd_is_mem(opnd1) &&
+             !ir1_opnd_is_imm(opnd1))) {
+            INSTPTN_REJECT_AND_RETURN(
+                INSTPTN_OPT_OR_JCC,
+                INSTPTN_REJECT_UNSUPPORTED_OPERAND, false);
+        }
+        if (ir1_is_prefix_lock(pir1)) {
+            INSTPTN_REJECT_AND_RETURN(
+                INSTPTN_OPT_OR_JCC,
+                INSTPTN_REJECT_FAULT_OR_HELPER, false);
+        }
+        switch (ir1_opcode(ir1_jcc)) {
+        case WRAP(JE):
+        case WRAP(JNE):
+        case WRAP(JS):
+        case WRAP(JNS):
+            if (pir1_index + 1 == SCAN_IDX(scan, 0)) {
+                instptn_check_or_jcc_0();
+                pir1->instptn.opc = INSTPTN_OPC_OR_JCC;
+                pir1->instptn.next = ir1_jcc;
+                ir1_jcc->instptn.opc = INSTPTN_OPC_NOP;
+            } else {
+                instptn_stats_record_reject(
+                    INSTPTN_OPT_OR_JCC,
+                    INSTPTN_REJECT_NON_ADJACENT);
+            }
+            return false;
+        default:
+            INSTPTN_REJECT_AND_RETURN(INSTPTN_OPT_OR_JCC,
                                       INSTPTN_REJECT_UNSUPPORTED_CC, false);
         }
 #ifdef CONFIG_LATX_XCOMISX_OPT

--- a/target/i386/latx/optimization/insts-pattern.c
+++ b/target/i386/latx/optimization/insts-pattern.c
@@ -89,6 +89,9 @@ static bool instptn_opcode_to_option(InstPtnOpcode opcode,
     case INSTPTN_OPC_CMP_JCC:
         *option = INSTPTN_OPT_CMP_JCC;
         break;
+    case INSTPTN_OPC_CMP_JS_JNS:
+        *option = INSTPTN_OPT_CMP_JS_JNS;
+        break;
     case INSTPTN_OPC_TEST_JCC:
         *option = INSTPTN_OPT_TEST_JCC;
         break;
@@ -152,6 +155,9 @@ static bool instptn_opcode_to_option(InstPtnOpcode opcode,
     case INSTPTN_OPC_SUB_JCC:
         *option = INSTPTN_OPT_SUB_JCC;
         break;
+    case INSTPTN_OPC_SUB_JS_JNS:
+        *option = INSTPTN_OPT_SUB_JS_JNS;
+        break;
     case INSTPTN_OPC_MOVAPS_VST_X4:
         *option = INSTPTN_OPT_MOVAPS_VST_X4;
         break;
@@ -163,6 +169,9 @@ static bool instptn_opcode_to_option(InstPtnOpcode opcode,
         break;
     case INSTPTN_OPC_AND_JCC:
         *option = INSTPTN_OPT_AND_JCC;
+        break;
+    case INSTPTN_OPC_AND_JE:
+        *option = INSTPTN_OPT_AND_JE;
         break;
     case INSTPTN_OPC_ADD_JCC:
         *option = INSTPTN_OPT_ADD_JCC;
@@ -774,13 +783,13 @@ bool insts_pattern_scan_jcc_end(TranslationBlock *tb, IR1_INST *pir1, int pir1_i
         case WRAP(JS):
         case WRAP(JNS):
             if (pir1_index + 1 == SCAN_IDX(scan, 0)) {
-                instptn_check_cmp_jcc_0();
-                pir1->instptn.opc = INSTPTN_OPC_CMP_JCC;
+                instptn_check_cmp_js_jns_0();
+                pir1->instptn.opc = INSTPTN_OPC_CMP_JS_JNS;
                 pir1->instptn.next = ir1_jcc;
                 ir1_jcc->instptn.opc = INSTPTN_OPC_NOP;
             } else {
                 instptn_stats_record_reject(
-                    INSTPTN_OPT_CMP_JCC,
+                    INSTPTN_OPT_CMP_JS_JNS,
                     INSTPTN_REJECT_NON_ADJACENT);
             }
             return false;
@@ -887,14 +896,22 @@ bool insts_pattern_scan_jcc_end(TranslationBlock *tb, IR1_INST *pir1, int pir1_i
         case WRAP(JS):
         case WRAP(JNS):
             if (pir1_index + 1 == SCAN_IDX(scan, 0)) {
-                instptn_check_sub_jcc_0();
-                pir1->instptn.opc  = INSTPTN_OPC_SUB_JCC;
+                if (ir1_opcode(ir1_jcc) == WRAP(JS) ||
+                    ir1_opcode(ir1_jcc) == WRAP(JNS)) {
+                    instptn_check_sub_js_jns_0();
+                    pir1->instptn.opc = INSTPTN_OPC_SUB_JS_JNS;
+                } else {
+                    instptn_check_sub_jcc_0();
+                    pir1->instptn.opc = INSTPTN_OPC_SUB_JCC;
+                }
                 pir1->instptn.next = ir1_jcc;
                 ir1_jcc->instptn.opc  = INSTPTN_OPC_NOP;
                 // ir1_jcc->instptn.next = NULL;
             } else {
                 instptn_stats_record_reject(
-                    INSTPTN_OPT_SUB_JCC,
+                    ir1_opcode(ir1_jcc) == WRAP(JS) ||
+                    ir1_opcode(ir1_jcc) == WRAP(JNS) ?
+                        INSTPTN_OPT_SUB_JS_JNS : INSTPTN_OPT_SUB_JCC,
                     INSTPTN_REJECT_NON_ADJACENT);
             }
             return false;
@@ -988,14 +1005,20 @@ bool insts_pattern_scan_jcc_end(TranslationBlock *tb, IR1_INST *pir1, int pir1_i
         case WRAP(JE):
         case WRAP(JNE):
             if (pir1_index + 1 == SCAN_IDX(scan, 0)) {
-                instptn_check_and_jcc_0();
-                pir1->instptn.opc  = INSTPTN_OPC_AND_JCC;
+                if (ir1_opcode(ir1_jcc) == WRAP(JE)) {
+                    instptn_check_and_je_0();
+                    pir1->instptn.opc = INSTPTN_OPC_AND_JE;
+                } else {
+                    instptn_check_and_jcc_0();
+                    pir1->instptn.opc = INSTPTN_OPC_AND_JCC;
+                }
                 pir1->instptn.next = ir1_jcc;
                 ir1_jcc->instptn.opc  = INSTPTN_OPC_NOP;
                 // ir1_jcc->instptn.next = NULL;
             } else {
                 instptn_stats_record_reject(
-                    INSTPTN_OPT_AND_JCC,
+                    ir1_opcode(ir1_jcc) == WRAP(JE) ?
+                        INSTPTN_OPT_AND_JE : INSTPTN_OPT_AND_JCC,
                     INSTPTN_REJECT_NON_ADJACENT);
             }
             return false;

--- a/target/i386/latx/optimization/ir1-optimization.c
+++ b/target/i386/latx/optimization/ir1-optimization.c
@@ -49,6 +49,9 @@ static bool result_jcc_option(IR1_INST *ir1, InstPtnOption *option)
     case INSTPTN_OPC_OR_JCC:
         *option = INSTPTN_OPT_OR_JCC;
         return true;
+    case INSTPTN_OPC_OR_XX_JCC:
+        *option = INSTPTN_OPT_OR_XX_JCC;
+        return true;
     case INSTPTN_OPC_CMP_JCC:
         *option = INSTPTN_OPT_CMP_JCC;
         return true;

--- a/target/i386/latx/optimization/ir1-optimization.c
+++ b/target/i386/latx/optimization/ir1-optimization.c
@@ -49,6 +49,15 @@ static bool result_jcc_option(IR1_INST *ir1, InstPtnOption *option)
     case INSTPTN_OPC_OR_JCC:
         *option = INSTPTN_OPT_OR_JCC;
         return true;
+    case INSTPTN_OPC_CMP_JCC:
+        *option = INSTPTN_OPT_CMP_JCC;
+        return true;
+    case INSTPTN_OPC_SUB_JCC:
+        *option = INSTPTN_OPT_SUB_JCC;
+        return true;
+    case INSTPTN_OPC_AND_JCC:
+        *option = INSTPTN_OPT_AND_JCC;
+        return true;
     default:
         return false;
     }
@@ -65,23 +74,17 @@ static void reduce_result_jcc_local_eflags(IR1_INST *ir1,
     }
 
     IR1_INST *jcc = ir1->instptn.next;
-    uint8 local_use;
-
     switch (ir1_opcode(jcc)) {
     case dt_X86_INS_JE:
     case dt_X86_INS_JNE:
-        local_use = __ZF;
-        break;
     case dt_X86_INS_JS:
     case dt_X86_INS_JNS:
-        local_use = __SF;
         break;
     default:
         return;
     }
 
-    uint8 dead_local_use = local_use & ~eflag_out;
-    uint8 eliminated = dead_local_use & ir1_get_eflag_def(ir1);
+    uint8 eliminated = ir1_get_eflag_def(ir1) & ~eflag_out;
 
     if (!eliminated) {
         return;

--- a/target/i386/latx/optimization/ir1-optimization.c
+++ b/target/i386/latx/optimization/ir1-optimization.c
@@ -52,6 +52,9 @@ static bool result_jcc_option(IR1_INST *ir1, InstPtnOption *option)
     case INSTPTN_OPC_XOR_JCC:
         *option = INSTPTN_OPT_XOR_JCC;
         return true;
+    case INSTPTN_OPC_DEC_JCC:
+        *option = INSTPTN_OPT_DEC_JCC;
+        return true;
     case INSTPTN_OPC_OR_XX_JCC:
         *option = INSTPTN_OPT_OR_XX_JCC;
         return true;

--- a/target/i386/latx/optimization/ir1-optimization.c
+++ b/target/i386/latx/optimization/ir1-optimization.c
@@ -31,12 +31,33 @@
 #ifdef CONFIG_LATX_TU
 #if defined(CONFIG_LATX_FLAG_REDUCTION) && \
     defined(CONFIG_LATX_INSTS_PATTERN)
-static void reduce_add_jcc_local_eflags(IR1_INST *ir1,
-                                        uint8 *pending_use,
-                                        uint8 eflag_out)
+static bool result_jcc_option(IR1_INST *ir1, InstPtnOption *option)
 {
-    if (!option_flag_reduction ||
-        ir1->instptn.opc != INSTPTN_OPC_ADD_JCC) {
+    switch (ir1->instptn.opc) {
+    case INSTPTN_OPC_ADD_JCC:
+        *option = INSTPTN_OPT_ADD_JCC;
+        return true;
+    case INSTPTN_OPC_SAR_JCC:
+        *option = INSTPTN_OPT_SAR_JCC;
+        return true;
+    case INSTPTN_OPC_SHR_JCC:
+        *option = INSTPTN_OPT_SHR_JCC;
+        return true;
+    case INSTPTN_OPC_SHR_JE:
+        *option = INSTPTN_OPT_SHR_JE;
+        return true;
+    default:
+        return false;
+    }
+}
+
+static void reduce_result_jcc_local_eflags(IR1_INST *ir1,
+                                           uint8 *pending_use,
+                                           uint8 eflag_out)
+{
+    InstPtnOption option;
+
+    if (!option_flag_reduction || !result_jcc_option(ir1, &option)) {
         return;
     }
 
@@ -66,7 +87,7 @@ static void reduce_add_jcc_local_eflags(IR1_INST *ir1,
     *pending_use &= ~eliminated;
     ir1_set_eflag_def(ir1,
                       ir1_get_eflag_def(ir1) & ~eliminated);
-    instptn_stats_record_eflags_eliminated(INSTPTN_OPT_ADD_JCC);
+    instptn_stats_record_eflags_eliminated(option);
 }
 #endif
 
@@ -94,8 +115,8 @@ static void ir1_optimization_over_tb(TranslationBlock *tb)
         OPT_INSTS_PTN(tb, ir1, i, ptn);
 #if defined(CONFIG_LATX_FLAG_REDUCTION) && \
     defined(CONFIG_LATX_INSTS_PATTERN)
-        reduce_add_jcc_local_eflags(ir1, &rdtn_pending_use,
-                                    tb->s_data->eflag_out);
+        reduce_result_jcc_local_eflags(ir1, &rdtn_pending_use,
+                                       tb->s_data->eflag_out);
 #endif
     }
     SAVE_FLAG_TO_TB(rdtn, tb);

--- a/target/i386/latx/optimization/ir1-optimization.c
+++ b/target/i386/latx/optimization/ir1-optimization.c
@@ -46,6 +46,9 @@ static bool result_jcc_option(IR1_INST *ir1, InstPtnOption *option)
     case INSTPTN_OPC_SHR_JE:
         *option = INSTPTN_OPT_SHR_JE;
         return true;
+    case INSTPTN_OPC_OR_JCC:
+        *option = INSTPTN_OPT_OR_JCC;
+        return true;
     default:
         return false;
     }

--- a/target/i386/latx/optimization/ir1-optimization.c
+++ b/target/i386/latx/optimization/ir1-optimization.c
@@ -49,6 +49,9 @@ static bool result_jcc_option(IR1_INST *ir1, InstPtnOption *option)
     case INSTPTN_OPC_OR_JCC:
         *option = INSTPTN_OPT_OR_JCC;
         return true;
+    case INSTPTN_OPC_XOR_JCC:
+        *option = INSTPTN_OPT_XOR_JCC;
+        return true;
     case INSTPTN_OPC_OR_XX_JCC:
         *option = INSTPTN_OPT_OR_XX_JCC;
         return true;

--- a/target/i386/latx/optimization/ir1-optimization.c
+++ b/target/i386/latx/optimization/ir1-optimization.c
@@ -29,6 +29,47 @@
  */
 
 #ifdef CONFIG_LATX_TU
+#if defined(CONFIG_LATX_FLAG_REDUCTION) && \
+    defined(CONFIG_LATX_INSTS_PATTERN)
+static void reduce_add_jcc_local_eflags(IR1_INST *ir1,
+                                        uint8 *pending_use,
+                                        uint8 eflag_out)
+{
+    if (!option_flag_reduction ||
+        ir1->instptn.opc != INSTPTN_OPC_ADD_JCC) {
+        return;
+    }
+
+    IR1_INST *jcc = ir1->instptn.next;
+    uint8 local_use;
+
+    switch (ir1_opcode(jcc)) {
+    case dt_X86_INS_JE:
+    case dt_X86_INS_JNE:
+        local_use = __ZF;
+        break;
+    case dt_X86_INS_JS:
+    case dt_X86_INS_JNS:
+        local_use = __SF;
+        break;
+    default:
+        return;
+    }
+
+    uint8 dead_local_use = local_use & ~eflag_out;
+    uint8 eliminated = dead_local_use & ir1_get_eflag_def(ir1);
+
+    if (!eliminated) {
+        return;
+    }
+
+    *pending_use &= ~eliminated;
+    ir1_set_eflag_def(ir1,
+                      ir1_get_eflag_def(ir1) & ~eliminated);
+    instptn_stats_record_eflags_eliminated(INSTPTN_OPT_ADD_JCC);
+}
+#endif
+
 /* static int opt, noopt; */
 static void ir1_optimization_over_tb(TranslationBlock *tb)
 {
@@ -51,6 +92,11 @@ static void ir1_optimization_over_tb(TranslationBlock *tb)
         OPT_FLAG_RDTN(rdtn, ir1);
         /* TODO: TU */
         OPT_INSTS_PTN(tb, ir1, i, ptn);
+#if defined(CONFIG_LATX_FLAG_REDUCTION) && \
+    defined(CONFIG_LATX_INSTS_PATTERN)
+        reduce_add_jcc_local_eflags(ir1, &rdtn_pending_use,
+                                    tb->s_data->eflag_out);
+#endif
     }
     SAVE_FLAG_TO_TB(rdtn, tb);
 }

--- a/target/i386/latx/optimization/ir1-optimization.c
+++ b/target/i386/latx/optimization/ir1-optimization.c
@@ -61,11 +61,20 @@ static bool result_jcc_option(IR1_INST *ir1, InstPtnOption *option)
     case INSTPTN_OPC_CMP_JCC:
         *option = INSTPTN_OPT_CMP_JCC;
         return true;
+    case INSTPTN_OPC_CMP_JS_JNS:
+        *option = INSTPTN_OPT_CMP_JS_JNS;
+        return true;
     case INSTPTN_OPC_SUB_JCC:
         *option = INSTPTN_OPT_SUB_JCC;
         return true;
+    case INSTPTN_OPC_SUB_JS_JNS:
+        *option = INSTPTN_OPT_SUB_JS_JNS;
+        return true;
     case INSTPTN_OPC_AND_JCC:
         *option = INSTPTN_OPT_AND_JCC;
+        return true;
+    case INSTPTN_OPC_AND_JE:
+        *option = INSTPTN_OPT_AND_JE;
         return true;
     default:
         return false;

--- a/target/i386/latx/translator/tr-pattern.c
+++ b/target/i386/latx/translator/tr-pattern.c
@@ -83,6 +83,9 @@
 #define EFLAGS_CACULATE(opnd0, opnd1, inst, i, flags)                \
     EFLAGS_CACULATE_RESULT(opnd0, opnd0, opnd1, inst, i, flags)
 
+static IR2_OPND load_opnd_from_opnd(IR2_OPND src_opnd,
+        EXTENSION_MODE em, int opnd_size);
+
 static inline void cmp_jcc_gen_bcc(IR2_OPND src_opnd_0, IR2_OPND src_opnd_1,
         IR2_OPND target_label_opnd, IR1_INST *jcc_inst)
 {
@@ -117,6 +120,12 @@ static inline void cmp_jcc_gen_bcc(IR2_OPND src_opnd_0, IR2_OPND src_opnd_1,
     case WRAP(JG):
         la_blt(src_opnd_1, src_opnd_0, target_label_opnd);
         break;
+    case WRAP(JS):
+        la_blt(src_opnd_0, src_opnd_1, target_label_opnd);
+        break;
+    case WRAP(JNS):
+        la_bge(src_opnd_0, src_opnd_1, target_label_opnd);
+        break;
     default:
         lsassert(0);
         break;
@@ -130,20 +139,37 @@ static bool translate_cmp_jcc(IR1_INST *ir1)
 
     curr->info->id = WRAP(CMP);
 
+    bool sign_result = ir1_opcode(next) == WRAP(JS) ||
+                       ir1_opcode(next) == WRAP(JNS);
     int em = ZERO_EXTENSION;
-    switch (ir1_opcode(next)) {
-    case WRAP(JL):
-    case WRAP(JGE):
-    case WRAP(JLE):
-    case WRAP(JG):
-        em = SIGN_EXTENSION;
-        break;
-    default:
-        break;
+    if (sign_result) {
+        em = UNKNOWN_EXTENSION;
+    } else {
+        switch (ir1_opcode(next)) {
+        case WRAP(JL):
+        case WRAP(JGE):
+        case WRAP(JLE):
+        case WRAP(JG):
+            em = SIGN_EXTENSION;
+            break;
+        default:
+            break;
+        }
     }
 
     IR2_OPND src_opnd_0 = load_ireg_from_ir1(ir1_get_opnd(curr, 0), em, false);
     IR2_OPND src_opnd_1 = load_ireg_from_ir1(ir1_get_opnd(curr, 1), em, false);
+    IR2_OPND branch_src0 = src_opnd_0;
+    IR2_OPND branch_src1 = src_opnd_1;
+
+    if (sign_result) {
+        int opnd_size = ir1_opnd_size(ir1_get_opnd(curr, 0));
+        IR2_OPND result = ra_alloc_itemp();
+        la_sub_d(result, src_opnd_0, src_opnd_1);
+        branch_src0 = opnd_size == 64 ? result :
+            load_opnd_from_opnd(result, SIGN_EXTENSION, opnd_size);
+        branch_src1 = zero_ir2_opnd;
+    }
 
     IR2_OPND target_label_opnd = ra_alloc_label();
 #ifdef CONFIG_LATX_TU
@@ -159,7 +185,8 @@ static bool translate_cmp_jcc(IR1_INST *ir1)
 
         la_label(tu_reset_label_opnd);
         tb->tu_jmp[TU_TB_INDEX_TARGET] = tu_reset_label_opnd._label_id;
-        cmp_jcc_gen_bcc(src_opnd_0, src_opnd_1, target_label_opnd, next);
+        cmp_jcc_gen_bcc(branch_src0, branch_src1,
+                        target_label_opnd, next);
         tu_jcc_nop_gen(tb);
 
         if (tb_next->eflag_use && !tb_target->eflag_use) {
@@ -182,7 +209,7 @@ static bool translate_cmp_jcc(IR1_INST *ir1)
     }
 #endif
 
-    cmp_jcc_gen_bcc(src_opnd_0, src_opnd_1, target_label_opnd, next);
+    cmp_jcc_gen_bcc(branch_src0, branch_src1, target_label_opnd, next);
 
     /* not taken */
     EFLAGS_CACULATE(src_opnd_0, src_opnd_1, curr, 0, true);
@@ -294,7 +321,6 @@ static bool translate_sub_jcc(IR1_INST *ir1)
 {
     IR1_INST *curr = ir1;
     IR1_INST *next = ir1->instptn.next;
-
     CPUArchState* env = (CPUArchState*)(lsenv->cpu_state);
     CPUState *cpu = env_cpu(env);
     IR1_OPND *opnd0 = ir1_get_opnd(ir1, 0);
@@ -303,6 +329,9 @@ static bool translate_sub_jcc(IR1_INST *ir1)
     IR2_OPND bcc_src0, bcc_src1;
     IR2_OPND dest, mem_opnd;
     int imm, opnd0_size;
+    bool result_jcc = ir1_opcode(next) == WRAP(JS) ||
+                      ir1_opcode(next) == WRAP(JNS);
+    bool eflags_calc = ir1_need_calculate_any_flag(curr);
 
     curr->info->id = WRAP(SUB);
     opnd0_size = ir1_opnd_size(opnd0);
@@ -330,28 +359,44 @@ static bool translate_sub_jcc(IR1_INST *ir1)
         break;
     }
 
-    src_opnd_1 = load_ireg_from_ir1(opnd1, UNKNOWN_EXTENSION, false);
+    if (result_jcc && eflags_calc) {
+        src_opnd_1 = ra_alloc_itemp();
+        load_ireg_from_ir1_2(src_opnd_1, opnd1,
+                             UNKNOWN_EXTENSION, false);
+    } else {
+        src_opnd_1 = load_ireg_from_ir1(opnd1,
+                                        UNKNOWN_EXTENSION, false);
+    }
     if (ir1_opnd_is_gpr(opnd0)) {
-        src_opnd_0 = convert_gpr_opnd(opnd0, UNKNOWN_EXTENSION);
+        if (result_jcc && eflags_calc) {
+            src_opnd_0 = ra_alloc_itemp();
+            load_ireg_from_ir1_2(src_opnd_0, opnd0,
+                                 UNKNOWN_EXTENSION, false);
+        } else {
+            src_opnd_0 = convert_gpr_opnd(opnd0, UNKNOWN_EXTENSION);
+        }
         if (opnd0_size >= 32) {
-            dest = src_opnd_0;
+            dest = convert_gpr_opnd(opnd0, UNKNOWN_EXTENSION);
         } else {
             dest = ra_alloc_itemp();
         }
     } else {
         src_opnd_0 = ra_alloc_itemp();
-        dest = src_opnd_0;
+        dest = result_jcc && eflags_calc ? ra_alloc_itemp() : src_opnd_0;
         mem_opnd = convert_mem(opnd0, &imm);
         la_ld_by_op_size(src_opnd_0, mem_opnd, imm, opnd0_size);
     }
 
     int opnd1_size = ir1_opnd_size(opnd1);
-    if (opnd1_size == 64 || em == UNKNOWN_EXTENSION) {
+    if (result_jcc) {
+        bcc_src1 = zero_ir2_opnd;
+    } else if (opnd1_size == 64 || em == UNKNOWN_EXTENSION) {
         bcc_src1 = src_opnd_1;
     } else {
         bcc_src1 = load_opnd_from_opnd(src_opnd_1, em, opnd1_size);
     }
 
+    IR2_OPND eflags_result = result_jcc ? dest : src_opnd_0;
     IR2_OPND target_label_opnd = ra_alloc_label();
 #ifdef CONFIG_LATX_TU
     TranslationBlock *tb = lsenv->tr_data->curr_tb;
@@ -361,14 +406,28 @@ static bool translate_sub_jcc(IR1_INST *ir1)
         TranslationBlock *tb_next = tb->s_data->next_tb[TU_TB_INDEX_NEXT];
         TranslationBlock *tb_target = tb->s_data->next_tb[TU_TB_INDEX_TARGET];
 
-        /* cmp_jcc_gen_bcc() is after gen_sub(), so we must store src_opnd_0 into a temp reg. */
-        bcc_src0 = load_opnd_from_opnd(src_opnd_0, em, opnd0_size);
-        if (tb_next->eflag_use || tb_target->eflag_use) {
+        if (!result_jcc) {
+            /* Preserve operand 0 because gen_sub() may overwrite it. */
+            bcc_src0 = load_opnd_from_opnd(src_opnd_0, em, opnd0_size);
+        }
+        if (!result_jcc &&
+            (tb_next->eflag_use || tb_target->eflag_use)) {
             /* Sometimes an extra calculation of eflags is performed. */
-            generate_eflag_calculation(src_opnd_0, src_opnd_0, src_opnd_1, curr, true);
+            generate_eflag_calculation(eflags_result, src_opnd_0,
+                                       src_opnd_1, curr, true);
         }
 
-        gen_sub(dest, src_opnd_0, src_opnd_1, mem_opnd, imm, ir1, opnd0, opnd0_size);
+        gen_sub(dest, src_opnd_0, src_opnd_1, mem_opnd, imm,
+                ir1, opnd0, opnd0_size);
+
+        if (result_jcc) {
+            bcc_src0 = opnd0_size == 64 ? dest :
+                load_opnd_from_opnd(dest, SIGN_EXTENSION, opnd0_size);
+            if (tb_next->eflag_use || tb_target->eflag_use) {
+                generate_eflag_calculation(eflags_result, src_opnd_0,
+                                           src_opnd_1, curr, true);
+            }
+        }
 
         la_label(tu_reset_label_opnd);
         tb->tu_jmp[TU_TB_INDEX_TARGET] = tu_reset_label_opnd._label_id;
@@ -396,7 +455,12 @@ static bool translate_sub_jcc(IR1_INST *ir1)
     }
 #endif
 
-    if (opnd0_size == 64 || em == UNKNOWN_EXTENSION) {
+    if (result_jcc) {
+        gen_sub(dest, src_opnd_0, src_opnd_1, mem_opnd, imm,
+                ir1, opnd0, opnd0_size);
+        bcc_src0 = opnd0_size == 64 ? dest :
+            load_opnd_from_opnd(dest, SIGN_EXTENSION, opnd0_size);
+    } else if (opnd0_size == 64 || em == UNKNOWN_EXTENSION) {
         bcc_src0 = src_opnd_0;
     } else {
         bcc_src0 = load_opnd_from_opnd(src_opnd_0, em, opnd1_size);
@@ -404,22 +468,29 @@ static bool translate_sub_jcc(IR1_INST *ir1)
     cmp_jcc_gen_bcc(bcc_src0, bcc_src1, target_label_opnd, next);
 
     /* not taken */
-    EFLAGS_CACULATE(src_opnd_0, src_opnd_1, curr, 0, true);
-    gen_sub(dest, src_opnd_0, src_opnd_1, mem_opnd, imm,
-            ir1, opnd0, opnd0_size);
+    EFLAGS_CACULATE_RESULT(eflags_result, src_opnd_0, src_opnd_1,
+                           curr, 0, true);
+    if (!result_jcc) {
+        gen_sub(dest, src_opnd_0, src_opnd_1, mem_opnd, imm,
+                ir1, opnd0, opnd0_size);
+    }
     tr_generate_exit_tb(next, 0);
 
     la_label(target_label_opnd);
     /* taken */
-    EFLAGS_CACULATE(src_opnd_0, src_opnd_1, curr, 1, true);
-    gen_sub(dest, src_opnd_0, src_opnd_1, mem_opnd, imm,
-            ir1, opnd0, opnd0_size);
+    EFLAGS_CACULATE_RESULT(eflags_result, src_opnd_0, src_opnd_1,
+                           curr, 1, true);
+    if (!result_jcc) {
+        gen_sub(dest, src_opnd_0, src_opnd_1, mem_opnd, imm,
+                ir1, opnd0, opnd0_size);
+    }
     tr_generate_exit_tb(next, 1);
     /*
      * the backup of the eflags instruction, which is used
      * to recover the eflags instruction when unlink a tb.
      */
-    EFLAGS_CACULATE(src_opnd_0, src_opnd_1, curr, EFLAG_BACKUP, true);
+    EFLAGS_CACULATE_RESULT(eflags_result, src_opnd_0, src_opnd_1,
+                           curr, EFLAG_BACKUP, true);
     /* ra_free_temp(bcc_src0); */
     /* ra_free_temp(bcc_src1); */
 
@@ -2423,12 +2494,15 @@ static bool translate_and_jcc(IR1_INST *pir1)
         la_label(tu_reset_label_opnd);
         tb->tu_jmp[TU_TB_INDEX_TARGET] = tu_reset_label_opnd._label_id;
         switch (ir1_opcode(next)) {
-            case WRAP(JNE): //dest!=0
-                la_bnez(dest, target_label_opnd);
-                break;
-            default:
-                lsassert(0);
-                break;
+        case WRAP(JE):
+            la_beqz(dest, target_label_opnd);
+            break;
+        case WRAP(JNE):
+            la_bnez(dest, target_label_opnd);
+            break;
+        default:
+            lsassert(0);
+            break;
         }
         tu_jcc_nop_gen(tb);
 
@@ -2453,6 +2527,9 @@ static bool translate_and_jcc(IR1_INST *pir1)
 #endif
 
     switch (ir1_opcode(next)) {
+    case WRAP(JE):
+        la_beqz(dest, target_label_opnd);
+        break;
     case WRAP(JNE):
         la_bnez(dest, target_label_opnd);
         break;

--- a/target/i386/latx/translator/tr-pattern.c
+++ b/target/i386/latx/translator/tr-pattern.c
@@ -571,6 +571,139 @@ static bool translate_add_jcc(IR1_INST *ir1)
     return true;
 }
 
+static bool translate_or_jcc(IR1_INST *ir1)
+{
+    IR1_INST *curr = ir1;
+    IR1_INST *next = curr->instptn.next;
+    IR1_OPND *opnd0 = ir1_get_opnd(curr, 0);
+    IR1_OPND *opnd1 = ir1_get_opnd(curr, 1);
+    IR2_OPND src0, src1, dest, mem_opnd;
+    int imm = 0;
+    int opnd0_size = ir1_opnd_size(opnd0);
+    bool opt_imm = ir1_opnd_is_s2uimm12(opnd1);
+    bool eflags_calc = ir1_need_calculate_any_flag(curr);
+
+    if (ir1_is_prefix_lock(curr)) {
+        translate_or(curr);
+        translate_jcc(next);
+        return true;
+    }
+
+    if (opt_imm && !eflags_calc) {
+        src1 = zero_ir2_opnd;
+    } else if (!eflags_calc) {
+        src1 = load_ireg_from_ir1(opnd1, UNKNOWN_EXTENSION, false);
+    } else {
+        src1 = ra_alloc_itemp();
+        load_ireg_from_ir1_2(src1, opnd1, UNKNOWN_EXTENSION, false);
+    }
+
+    if (ir1_opnd_is_gpr(opnd0)) {
+        if (eflags_calc) {
+            src0 = ra_alloc_itemp();
+            load_ireg_from_ir1_2(src0, opnd0, UNKNOWN_EXTENSION, false);
+        } else {
+            src0 = convert_gpr_opnd(opnd0, UNKNOWN_EXTENSION);
+        }
+        if (opnd0_size >= 32) {
+            dest = convert_gpr_opnd(opnd0, UNKNOWN_EXTENSION);
+        } else {
+            dest = ra_alloc_itemp();
+        }
+    } else {
+        src0 = ra_alloc_itemp();
+        dest = ra_alloc_itemp();
+        mem_opnd = convert_mem(opnd0, &imm);
+        la_ld_by_op_size(src0, mem_opnd, imm, opnd0_size);
+    }
+
+    if (opt_imm) {
+        la_ori(dest, src0, ir1_opnd_s2uimm(opnd1));
+    } else {
+        la_or(dest, src0, src1);
+    }
+
+#ifdef TARGET_X86_64
+    if (!GHBR_ON(curr) && CODEIS64 && ir1_opnd_is_gpr(opnd0) &&
+        opnd0_size == 32) {
+        la_mov32_zx(dest, dest);
+    }
+#endif
+
+    if (ir1_opnd_is_gpr(opnd0)) {
+        if (opnd0_size < 32) {
+            store_ireg_to_ir1(dest, opnd0, false);
+        }
+    } else {
+        la_st_by_op_size(dest, mem_opnd, imm, opnd0_size);
+    }
+
+    bool zero_branch = ir1_opcode(next) == WRAP(JE) ||
+                       ir1_opcode(next) == WRAP(JNE);
+    IR2_OPND branch_result;
+    if (opnd0_size == 64 ||
+        (opnd0_size == 32 && zero_branch && !GHBR_ON(curr))) {
+        branch_result = dest;
+    } else {
+        branch_result = load_opnd_from_opnd(
+            dest, zero_branch ? ZERO_EXTENSION : SIGN_EXTENSION,
+            opnd0_size);
+    }
+
+    IR2_OPND target_label_opnd = ra_alloc_label();
+#ifdef CONFIG_LATX_TU
+    TranslationBlock *tb = lsenv->tr_data->curr_tb;
+    if (judge_tu_eflag_gen(tb)) {
+        IR2_OPND tu_reset_label_opnd = ra_alloc_label();
+        TranslationBlock *tb_next =
+            tb->s_data->next_tb[TU_TB_INDEX_NEXT];
+        TranslationBlock *tb_target =
+            tb->s_data->next_tb[TU_TB_INDEX_TARGET];
+
+        if (tb_next->eflag_use && tb_target->eflag_use) {
+            generate_eflag_calculation(dest, src0, src1, curr, true);
+        }
+
+        la_label(tu_reset_label_opnd);
+        tb->tu_jmp[TU_TB_INDEX_TARGET] = tu_reset_label_opnd._label_id;
+        add_jcc_gen_bcc(branch_result, target_label_opnd, next);
+        tu_jcc_nop_gen(tb);
+
+        if (tb_next->eflag_use && !tb_target->eflag_use) {
+            generate_eflag_calculation(dest, src0, src1, curr, true);
+        }
+
+        if (tb->tu_jmp[TU_TB_INDEX_NEXT] !=
+            TB_JMP_RESET_OFFSET_INVALID) {
+            IR2_OPND translated_label_opnd = ra_alloc_label();
+            la_label(translated_label_opnd);
+            la_b(imm_zero_ir2_opnd);
+            la_nop();
+            tb->tu_jmp[TU_TB_INDEX_NEXT] =
+                translated_label_opnd._label_id;
+        }
+
+        IR2_OPND unlink_label_opnd = ra_alloc_label();
+        la_label(unlink_label_opnd);
+        tb->tu_unlink.stub_offset = unlink_label_opnd._label_id;
+        tb->tu_unlink.rel_num = 2;
+        set_use_tu_jmp(tb);
+    }
+#endif
+
+    add_jcc_gen_bcc(branch_result, target_label_opnd, next);
+
+    EFLAGS_CACULATE_RESULT(dest, src0, src1, curr, 0, true);
+    tr_generate_exit_tb(next, 0);
+
+    la_label(target_label_opnd);
+    EFLAGS_CACULATE_RESULT(dest, src0, src1, curr, 1, true);
+    tr_generate_exit_tb(next, 1);
+
+    EFLAGS_CACULATE_RESULT(dest, src0, src1, curr, EFLAG_BACKUP, true);
+    return true;
+}
+
 #ifdef CONFIG_LATX_XCOMISX_OPT
 static inline bool xcomisx_jcc(IR1_INST *ir1, bool is_double, bool qnan_exp)
 {
@@ -2622,6 +2755,8 @@ static bool try_translate_instptn_impl(IR1_INST *pir1)
         return translate_and_jcc(pir1);
     case INSTPTN_OPC_ADD_JCC:
         return translate_add_jcc(pir1);
+    case INSTPTN_OPC_OR_JCC:
+        return translate_or_jcc(pir1);
     default:
         lsassert(0);
         break;

--- a/target/i386/latx/translator/tr-pattern.c
+++ b/target/i386/latx/translator/tr-pattern.c
@@ -76,6 +76,8 @@
         IR2_OPND eflags = ra_alloc_label();                          \
         la_label(eflags);                                            \
         tb->eflags_target_arg[i] = ir2_opnd_label_id(&eflags);       \
+        instptn_stats_record_eflags_fallback_opcode(                 \
+            (inst)->instptn.opc);                                    \
         generate_eflag_calculation(opnd0, opnd0, opnd1, inst, flags); \
     } while (0)
 
@@ -2384,7 +2386,7 @@ static bool translate_ucomiss_xx_jcc(IR1_INST *pir1)
 #endif
 
 
-bool try_translate_instptn(IR1_INST *pir1)
+static bool try_translate_instptn_impl(IR1_INST *pir1)
 {
     instptn_check_false();
 
@@ -2470,6 +2472,26 @@ bool try_translate_instptn(IR1_INST *pir1)
     }
 
     return false;
+}
+
+bool try_translate_instptn(IR1_INST *pir1)
+{
+    if (!option_instptn_stats) {
+        return try_translate_instptn_impl(pir1);
+    }
+
+    InstPtnOpcode opcode = pir1->instptn.opc;
+    int ir2_before = lsenv->tr_data->ir2_inst_num_current;
+    int host_before = lsenv->tr_data->real_ir2_inst_num;
+    bool translated = try_translate_instptn_impl(pir1);
+
+    if (translated) {
+        instptn_stats_record_codegen_opcode(
+            opcode,
+            lsenv->tr_data->ir2_inst_num_current - ir2_before,
+            lsenv->tr_data->real_ir2_inst_num - host_before);
+    }
+    return translated;
 }
 
 void opt_instptn_fix(CPUState *cpu, TranslationBlock *tb, int index)

--- a/target/i386/latx/translator/tr-pattern.c
+++ b/target/i386/latx/translator/tr-pattern.c
@@ -67,7 +67,7 @@
     ".error \"Unable to parse register name \\r\"\n\t" \
     ".endif\n\t"                                \
     ".endm\n\t"
-#define EFLAGS_CACULATE(opnd0, opnd1, inst, i, flags)            \
+#define EFLAGS_CACULATE_RESULT(dest, src0, src1, inst, i, flags)     \
     do {                                                             \
         bool need_calc_flag = ir1_need_calculate_any_flag(inst);     \
         if (!need_calc_flag)                                         \
@@ -78,8 +78,10 @@
         tb->eflags_target_arg[i] = ir2_opnd_label_id(&eflags);       \
         instptn_stats_record_eflags_fallback_opcode(                 \
             (inst)->instptn.opc);                                    \
-        generate_eflag_calculation(opnd0, opnd0, opnd1, inst, flags); \
+        generate_eflag_calculation(dest, src0, src1, inst, flags);   \
     } while (0)
+#define EFLAGS_CACULATE(opnd0, opnd1, inst, i, flags)                \
+    EFLAGS_CACULATE_RESULT(opnd0, opnd0, opnd1, inst, i, flags)
 
 static inline void cmp_jcc_gen_bcc(IR2_OPND src_opnd_0, IR2_OPND src_opnd_1,
         IR2_OPND target_label_opnd, IR1_INST *jcc_inst)
@@ -421,6 +423,151 @@ static bool translate_sub_jcc(IR1_INST *ir1)
     /* ra_free_temp(bcc_src0); */
     /* ra_free_temp(bcc_src1); */
 
+    return true;
+}
+
+static inline void add_jcc_gen_bcc(IR2_OPND result,
+        IR2_OPND target_label_opnd, IR1_INST *jcc_inst)
+{
+    switch (ir1_opcode(jcc_inst)) {
+    case WRAP(JE):
+        la_beqz(result, target_label_opnd);
+        break;
+    case WRAP(JNE):
+        la_bnez(result, target_label_opnd);
+        break;
+    case WRAP(JS):
+        la_blt(result, zero_ir2_opnd, target_label_opnd);
+        break;
+    case WRAP(JNS):
+        la_bge(result, zero_ir2_opnd, target_label_opnd);
+        break;
+    default:
+        lsassert(0);
+        break;
+    }
+}
+
+static bool translate_add_jcc(IR1_INST *ir1)
+{
+    IR1_INST *curr = ir1;
+    IR1_INST *next = curr->instptn.next;
+    IR1_OPND *opnd0 = ir1_get_opnd(curr, 0);
+    IR1_OPND *opnd1 = ir1_get_opnd(curr, 1);
+    IR2_OPND src0, src1, dest, mem_opnd;
+    int imm = 0;
+    int opnd0_size = ir1_opnd_size(opnd0);
+
+    curr->info->id = WRAP(ADD);
+
+    bool opt_imm = tr_opt_simm12(curr);
+
+    if (opt_imm) {
+        src1 = zero_ir2_opnd;
+    } else {
+        src1 = ra_alloc_itemp();
+        load_ireg_from_ir1_2(src1, opnd1, UNKNOWN_EXTENSION, false);
+    }
+
+    if (ir1_opnd_is_gpr(opnd0)) {
+        src0 = ra_alloc_itemp();
+        load_ireg_from_ir1_2(src0, opnd0, UNKNOWN_EXTENSION, false);
+        if (opnd0_size >= 32) {
+            dest = convert_gpr_opnd(opnd0, UNKNOWN_EXTENSION);
+        } else {
+            dest = ra_alloc_itemp();
+        }
+    } else {
+        src0 = ra_alloc_itemp();
+        dest = ra_alloc_itemp();
+        mem_opnd = convert_mem(opnd0, &imm);
+        la_ld_by_op_size(src0, mem_opnd, imm, opnd0_size);
+    }
+
+    if (opt_imm) {
+        la_addi_d(dest, src0, (int)ir1_opnd_simm(opnd1));
+    } else {
+        la_add_d(dest, src0, src1);
+    }
+
+#ifdef TARGET_X86_64
+    if (!GHBR_ON(curr) && CODEIS64 && ir1_opnd_is_gpr(opnd0) &&
+        opnd0_size == 32) {
+        la_mov32_zx(dest, dest);
+    }
+#endif
+
+    if (ir1_opnd_is_gpr(opnd0)) {
+        if (opnd0_size < 32) {
+            store_ireg_to_ir1(dest, opnd0, false);
+        }
+    } else {
+        la_st_by_op_size(dest, mem_opnd, imm, opnd0_size);
+    }
+
+    bool zero_branch = ir1_opcode(next) == WRAP(JE) ||
+                       ir1_opcode(next) == WRAP(JNE);
+    IR2_OPND branch_result;
+    if (opnd0_size == 64 ||
+        (opnd0_size == 32 && zero_branch && !GHBR_ON(curr))) {
+        branch_result = dest;
+    } else {
+        branch_result = load_opnd_from_opnd(
+            dest, zero_branch ? ZERO_EXTENSION : SIGN_EXTENSION,
+            opnd0_size);
+    }
+
+    IR2_OPND target_label_opnd = ra_alloc_label();
+#ifdef CONFIG_LATX_TU
+    TranslationBlock *tb = lsenv->tr_data->curr_tb;
+    if (judge_tu_eflag_gen(tb)) {
+        IR2_OPND tu_reset_label_opnd = ra_alloc_label();
+        TranslationBlock *tb_next =
+            tb->s_data->next_tb[TU_TB_INDEX_NEXT];
+        TranslationBlock *tb_target =
+            tb->s_data->next_tb[TU_TB_INDEX_TARGET];
+
+        if (tb_next->eflag_use && tb_target->eflag_use) {
+            generate_eflag_calculation(dest, src0, src1, curr, true);
+        }
+
+        la_label(tu_reset_label_opnd);
+        tb->tu_jmp[TU_TB_INDEX_TARGET] = tu_reset_label_opnd._label_id;
+        add_jcc_gen_bcc(branch_result, target_label_opnd, next);
+        tu_jcc_nop_gen(tb);
+
+        if (tb_next->eflag_use && !tb_target->eflag_use) {
+            generate_eflag_calculation(dest, src0, src1, curr, true);
+        }
+
+        if (tb->tu_jmp[TU_TB_INDEX_NEXT] !=
+            TB_JMP_RESET_OFFSET_INVALID) {
+            IR2_OPND translated_label_opnd = ra_alloc_label();
+            la_label(translated_label_opnd);
+            la_b(imm_zero_ir2_opnd);
+            la_nop();
+            tb->tu_jmp[TU_TB_INDEX_NEXT] =
+                translated_label_opnd._label_id;
+        }
+
+        IR2_OPND unlink_label_opnd = ra_alloc_label();
+        la_label(unlink_label_opnd);
+        tb->tu_unlink.stub_offset = unlink_label_opnd._label_id;
+        tb->tu_unlink.rel_num = 2;
+        set_use_tu_jmp(tb);
+    }
+#endif
+
+    add_jcc_gen_bcc(branch_result, target_label_opnd, next);
+
+    EFLAGS_CACULATE_RESULT(dest, src0, src1, curr, 0, true);
+    tr_generate_exit_tb(next, 0);
+
+    la_label(target_label_opnd);
+    EFLAGS_CACULATE_RESULT(dest, src0, src1, curr, 1, true);
+    tr_generate_exit_tb(next, 1);
+
+    EFLAGS_CACULATE_RESULT(dest, src0, src1, curr, EFLAG_BACKUP, true);
     return true;
 }
 
@@ -2466,6 +2613,8 @@ static bool try_translate_instptn_impl(IR1_INST *pir1)
         return translate_shr_jcc(pir1);
     case INSTPTN_OPC_AND_JCC:
         return translate_and_jcc(pir1);
+    case INSTPTN_OPC_ADD_JCC:
+        return translate_add_jcc(pir1);
     default:
         lsassert(0);
         break;

--- a/target/i386/latx/translator/tr-pattern.c
+++ b/target/i386/latx/translator/tr-pattern.c
@@ -775,6 +775,172 @@ static bool translate_or_jcc(IR1_INST *ir1)
     return true;
 }
 
+static void xor_jcc_generate_eflags(IR2_OPND result, int opnd_size)
+{
+    switch (opnd_size) {
+    case 8:
+        la_x86or_b(result, result);
+        break;
+    case 16:
+        la_x86or_h(result, result);
+        break;
+    case 32:
+        la_x86or_w(result, result);
+        break;
+    case 64:
+        la_x86or_d(result, result);
+        break;
+    default:
+        lsassert(0);
+        break;
+    }
+}
+
+static bool translate_xor_jcc(IR1_INST *ir1)
+{
+    IR1_INST *curr = ir1;
+    IR1_INST *next = curr->instptn.next;
+    IR1_OPND *opnd0 = ir1_get_opnd(curr, 0);
+    IR1_OPND *opnd1 = ir1_get_opnd(curr, 1);
+    IR2_OPND src0, src1, dest, mem_opnd;
+    int imm = 0;
+    int opnd0_size = ir1_opnd_size(opnd0);
+    bool same_reg = ir1_opnd_is_same_reg(opnd0, opnd1);
+    bool opt_imm = ir1_opnd_is_s2uimm12(opnd1);
+    bool eflags_calc = ir1_need_calculate_any_flag(curr);
+
+    if (ir1_is_prefix_lock(curr)) {
+        translate_xor(curr);
+        translate_jcc(next);
+        return true;
+    }
+
+    if (!same_reg) {
+        if (opt_imm) {
+            src1 = zero_ir2_opnd;
+        } else {
+            src1 = load_ireg_from_ir1(opnd1, UNKNOWN_EXTENSION, false);
+        }
+    }
+
+    if (ir1_opnd_is_gpr(opnd0)) {
+        src0 = convert_gpr_opnd(opnd0, UNKNOWN_EXTENSION);
+        if (opnd0_size >= 32) {
+            dest = src0;
+        } else {
+            dest = ra_alloc_itemp();
+        }
+    } else {
+        src0 = ra_alloc_itemp();
+        dest = src0;
+        mem_opnd = convert_mem(opnd0, &imm);
+        la_ld_by_op_size(src0, mem_opnd, imm, opnd0_size);
+    }
+
+    if (same_reg) {
+        src1 = src0;
+        la_mov64(dest, zero_ir2_opnd);
+    } else if (opt_imm) {
+        la_xori(dest, src0, ir1_opnd_s2uimm(opnd1));
+    } else {
+        la_xor(dest, src0, src1);
+    }
+
+#ifdef TARGET_X86_64
+    if (!GHBR_ON(curr) && CODEIS64 && ir1_opnd_is_gpr(opnd0) &&
+        opnd0_size == 32 && !same_reg) {
+        la_mov32_zx(dest, dest);
+    }
+#endif
+
+    if (ir1_opnd_is_gpr(opnd0)) {
+        if (opnd0_size < 32) {
+            store_ireg_to_ir1(dest, opnd0, false);
+        }
+    } else {
+        la_st_by_op_size(dest, mem_opnd, imm, opnd0_size);
+    }
+
+    if (eflags_calc) {
+        instptn_stats_record_eflags_fallback_opcode(curr->instptn.opc);
+        xor_jcc_generate_eflags(dest, opnd0_size);
+    }
+
+#ifdef CONFIG_LATX_TU
+    bool tu_target_eflags = false;
+#endif
+
+    bool zero_branch = ir1_opcode(next) == WRAP(JE) ||
+                       ir1_opcode(next) == WRAP(JNE);
+    IR2_OPND branch_result;
+    if (opnd0_size == 64 ||
+        (opnd0_size == 32 && zero_branch && !GHBR_ON(curr))) {
+        branch_result = dest;
+    } else {
+        branch_result = load_opnd_from_opnd(
+            dest, zero_branch ? ZERO_EXTENSION : SIGN_EXTENSION,
+            opnd0_size);
+    }
+
+    IR2_OPND target_label_opnd = ra_alloc_label();
+#ifdef CONFIG_LATX_TU
+    TranslationBlock *tb = lsenv->tr_data->curr_tb;
+    if (judge_tu_eflag_gen(tb)) {
+        IR2_OPND tu_reset_label_opnd = ra_alloc_label();
+        TranslationBlock *tb_next =
+            tb->s_data->next_tb[TU_TB_INDEX_NEXT];
+        TranslationBlock *tb_target =
+            tb->s_data->next_tb[TU_TB_INDEX_TARGET];
+
+        tu_target_eflags = !eflags_calc && !tb_next->eflag_use &&
+                           tb_target->eflag_use;
+
+        if (!eflags_calc && tb_next->eflag_use && tb_target->eflag_use) {
+            xor_jcc_generate_eflags(dest, opnd0_size);
+        }
+
+        la_label(tu_reset_label_opnd);
+        tb->tu_jmp[TU_TB_INDEX_TARGET] = tu_reset_label_opnd._label_id;
+        add_jcc_gen_bcc(branch_result, target_label_opnd, next);
+        tu_jcc_nop_gen(tb);
+
+        if (!eflags_calc && tb_next->eflag_use && !tb_target->eflag_use) {
+            xor_jcc_generate_eflags(dest, opnd0_size);
+        }
+
+        if (tb->tu_jmp[TU_TB_INDEX_NEXT] !=
+            TB_JMP_RESET_OFFSET_INVALID) {
+            IR2_OPND translated_label_opnd = ra_alloc_label();
+            la_label(translated_label_opnd);
+            la_b(imm_zero_ir2_opnd);
+            la_nop();
+            tb->tu_jmp[TU_TB_INDEX_NEXT] =
+                translated_label_opnd._label_id;
+        }
+
+        IR2_OPND unlink_label_opnd = ra_alloc_label();
+        la_label(unlink_label_opnd);
+        tb->tu_unlink.stub_offset = unlink_label_opnd._label_id;
+        tb->tu_unlink.rel_num = 2;
+        set_use_tu_jmp(tb);
+    }
+#endif
+
+    add_jcc_gen_bcc(branch_result, target_label_opnd, next);
+
+    tr_generate_exit_tb(next, 0);
+
+    la_label(target_label_opnd);
+#ifdef CONFIG_LATX_TU
+    if (tu_target_eflags) {
+        xor_jcc_generate_eflags(dest, opnd0_size);
+    }
+#endif
+    tr_generate_exit_tb(next, 1);
+
+    return true;
+}
+
 #ifdef CONFIG_LATX_XCOMISX_OPT
 static inline bool xcomisx_jcc(IR1_INST *ir1, bool is_double, bool qnan_exp)
 {
@@ -2950,6 +3116,8 @@ static bool try_translate_instptn_impl(IR1_INST *pir1)
         return translate_add_jcc(pir1);
     case INSTPTN_OPC_OR_JCC:
         return translate_or_jcc(pir1);
+    case INSTPTN_OPC_XOR_JCC:
+        return translate_xor_jcc(pir1);
     case INSTPTN_OPC_OR_XX_JCC:
         return translate_or_xx_jcc(pir1);
     default:

--- a/target/i386/latx/translator/tr-pattern.c
+++ b/target/i386/latx/translator/tr-pattern.c
@@ -1952,6 +1952,122 @@ bool translate_cmp_xx_jcc(IR1_INST *pir1)
     return true;
 }
 
+static bool translate_or_xx_jcc(IR1_INST *pir1)
+{
+    TRANSLATION_DATA *td = lsenv->tr_data;
+
+    if (ir1_opcode(pir1) == WRAP(OR)) {
+        IR1_INST *jcc = pir1->instptn.next;
+        IR1_OPND *opnd0 = ir1_get_opnd(pir1, 0);
+        IR1_OPND *opnd1 = ir1_get_opnd(pir1, 1);
+        int opnd0_size = ir1_opnd_size(opnd0);
+        bool zero_branch = ir1_opcode(jcc) == WRAP(JE) ||
+                           ir1_opcode(jcc) == WRAP(JNE);
+        IR2_OPND dest;
+
+        td->ptn_itemp0 = a0_ir2_opnd;
+        if (opnd0_size >= 32) {
+            dest = convert_gpr_opnd(opnd0, UNKNOWN_EXTENSION);
+        } else {
+            dest = td->ptn_itemp0;
+            load_ireg_from_ir1_2(dest, opnd0, UNKNOWN_EXTENSION, false);
+        }
+        if (ir1_opnd_is_s2uimm12(opnd1)) {
+            la_ori(dest, dest, ir1_opnd_s2uimm(opnd1));
+        } else {
+            IR2_OPND src1 = load_ireg_from_ir1(
+                opnd1, UNKNOWN_EXTENSION, false);
+            la_or(dest, dest, src1);
+        }
+
+        if (opnd0_size == 32) {
+            if (zero_branch) {
+                la_mov32_zx(td->ptn_itemp0, dest);
+            } else {
+                la_mov32_sx(td->ptn_itemp0, dest);
+            }
+            store_ireg_to_ir1(dest, opnd0, false);
+        } else if (opnd0_size == 64) {
+            la_mov64(td->ptn_itemp0, dest);
+        } else if (opnd0_size == 16) {
+            if (zero_branch) {
+                la_bstrpick_d(td->ptn_itemp0, td->ptn_itemp0, 15, 0);
+            } else {
+                la_ext_w_h(td->ptn_itemp0, td->ptn_itemp0);
+            }
+        } else if (opnd0_size == 8) {
+            if (zero_branch) {
+                la_andi(td->ptn_itemp0, td->ptn_itemp0, 0xff);
+            } else {
+                la_ext_w_b(td->ptn_itemp0, td->ptn_itemp0);
+            }
+        }
+        if (opnd0_size < 32) {
+            store_ireg_to_ir1(td->ptn_itemp0, opnd0, false);
+        }
+        return true;
+    }
+
+    IR1_INST *or_inst = pir1->instptn.next;
+    IR2_OPND result = td->ptn_itemp0;
+    IR2_OPND target_label_opnd = ra_alloc_label();
+
+#ifdef CONFIG_LATX_TU
+    TranslationBlock *tb = td->curr_tb;
+    if (judge_tu_eflag_gen(tb)) {
+        IR2_OPND tu_reset_label_opnd = ra_alloc_label();
+        TranslationBlock *tb_next =
+            tb->s_data->next_tb[TU_TB_INDEX_NEXT];
+        TranslationBlock *tb_target =
+            tb->s_data->next_tb[TU_TB_INDEX_TARGET];
+
+        if (tb_next->eflag_use && tb_target->eflag_use) {
+            generate_eflag_calculation(result, result, result,
+                                       or_inst, true);
+        }
+
+        la_label(tu_reset_label_opnd);
+        tb->tu_jmp[TU_TB_INDEX_TARGET] =
+            tu_reset_label_opnd._label_id;
+        add_jcc_gen_bcc(result, target_label_opnd, pir1);
+        tu_jcc_nop_gen(tb);
+
+        if (tb_next->eflag_use && !tb_target->eflag_use) {
+            generate_eflag_calculation(result, result, result,
+                                       or_inst, true);
+        }
+        if (tb->tu_jmp[TU_TB_INDEX_NEXT] !=
+            TB_JMP_RESET_OFFSET_INVALID) {
+            IR2_OPND translated_label_opnd = ra_alloc_label();
+            la_label(translated_label_opnd);
+            la_b(imm_zero_ir2_opnd);
+            la_nop();
+            tb->tu_jmp[TU_TB_INDEX_NEXT] =
+                translated_label_opnd._label_id;
+        }
+
+        IR2_OPND unlink_label_opnd = ra_alloc_label();
+        la_label(unlink_label_opnd);
+        tb->tu_unlink.stub_offset = unlink_label_opnd._label_id;
+        tb->tu_unlink.rel_num = 2;
+        set_use_tu_jmp(tb);
+    }
+#endif
+
+    add_jcc_gen_bcc(result, target_label_opnd, pir1);
+
+    EFLAGS_CACULATE_RESULT(result, result, result, or_inst, 0, true);
+    tr_generate_exit_tb(pir1, 0);
+
+    la_label(target_label_opnd);
+    EFLAGS_CACULATE_RESULT(result, result, result, or_inst, 1, true);
+    tr_generate_exit_tb(pir1, 1);
+
+    EFLAGS_CACULATE_RESULT(result, result, result, or_inst,
+                           EFLAG_BACKUP, true);
+    return true;
+}
+
 /* Return true when it is a branch. */
 static inline bool test_xx_jcc_gen_bcc(IR2_OPND itemp,
         IR2_OPND target_label_opnd, IR1_INST *jcc_inst)
@@ -2834,6 +2950,8 @@ static bool try_translate_instptn_impl(IR1_INST *pir1)
         return translate_add_jcc(pir1);
     case INSTPTN_OPC_OR_JCC:
         return translate_or_jcc(pir1);
+    case INSTPTN_OPC_OR_XX_JCC:
+        return translate_or_xx_jcc(pir1);
     default:
         lsassert(0);
         break;
@@ -2870,7 +2988,8 @@ void opt_instptn_fix(CPUState *cpu, TranslationBlock *tb, int index)
         IR1_INST *pir1 = tb_ir1_inst(tb, i);
         if (pir1->instptn.opc == INSTPTN_OPC_CMP_XX_JCC ||
             pir1->instptn.opc == INSTPTN_OPC_TEST_XX_JCC ||
-            pir1->instptn.opc == INSTPTN_OPC_BT_XX_JCC) {
+            pir1->instptn.opc == INSTPTN_OPC_BT_XX_JCC ||
+            pir1->instptn.opc == INSTPTN_OPC_OR_XX_JCC) {
 
             int opnd_size = ir1_opnd_size(ir1_get_opnd(pir1, 0));
             ucontext_t *uc = env->puc;
@@ -3020,6 +3139,91 @@ void opt_instptn_fix(CPUState *cpu, TranslationBlock *tb, int index)
                 }
                 env->eflags = env->eflags & ~(0b100011000101);
                 env->eflags = env->eflags | (eflags & 0b100011000101);
+            }
+            break;
+            case WRAP(OR):
+            {
+                uint64_t result = UC_GR(uc)[4];
+                uint64_t eflags = 0;
+
+                switch (opnd_size) {
+                case 8:
+                    asm volatile (
+                        DEFINE_PARSE_R
+                        "parse_r_%= __src, %[src]\n\t"
+                        "parse_r_%= __dst, %[dst]\n\t"
+                        /* x86or.b */
+                        ".word (0x003f8014 | (__src << 10) | "
+                        "(__dst << 5))\n\t"
+                        "parse_r_%= __flags, %[flags]\n\t"
+                        /* x86mfflag */
+                        ".word (0x005c0000 | (0x3f << 10) | "
+                        "__flags)\n\t"
+                        : [dst]"+r"(result),
+                        [flags]"=r"(eflags)
+                        : [src]"r"(result)
+                        : "cc"
+                    );
+                    break;
+                case 16:
+                    asm volatile (
+                        DEFINE_PARSE_R
+                        "parse_r_%= __src, %[src]\n\t"
+                        "parse_r_%= __dst, %[dst]\n\t"
+                        /* x86or.h */
+                        ".word (0x003f8015 | (__src << 10) | "
+                        "(__dst << 5))\n\t"
+                        "parse_r_%= __flags, %[flags]\n\t"
+                        /* x86mfflag */
+                        ".word (0x005c0000 | (0x3f << 10) | "
+                        "__flags)\n\t"
+                        : [dst]"+r"(result),
+                        [flags]"=r"(eflags)
+                        : [src]"r"(result)
+                        : "cc"
+                    );
+                    break;
+                case 32:
+                    asm volatile (
+                        DEFINE_PARSE_R
+                        "parse_r_%= __src, %[src]\n\t"
+                        "parse_r_%= __dst, %[dst]\n\t"
+                        /* x86or.w */
+                        ".word (0x003f8016 | (__src << 10) | "
+                        "(__dst << 5))\n\t"
+                        "parse_r_%= __flags, %[flags]\n\t"
+                        /* x86mfflag */
+                        ".word (0x005c0000 | (0x3f << 10) | "
+                        "__flags)\n\t"
+                        : [dst]"+r"(result),
+                        [flags]"=r"(eflags)
+                        : [src]"r"(result)
+                        : "cc"
+                    );
+                    break;
+                case 64:
+                    asm volatile (
+                        DEFINE_PARSE_R
+                        "parse_r_%= __src, %[src]\n\t"
+                        "parse_r_%= __dst, %[dst]\n\t"
+                        /* x86or.d */
+                        ".word (0x003f8017 | (__src << 10) | "
+                        "(__dst << 5))\n\t"
+                        "parse_r_%= __flags, %[flags]\n\t"
+                        /* x86mfflag */
+                        ".word (0x005c0000 | (0x3f << 10) | "
+                        "__flags)\n\t"
+                        : [dst]"+r"(result),
+                        [flags]"=r"(eflags)
+                        : [src]"r"(result)
+                        : "cc"
+                    );
+                    break;
+                default:
+                    break;
+                }
+                const uint64_t mask = 0x8c5;
+                env->eflags = (env->eflags & ~mask) | (eflags & mask);
             }
             break;
             case WRAP(BT):

--- a/target/i386/latx/translator/tr-pattern.c
+++ b/target/i386/latx/translator/tr-pattern.c
@@ -2034,7 +2034,29 @@ bool translate_bt_xx_jcc(IR1_INST *pir1)
     return true;
 }
 
-static bool translate_shr_jcc(IR1_INST *pir1)
+static inline void shift_jcc_gen_bcc(IR2_OPND result,
+        IR2_OPND target_label_opnd, IR1_INST *jcc_inst)
+{
+    switch (ir1_opcode(jcc_inst)) {
+    case WRAP(JE):
+        la_beqz(result, target_label_opnd);
+        break;
+    case WRAP(JNE):
+        la_bnez(result, target_label_opnd);
+        break;
+    case WRAP(JS):
+        la_blt(result, zero_ir2_opnd, target_label_opnd);
+        break;
+    case WRAP(JNS):
+        la_bge(result, zero_ir2_opnd, target_label_opnd);
+        break;
+    default:
+        lsassert(0);
+        break;
+    }
+}
+
+static bool translate_shift_jcc(IR1_INST *pir1)
 {
     IR1_INST *curr = pir1;
     IR1_INST *next = curr->instptn.next;
@@ -2045,42 +2067,45 @@ static bool translate_shr_jcc(IR1_INST *pir1)
     int opnd_size = ir1_opnd_size(opnd0);
     uint32 mask = (opnd_size == 64) ? 63 : 31;
     uint8 shift = ir1_opnd_uimm(opnd1) & mask;
+    bool is_sar = curr->instptn.opc == INSTPTN_OPC_SAR_JCC;
+    EXTENSION_MODE extension = is_sar ? SIGN_EXTENSION : ZERO_EXTENSION;
 
     IR2_OPND dest, src;
 
     if (ir1_opnd_is_gpr(opnd0) && (opnd_size >= 32)) {
         dest = ra_alloc_gpr(ir1_opnd_base_reg_num(opnd0));
-        if (shift) {
-            if (opnd_size == 64) {
-                src = ra_alloc_itemp();
-                la_mov64(src, dest);
-            } else {
-                src = load_ireg_from_ir1(opnd0, ZERO_EXTENSION, false);
-            }
-        }
+        src = ra_alloc_itemp();
+        load_ireg_from_ir1_2(src, opnd0, extension, false);
     } else {
-        src = load_ireg_from_ir1(opnd0, ZERO_EXTENSION, false);
+        src = load_ireg_from_ir1(opnd0, extension, false);
         dest = ra_alloc_itemp();
     }
 
     IR2_INST *(*shifti_inst)(IR2_OPND, IR2_OPND, int);
-    shifti_inst = (opnd_size == 64) ? la_srli_d : la_srli_w;
+    if (is_sar) {
+        shifti_inst = (opnd_size == 64) ? la_srai_d : la_srai_w;
+    } else {
+        shifti_inst = (opnd_size == 64) ? la_srli_d : la_srli_w;
+    }
 
     lsassert(ir1_opnd_is_imm(opnd1));
+    lsassert(shift != 0);
     bool can_use_imm = shift < opnd_size;
-    if (shift) {
-        shifti_inst(dest, src, shift);
-    }
-    if (shift || (ir1_opnd_is_gpr(opnd0) && (opnd_size == 32))) {
-        store_ireg_to_ir1(dest, opnd0, false);
-    }
-
-    if (!shift) {
-        translate_jcc(next);
-        return true;
-    }
+    shifti_inst(dest, src, shift);
+    store_ireg_to_ir1(dest, opnd0, false);
 
     IR2_OPND src1 = ir2_opnd_new(IR2_OPND_IMM, shift);
+    bool zero_branch = ir1_opcode(next) == WRAP(JE) ||
+                       ir1_opcode(next) == WRAP(JNE);
+    IR2_OPND branch_result;
+    if (opnd_size == 64 ||
+        (opnd_size == 32 && zero_branch && !GHBR_ON(curr))) {
+        branch_result = dest;
+    } else {
+        branch_result = load_opnd_from_opnd(
+            dest, zero_branch ? ZERO_EXTENSION : SIGN_EXTENSION,
+            opnd_size);
+    }
     IR2_OPND target_label_opnd = ra_alloc_label();
 
 #ifdef CONFIG_LATX_TU
@@ -2090,23 +2115,16 @@ static bool translate_shr_jcc(IR1_INST *pir1)
         TranslationBlock *tb_next = tb->s_data->next_tb[TU_TB_INDEX_NEXT];
         TranslationBlock *tb_target = tb->s_data->next_tb[TU_TB_INDEX_TARGET];
 
-        if (shift && tb_next->eflag_use && tb_target->eflag_use) {
+        if (tb_next->eflag_use && tb_target->eflag_use) {
             generate_eflag_calculation(src, src, src1, curr, can_use_imm);
         }
 
         la_label(tu_reset_label_opnd);
         tb->tu_jmp[TU_TB_INDEX_TARGET] = tu_reset_label_opnd._label_id;
-        switch (ir1_opcode(next)) {
-            case WRAP(JNE): //dest!=0
-                la_bnez(dest, target_label_opnd);
-                break;
-            default:
-                lsassert(0);
-                break;
-        }
+        shift_jcc_gen_bcc(branch_result, target_label_opnd, next);
         tu_jcc_nop_gen(tb);
 
-        if (shift && tb_next->eflag_use && !tb_target->eflag_use) {
+        if (tb_next->eflag_use && !tb_target->eflag_use) {
             generate_eflag_calculation(src, src, src1, curr, can_use_imm);
         }
 
@@ -2126,29 +2144,16 @@ static bool translate_shr_jcc(IR1_INST *pir1)
     }
 #endif
 
-    switch (ir1_opcode(next)) {
-        case WRAP(JNE): //dest!=0
-            la_bnez(dest, target_label_opnd);
-            break;
-        default:
-            lsassert(0);
-            break;
-    }
+    shift_jcc_gen_bcc(branch_result, target_label_opnd, next);
 
-    if (shift) {
-        EFLAGS_CACULATE(src, src1, curr, 0, can_use_imm);
-    }
+    EFLAGS_CACULATE(src, src1, curr, 0, can_use_imm);
     tr_generate_exit_tb(next, 0);
 
     la_label(target_label_opnd);
 
-    if (shift) {
-        EFLAGS_CACULATE(src, src1, curr, 1, can_use_imm);
-    }
+    EFLAGS_CACULATE(src, src1, curr, 1, can_use_imm);
     tr_generate_exit_tb(next, 1);
-    if (shift) {
-        EFLAGS_CACULATE(src, src1, curr, EFLAG_BACKUP, can_use_imm);
-    }
+    EFLAGS_CACULATE(src, src1, curr, EFLAG_BACKUP, can_use_imm);
     return true;
 }
 
@@ -2610,7 +2615,9 @@ static bool try_translate_instptn_impl(IR1_INST *pir1)
     case INSTPTN_OPC_NEG_CMOVCC:
         return translate_neg_cmovcc(pir1);
     case INSTPTN_OPC_SHR_JCC:
-        return translate_shr_jcc(pir1);
+    case INSTPTN_OPC_SAR_JCC:
+    case INSTPTN_OPC_SHR_JE:
+        return translate_shift_jcc(pir1);
     case INSTPTN_OPC_AND_JCC:
         return translate_and_jcc(pir1);
     case INSTPTN_OPC_ADD_JCC:

--- a/target/i386/latx/translator/tr-pattern.c
+++ b/target/i386/latx/translator/tr-pattern.c
@@ -519,6 +519,97 @@ static inline void add_jcc_gen_bcc(IR2_OPND result,
     }
 }
 
+static bool translate_dec_jcc(IR1_INST *ir1)
+{
+    IR1_INST *curr = ir1;
+    IR1_INST *next = curr->instptn.next;
+    IR1_OPND *opnd0 = ir1_get_opnd(curr, 0);
+    int opnd0_size = ir1_opnd_size(opnd0);
+    IR2_OPND src0 = ra_alloc_itemp();
+    IR2_OPND dest;
+
+    load_ireg_from_ir1_2(src0, opnd0, UNKNOWN_EXTENSION, false);
+    if (opnd0_size >= 32) {
+        dest = convert_gpr_opnd(opnd0, UNKNOWN_EXTENSION);
+    } else {
+        dest = ra_alloc_itemp();
+    }
+
+    la_addi_d(dest, src0, -1);
+
+#ifdef TARGET_X86_64
+    if (!GHBR_ON(curr) && CODEIS64 && opnd0_size == 32) {
+        la_mov32_zx(dest, dest);
+    }
+#endif
+
+    if (opnd0_size < 32) {
+        store_ireg_to_ir1(dest, opnd0, false);
+    }
+
+    IR2_OPND branch_result;
+    if (opnd0_size == 64 ||
+        (opnd0_size == 32 && !GHBR_ON(curr))) {
+        branch_result = dest;
+    } else {
+        branch_result = load_opnd_from_opnd(
+            dest, ZERO_EXTENSION, opnd0_size);
+    }
+    IR2_OPND target_label_opnd = ra_alloc_label();
+
+#ifdef CONFIG_LATX_TU
+    TranslationBlock *tb = lsenv->tr_data->curr_tb;
+    if (judge_tu_eflag_gen(tb)) {
+        IR2_OPND tu_reset_label_opnd = ra_alloc_label();
+        TranslationBlock *tb_next =
+            tb->s_data->next_tb[TU_TB_INDEX_NEXT];
+        TranslationBlock *tb_target =
+            tb->s_data->next_tb[TU_TB_INDEX_TARGET];
+
+        if (tb_next->eflag_use && tb_target->eflag_use) {
+            generate_eflag_calculation(dest, src0, src0, curr, true);
+        }
+
+        la_label(tu_reset_label_opnd);
+        tb->tu_jmp[TU_TB_INDEX_TARGET] = tu_reset_label_opnd._label_id;
+        add_jcc_gen_bcc(branch_result, target_label_opnd, next);
+        tu_jcc_nop_gen(tb);
+
+        if (tb_next->eflag_use && !tb_target->eflag_use) {
+            generate_eflag_calculation(dest, src0, src0, curr, true);
+        }
+
+        if (tb->tu_jmp[TU_TB_INDEX_NEXT] !=
+            TB_JMP_RESET_OFFSET_INVALID) {
+            IR2_OPND translated_label_opnd = ra_alloc_label();
+            la_label(translated_label_opnd);
+            la_b(imm_zero_ir2_opnd);
+            la_nop();
+            tb->tu_jmp[TU_TB_INDEX_NEXT] =
+                translated_label_opnd._label_id;
+        }
+
+        IR2_OPND unlink_label_opnd = ra_alloc_label();
+        la_label(unlink_label_opnd);
+        tb->tu_unlink.stub_offset = unlink_label_opnd._label_id;
+        tb->tu_unlink.rel_num = 2;
+        set_use_tu_jmp(tb);
+    }
+#endif
+
+    add_jcc_gen_bcc(branch_result, target_label_opnd, next);
+
+    EFLAGS_CACULATE_RESULT(dest, src0, src0, curr, 0, true);
+    tr_generate_exit_tb(next, 0);
+
+    la_label(target_label_opnd);
+    EFLAGS_CACULATE_RESULT(dest, src0, src0, curr, 1, true);
+    tr_generate_exit_tb(next, 1);
+
+    EFLAGS_CACULATE_RESULT(dest, src0, src0, curr, EFLAG_BACKUP, true);
+    return true;
+}
+
 static bool translate_add_jcc(IR1_INST *ir1)
 {
     IR1_INST *curr = ir1;
@@ -3118,6 +3209,8 @@ static bool try_translate_instptn_impl(IR1_INST *pir1)
         return translate_or_jcc(pir1);
     case INSTPTN_OPC_XOR_JCC:
         return translate_xor_jcc(pir1);
+    case INSTPTN_OPC_DEC_JCC:
+        return translate_dec_jcc(pir1);
     case INSTPTN_OPC_OR_XX_JCC:
         return translate_or_xx_jcc(pir1);
     default:

--- a/target/i386/latx/translator/tr-pattern.c
+++ b/target/i386/latx/translator/tr-pattern.c
@@ -670,8 +670,10 @@ static bool translate_add_jcc(IR1_INST *ir1)
     bool zero_branch = ir1_opcode(next) == WRAP(JE) ||
                        ir1_opcode(next) == WRAP(JNE);
     IR2_OPND branch_result;
+    /* Memory writeback truncates the value, but not the host temporary. */
     if (opnd0_size == 64 ||
-        (opnd0_size == 32 && zero_branch && !GHBR_ON(curr))) {
+        (opnd0_size == 32 && zero_branch && CODEIS64 &&
+         ir1_opnd_is_gpr(opnd0) && !GHBR_ON(curr))) {
         branch_result = dest;
     } else {
         branch_result = load_opnd_from_opnd(
@@ -964,8 +966,10 @@ static bool translate_xor_jcc(IR1_INST *ir1)
     bool zero_branch = ir1_opcode(next) == WRAP(JE) ||
                        ir1_opcode(next) == WRAP(JNE);
     IR2_OPND branch_result;
+    /* Memory writeback truncates the value, but not the host temporary. */
     if (opnd0_size == 64 ||
-        (opnd0_size == 32 && zero_branch && !GHBR_ON(curr))) {
+        (opnd0_size == 32 && zero_branch && CODEIS64 &&
+         ir1_opnd_is_gpr(opnd0) && !GHBR_ON(curr))) {
         branch_result = dest;
     } else {
         branch_result = load_opnd_from_opnd(

--- a/target/i386/latx/translator/tr-pattern.c
+++ b/target/i386/latx/translator/tr-pattern.c
@@ -3136,6 +3136,7 @@ static bool try_translate_instptn_impl(IR1_INST *pir1)
     case INSTPTN_OPC_NOP_DIV:
         return true;
     case INSTPTN_OPC_CMP_JCC:
+    case INSTPTN_OPC_CMP_JS_JNS:
         return translate_cmp_jcc(pir1);
     case INSTPTN_OPC_TEST_JCC:
         return translate_test_jcc(pir1);
@@ -3168,6 +3169,7 @@ static bool try_translate_instptn_impl(IR1_INST *pir1)
     case INSTPTN_OPC_UCOMISD_SETA:
         return translate_ucomisd_seta(pir1);
     case INSTPTN_OPC_SUB_JCC:
+    case INSTPTN_OPC_SUB_JS_JNS:
         return translate_sub_jcc(pir1);
 
     case INSTPTN_OPC_CMP_XX_JCC:
@@ -3206,6 +3208,7 @@ static bool try_translate_instptn_impl(IR1_INST *pir1)
     case INSTPTN_OPC_SHR_JE:
         return translate_shift_jcc(pir1);
     case INSTPTN_OPC_AND_JCC:
+    case INSTPTN_OPC_AND_JE:
         return translate_and_jcc(pir1);
     case INSTPTN_OPC_ADD_JCC:
         return translate_add_jcc(pir1);

--- a/tests/integration/add-jcc.S
+++ b/tests/integration/add-jcc.S
@@ -1,0 +1,212 @@
+/*
+ * SPDX-License-Identifier: GPL-2.0-only
+ *
+ * Exercise the adjacent ADD + JE/JNE/JS/JNS instruction pattern.
+ */
+
+    .text
+    .globl _start
+_start:
+    cmpq $1, (%rsp)
+    jne fault_case
+
+    /* 8-bit zero result with CF/AF/PF/ZF live. */
+    movl $1, %edi
+    movl $0x55, %r9d
+    movb $0xff, %al
+    addb $1, %al
+    je 1f
+    jmp exit_guest
+1:
+    call check_flags
+    testb %al, %al
+    jne exit_guest
+
+    /* 8-bit signed overflow and negative result. */
+    movl $2, %edi
+    movl $0x890, %r9d
+    movb $0x7f, %al
+    addb $1, %al
+    js 2f
+    jmp exit_guest
+2:
+    call check_flags
+    cmpb $0x80, %al
+    jne exit_guest
+
+    /* 16-bit positive result with carry. */
+    movl $3, %edi
+    movl $0x11, %r9d
+    movw $0xffff, %ax
+    addw $2, %ax
+    jns 3f
+    jmp exit_guest
+3:
+    call check_flags
+    cmpw $1, %ax
+    jne exit_guest
+
+    /* A 32-bit destination must clear the upper half of the GPR. */
+    movl $4, %edi
+    movl $0x55, %r9d
+    movq $-1, %rax
+    addl $1, %eax
+    je 4f
+    jmp exit_guest
+4:
+    call check_flags
+    testq %rax, %rax
+    jne exit_guest
+
+    /* 64-bit signed overflow and negative result. */
+    movl $5, %edi
+    movl $0x894, %r9d
+    movabsq $0x7fffffffffffffff, %rax
+    addq $1, %rax
+    js 5f
+    jmp exit_guest
+5:
+    call check_flags
+    movabsq $0x8000000000000000, %r10
+    cmpq %r10, %rax
+    jne exit_guest
+
+    /* Preserve both original inputs when source and destination alias. */
+    movl $6, %edi
+    movl $0x845, %r9d
+    movl $0x80000000, %eax
+    addl %eax, %eax
+    je 6f
+    jmp exit_guest
+6:
+    call check_flags
+    testq %rax, %rax
+    jne exit_guest
+
+    /* Memory source. */
+    movl $7, %edi
+    movl $0x55, %r9d
+    movq $-1, %rax
+    addq one(%rip), %rax
+    je 7f
+    jmp exit_guest
+7:
+    call check_flags
+    testq %rax, %rax
+    jne exit_guest
+
+    /* Immediate to memory destination. */
+    movl $8, %edi
+    movl $0x55, %r9d
+    movl $-1, mem32(%rip)
+    addl $1, mem32(%rip)
+    je 8f
+    jmp exit_guest
+8:
+    call check_flags
+    cmpl $0, mem32(%rip)
+    jne exit_guest
+
+    /* GPR to memory destination. */
+    movl $9, %edi
+    movl $0x55, %r9d
+    movq $-1, mem64(%rip)
+    movq $1, %rax
+    addq %rax, mem64(%rip)
+    je 9f
+    jmp exit_guest
+9:
+    call check_flags
+    cmpq $0, mem64(%rip)
+    jne exit_guest
+
+    /* Exercise the not-taken side of every supported condition. */
+    movl $10, %edi
+    xorl %eax, %eax
+    addl $1, %eax
+    je exit_guest
+    movl $11, %edi
+    movl $-1, %eax
+    addl $1, %eax
+    jne exit_guest
+    movl $12, %edi
+    xorl %eax, %eax
+    addl $1, %eax
+    js exit_guest
+    movl $13, %edi
+    movl $-2, %eax
+    addl $1, %eax
+    jns exit_guest
+
+    /* Non-adjacent ADD must execute normally and be rejected by the scanner. */
+    movl $14, %edi
+    xorl %eax, %eax
+    addl $1, %eax
+    nop
+    jne 10f
+    jmp exit_guest
+10:
+    cmpl $1, %eax
+    jne exit_guest
+
+    /* Unsupported JO must execute through the ordinary ADD path. */
+    movl $15, %edi
+    movl $0x7fffffff, %eax
+    addl $1, %eax
+    jo 11f
+    jmp exit_guest
+11:
+    cmpl $0x80000000, %eax
+    jne exit_guest
+
+    /* LOCK ADD remains on the ordinary atomic path. */
+    movl $16, %edi
+    movl $0, lock_value(%rip)
+    lock addl $1, lock_value(%rip)
+    jne 12f
+    jmp exit_guest
+12:
+    cmpl $1, lock_value(%rip)
+    jne exit_guest
+
+    /* Heat a matching loop so the TU/retranslation path is exercised. */
+    movl $-100000, %ecx
+14:
+    addl $1, %ecx
+    jne 14b
+    cmpl $0, %ecx
+    jne exit_guest
+
+    xorl %edi, %edi
+exit_guest:
+    movl $60, %eax
+    syscall
+
+/* Compare CF/PF/AF/ZF/SF/OF without modifying flags before PUSHFQ. */
+check_flags:
+    pushfq
+    popq %r10
+    andq $0x8d5, %r10
+    cmpq %r9, %r10
+    jne exit_guest
+    ret
+
+/* With an extra argv, execute a matching faulting memory ADD. */
+fault_case:
+    xorl %eax, %eax
+    addl $1, (%rax)
+    jne 13f
+13:
+    movl $17, %edi
+    jmp exit_guest
+
+    .data
+    .p2align 3
+one:
+    .quad 1
+mem64:
+    .quad 0
+mem32:
+    .long 0
+lock_value:
+    .long 0

--- a/tests/integration/add-jcc.S
+++ b/tests/integration/add-jcc.S
@@ -169,6 +169,24 @@ _start:
     cmpl $1, lock_value(%rip)
     jne exit_guest
 
+    /* Dword memory writes discard the high half of the host ADD result. */
+    movl $18, %edi
+    movl $0x845, %r9d
+    movl $0x80000000, mem32(%rip)
+    addl $-2147483648, mem32(%rip)
+    je .Lmem32_zero
+    jmp exit_guest
+.Lmem32_zero:
+    call check_flags
+    cmpl $0, mem32(%rip)
+    jne exit_guest
+
+    movl $19, %edi
+    movl $0x80000000, mem32(%rip)
+    addl $-2147483648, mem32(%rip)
+    jne exit_guest
+    call check_flags
+
     /* Heat a matching loop so the TU/retranslation path is exercised. */
     movl $-100000, %ecx
 14:

--- a/tests/integration/check-jcc-condition-options.sh
+++ b/tests/integration/check-jcc-condition-options.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-only
+set -eu
+
+emulator=$(readlink -f "$1")
+guest_dir=$(readlink -f "$2")
+
+matches()
+{
+    awk -v pattern="$1" '
+        $2 == pattern { split($3, count, "="); value = count[2] }
+        END { print value + 0 }
+    ' "$2"
+}
+
+for entry in \
+    'cmp cmp-js-jns cmp-jcc 0x80000000' \
+    'sub sub-js-jns sub-jcc 0x100000000' \
+    'and and-je and-jcc 0x200000000'; do
+    set -- $entry
+    kind=$1
+    pattern=$2
+    legacy=$3
+    enabled=$4
+    for mask in 0 0x3ffffff 0x80000000 0x100000000 0x200000000; do
+        expected=0
+        if [ "$mask" = "$enabled" ]; then
+            expected=2
+        fi
+        log="$guest_dir/options-$kind-$mask.log"
+        env LATX_AOT=0 LATX_INSTPTN_STATS=1 LATX_INSTPTN_MASK="$mask" \
+            "$emulator" "$guest_dir/probe-$kind" >"$log" 2>&1
+        actual=$(matches "$pattern" "$log")
+        old=$(matches "$legacy" "$log")
+        if [ "$actual" -ne "$expected" ] || [ "$old" -ne 0 ]; then
+            echo "FAIL: $pattern mask=$mask expected=$expected" \
+                "actual=$actual legacy=$old"
+            cat "$log"
+            exit 1
+        fi
+        echo "PASS: $pattern mask=$mask match=$actual legacy=$old"
+    done
+done

--- a/tests/integration/dec-jcc.S
+++ b/tests/integration/dec-jcc.S
@@ -1,0 +1,168 @@
+/*
+ * SPDX-License-Identifier: GPL-2.0-only
+ *
+ * Exercise the adjacent GPR DEC + JE/JNE instruction pattern.
+ */
+
+    .text
+    .globl _start
+_start:
+    cmpq $1, (%rsp)
+    jne fault_case
+
+    /* 8-bit 1 -> 0 with CF set and upper bits preserved. */
+    movl $1, %edi
+    movl $0x45, %r9d
+    movabsq $0x1122334455667701, %rax
+    stc
+    decb %al
+    je 1f
+    jmp exit_guest
+1:
+    call check_flags
+    movabsq $0x1122334455667700, %r10
+    cmpq %r10, %rax
+    jne exit_guest
+
+    /* 8-bit minimum negative value overflows to the maximum positive value. */
+    movl $2, %edi
+    movl $0x810, %r9d
+    movb $0x80, %al
+    clc
+    decb %al
+    jne 2f
+    jmp exit_guest
+2:
+    call check_flags
+    cmpb $0x7f, %al
+    jne exit_guest
+
+    /* 16-bit 0 -> -1 with CF set and upper bits preserved. */
+    movl $3, %edi
+    movl $0x95, %r9d
+    movabsq $0x1122334455660000, %rax
+    stc
+    decw %ax
+    jne 3f
+    jmp exit_guest
+3:
+    call check_flags
+    movabsq $0x112233445566ffff, %r10
+    cmpq %r10, %rax
+    jne exit_guest
+
+    /* A 32-bit destination must clear the upper half of the GPR. */
+    movl $4, %edi
+    movl $0x44, %r9d
+    movabsq $0xffffffff00000001, %rax
+    clc
+    decl %eax
+    je 4f
+    jmp exit_guest
+4:
+    call check_flags
+    testq %rax, %rax
+    jne exit_guest
+
+    /* 64-bit signed overflow must preserve CF. */
+    movl $5, %edi
+    movl $0x815, %r9d
+    movabsq $0x8000000000000000, %rax
+    stc
+    decq %rax
+    jne 5f
+    jmp exit_guest
+5:
+    call check_flags
+    movabsq $0x7fffffffffffffff, %r10
+    cmpq %r10, %rax
+    jne exit_guest
+
+    /* Exercise both not-taken sides. */
+    movl $6, %edi
+    movl $2, %eax
+    decl %eax
+    je exit_guest
+    movl $7, %edi
+    movl $1, %eax
+    decl %eax
+    jne exit_guest
+
+    /* Non-adjacent DEC must execute normally and be rejected. */
+    movl $8, %edi
+    movl $2, %eax
+    decl %eax
+    nop
+    jne 6f
+    jmp exit_guest
+6:
+    cmpl $1, %eax
+    jne exit_guest
+
+    /* Unsupported JO must execute through the ordinary DEC path. */
+    movl $9, %edi
+    movl $0x80000000, %eax
+    decl %eax
+    jo 7f
+    jmp exit_guest
+7:
+    cmpl $0x7fffffff, %eax
+    jne exit_guest
+
+    /* Memory destinations, including LOCK, remain outside this pattern. */
+    movl $10, %edi
+    movl $2, mem32(%rip)
+    decl mem32(%rip)
+    jne 8f
+    jmp exit_guest
+8:
+    cmpl $1, mem32(%rip)
+    jne exit_guest
+
+    movl $11, %edi
+    movl $1, mem32(%rip)
+    lock decl mem32(%rip)
+    je 9f
+    jmp exit_guest
+9:
+    cmpl $0, mem32(%rip)
+    jne exit_guest
+
+    /* Heat a matching loop and verify CF survives every DEC. */
+    movl $12, %edi
+    movl $100000, %ecx
+    stc
+10:
+    decl %ecx
+    jne 10b
+    jnc exit_guest
+    testl %ecx, %ecx
+    jne exit_guest
+
+    xorl %edi, %edi
+exit_guest:
+    movl $60, %eax
+    syscall
+
+/* Compare CF/PF/AF/ZF/SF/OF without modifying flags before PUSHFQ. */
+check_flags:
+    pushfq
+    popq %r10
+    andq $0x8d5, %r10
+    cmpq %r9, %r10
+    jne exit_guest
+    ret
+
+/* With an extra argv, execute a faulting memory DEC. */
+fault_case:
+    xorl %eax, %eax
+    decl (%rax)
+    jne 11f
+11:
+    movl $13, %edi
+    jmp exit_guest
+
+    .data
+    .p2align 2
+mem32:
+    .long 0

--- a/tests/integration/dec-jcc.S
+++ b/tests/integration/dec-jcc.S
@@ -4,6 +4,10 @@
  * Exercise the adjacent GPR DEC + JE/JNE instruction pattern.
  */
 
+#ifndef INSTPTN_LOOP_COUNT
+#define INSTPTN_LOOP_COUNT 100000
+#endif
+
     .text
     .globl _start
 _start:
@@ -130,7 +134,7 @@ _start:
 
     /* Heat a matching loop and verify CF survives every DEC. */
     movl $12, %edi
-    movl $100000, %ecx
+    movl $INSTPTN_LOOP_COUNT, %ecx
     stc
 10:
     decl %ecx

--- a/tests/integration/instptn-options-fork.S
+++ b/tests/integration/instptn-options-fork.S
@@ -15,7 +15,7 @@ _start:
 
     /* Unsupported Jcc for the existing SUB pattern. */
     subl $0, %r8d
-    js 2f
+    jo 2f
 2:
     /* Existing SUB pattern is adjacent-only. */
     subl $0, %r8d

--- a/tests/integration/instptn-options-fork.S
+++ b/tests/integration/instptn-options-fork.S
@@ -1,0 +1,49 @@
+/*
+ * SPDX-License-Identifier: GPL-2.0-only
+ *
+ * Exercise instruction-pattern matching, rejection statistics and fork
+ * accounting without relying on a guest libc.
+ */
+
+    .text
+    .globl _start
+_start:
+    movl $2, %ecx
+1:
+    subl $1, %ecx
+    jne 1b
+
+    /* Unsupported Jcc for the existing SUB pattern. */
+    subl $0, %r8d
+    js 2f
+2:
+    /* Existing SUB pattern is adjacent-only. */
+    subl $0, %r8d
+    nop
+    jne 3f
+3:
+    /* Existing SHR pattern accepts only an immediate count. */
+    movl $1, %r9d
+    movl $1, %ecx
+    shrl %cl, %r9d
+    jne 4f
+4:
+    /* A masked zero count must not be fused. */
+    shrl $0, %r9d
+    jne 5f
+5:
+    movl $57, %eax                 /* fork */
+    syscall
+    testl %eax, %eax
+    je 6f
+
+    movl %eax, %edi
+    xorl %esi, %esi
+    xorl %edx, %edx
+    xorl %r10d, %r10d
+    movl $61, %eax                 /* wait4(child, NULL, 0, NULL) */
+    syscall
+6:
+    xorl %edi, %edi
+    movl $60, %eax                 /* exit(0) */
+    syscall

--- a/tests/integration/jcc-conditions.S
+++ b/tests/integration/jcc-conditions.S
@@ -1,0 +1,293 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+    .text
+    .globl _start
+_start:
+    cmpq $2, (%rsp)
+    je cmp_fault
+    cmpq $3, (%rsp)
+    je sub_fault
+    cmpq $4, (%rsp)
+    je and_fault
+
+    /* CMP+JS/JNS: SF is the sign of the width-truncated subtraction. */
+    movl $1, %edi
+    movl $0x810, %r9d
+    movb $0x80, %al
+    cmpb $1, %al
+    jns .Lcmp8_overflow_ok
+    jmp exit_guest
+.Lcmp8_overflow_ok:
+    call check_arith_flags
+
+    movl $2, %edi
+    movb $0, %al
+    cmpb $1, %al
+    js .Lcmp8_negative_ok
+    jmp exit_guest
+.Lcmp8_negative_ok:
+
+    movl $3, %edi
+    movw $0x8000, %ax
+    cmpw $1, %ax
+    jns .Lcmp16_overflow_ok
+    jmp exit_guest
+.Lcmp16_overflow_ok:
+    movw $0, %ax
+    cmpw $1, %ax
+    js .Lcmp16_negative_ok
+    jmp exit_guest
+.Lcmp16_negative_ok:
+
+    movl $4, %edi
+    movl $0x80000000, %eax
+    cmpl $1, %eax
+    jns .Lcmp32_overflow_ok
+    jmp exit_guest
+.Lcmp32_overflow_ok:
+    xorl %eax, %eax
+    cmpl $1, %eax
+    js .Lcmp32_negative_ok
+    jmp exit_guest
+.Lcmp32_negative_ok:
+
+    movl $5, %edi
+    movabsq $0x8000000000000000, %rax
+    cmpq $1, %rax
+    jns .Lcmp64_overflow_ok
+    jmp exit_guest
+.Lcmp64_overflow_ok:
+    xorq %rax, %rax
+    cmpq $1, %rax
+    js .Lcmp64_negative_ok
+    jmp exit_guest
+.Lcmp64_negative_ok:
+
+    /* SUB+JS/JNS also has to preserve the written result. */
+    movl $6, %edi
+    movb $0x80, %al
+    subb $1, %al
+    jns .Lsub8_overflow_ok
+    jmp exit_guest
+.Lsub8_overflow_ok:
+    cmpb $0x7f, %al
+    jne exit_guest
+
+    movl $7, %edi
+    movb $0, %al
+    subb $1, %al
+    js .Lsub8_negative_ok
+    jmp exit_guest
+.Lsub8_negative_ok:
+    cmpb $0xff, %al
+    jne exit_guest
+
+    movl $8, %edi
+    movw $0x8000, %ax
+    subw $1, %ax
+    jns .Lsub16_overflow_ok
+    jmp exit_guest
+.Lsub16_overflow_ok:
+    cmpw $0x7fff, %ax
+    jne exit_guest
+
+    movl $9, %edi
+    movl $0x80000000, %eax
+    subl $1, %eax
+    jns .Lsub32_overflow_ok
+    jmp exit_guest
+.Lsub32_overflow_ok:
+    cmpl $0x7fffffff, %eax
+    jne exit_guest
+
+    movl $10, %edi
+    movabsq $0x8000000000000000, %rax
+    subq $1, %rax
+    jns .Lsub64_overflow_ok
+    jmp exit_guest
+.Lsub64_overflow_ok:
+    movabsq $0x7fffffffffffffff, %r10
+    cmpq %r10, %rax
+    jne exit_guest
+
+    movl $11, %edi
+    movl $0, mem32(%rip)
+    subl $1, mem32(%rip)
+    js .Lsub_mem_ok
+    jmp exit_guest
+.Lsub_mem_ok:
+    cmpl $-1, mem32(%rip)
+    jne exit_guest
+
+    /* AND+JE and the existing JNE path must be complementary. */
+    movl $12, %edi
+    movl $0x44, %r9d
+    movb $0xf0, %al
+    andb $0x0f, %al
+    je .Land8_zero_ok
+    jmp exit_guest
+.Land8_zero_ok:
+    call check_logic_flags
+
+    movl $13, %edi
+    movw $0x100, %ax
+    andw $0x100, %ax
+    je exit_guest
+    cmpw $0x100, %ax
+    jne exit_guest
+
+    movl $14, %edi
+    movabsq $0x100000001, %rax
+    andl $1, %eax
+    je exit_guest
+    cmpq $1, %rax
+    jne exit_guest
+
+    movl $15, %edi
+    movq $0x100, %rax
+    andq mem64(%rip), %rax
+    je .Land64_zero_ok
+    jmp exit_guest
+.Land64_zero_ok:
+
+    movl $16, %edi
+    movl $0xffffffff, mem32(%rip)
+    andl $0, mem32(%rip)
+    je .Land_mem_ok
+    jmp exit_guest
+.Land_mem_ok:
+    cmpl $0, mem32(%rip)
+    jne exit_guest
+
+    /* Existing SHR+JE, including count masking and JE/JNE complement. */
+    movl $17, %edi
+    movl $1, %eax
+    shrl $1, %eax
+    je .Lshr_zero_ok
+    jmp exit_guest
+.Lshr_zero_ok:
+    movl $2, %eax
+    shrl $1, %eax
+    je exit_guest
+    jne .Lshr_nonzero_ok
+    jmp exit_guest
+.Lshr_nonzero_ok:
+
+    movl $18, %edi
+    xorl %eax, %eax
+    cmpl %eax, %eax
+    shrl $32, %eax
+    je .Lshr_count_zero_ok
+    jmp exit_guest
+.Lshr_count_zero_ok:
+
+    /* Rejected cases stay on the ordinary path. */
+    movl $19, %edi
+    xorl %eax, %eax
+    cmpl $1, %eax
+    nop
+    js .Lcmp_nonadj_ok
+    jmp exit_guest
+.Lcmp_nonadj_ok:
+    subl $1, %eax
+    nop
+    js .Lsub_nonadj_ok
+    jmp exit_guest
+.Lsub_nonadj_ok:
+    andl $0, %eax
+    nop
+    je .Land_nonadj_ok
+    jmp exit_guest
+.Land_nonadj_ok:
+    shrl $1, %eax
+    nop
+    je .Lshr_nonadj_ok
+    jmp exit_guest
+.Lshr_nonadj_ok:
+
+    movl $20, %edi
+    movl $1, lock_value(%rip)
+    lock subl $1, lock_value(%rip)
+    jns .Llock_sub_ok
+    jmp exit_guest
+.Llock_sub_ok:
+    lock andl $0, lock_value(%rip)
+    je .Llock_and_ok
+    jmp exit_guest
+.Llock_and_ok:
+    cmpl $0, lock_value(%rip)
+    jne exit_guest
+
+    /* Hot loop for JIT/TU and performance tests. */
+    movl $100000, %ecx
+.Lhot_loop:
+    movl $0x80000000, %eax
+    cmpl $1, %eax
+    jns .Lhot_cmp_ok
+    jmp exit_guest
+.Lhot_cmp_ok:
+    subl $1, %eax
+    jns .Lhot_sub_ok
+    jmp exit_guest
+.Lhot_sub_ok:
+    andl $0, %eax
+    je .Lhot_and_ok
+    jmp exit_guest
+.Lhot_and_ok:
+    movl $1, %eax
+    shrl $1, %eax
+    je .Lhot_shr_ok
+    jmp exit_guest
+.Lhot_shr_ok:
+    decl %ecx
+    jne .Lhot_loop
+
+    xorl %edi, %edi
+exit_guest:
+    movl $60, %eax
+    syscall
+
+check_arith_flags:
+    pushfq
+    popq %r10
+    andq $0x8d5, %r10
+    cmpq %r9, %r10
+    jne exit_guest
+    ret
+
+check_logic_flags:
+    pushfq
+    popq %r10
+    andq $0x8c5, %r10
+    cmpq %r9, %r10
+    jne exit_guest
+    ret
+
+cmp_fault:
+    xorl %eax, %eax
+    cmpq $1, (%rax)
+    js .Lcmp_fault_unreachable
+.Lcmp_fault_unreachable:
+    movl $21, %edi
+    jmp exit_guest
+
+sub_fault:
+    xorl %eax, %eax
+    subq $1, (%rax)
+    js .Lsub_fault_unreachable
+.Lsub_fault_unreachable:
+    movl $22, %edi
+    jmp exit_guest
+
+and_fault:
+    xorl %eax, %eax
+    andq $1, (%rax)
+    je .Land_fault_unreachable
+.Land_fault_unreachable:
+    movl $23, %edi
+    jmp exit_guest
+
+    .data
+    .p2align 3
+mem32:       .long 0
+lock_value:  .long 0
+mem64:       .quad 0xff

--- a/tests/integration/jcc-conditions.S
+++ b/tests/integration/jcc-conditions.S
@@ -2,6 +2,43 @@
     .text
     .globl _start
 _start:
+#if defined(INSTPTN_CMP_PROBE) || defined(INSTPTN_SUB_PROBE) || \
+    defined(INSTPTN_AND_PROBE)
+    /* Isolate new conditions so legacy matches cannot hide a mask error. */
+    movl $1, %edi
+    movl $0x80000000, %eax
+#if defined(INSTPTN_CMP_PROBE)
+    cmpl $1, %eax
+    jns .Lprobe_second
+    jmp .Lprobe_exit
+.Lprobe_second:
+    movl $0, %eax
+    cmpl $1, %eax
+    js .Lprobe_ok
+#elif defined(INSTPTN_SUB_PROBE)
+    subl $1, %eax
+    jns .Lprobe_second
+    jmp .Lprobe_exit
+.Lprobe_second:
+    movl $0, %eax
+    subl $1, %eax
+    js .Lprobe_ok
+#else
+    andl $0, %eax
+    je .Lprobe_second
+    jmp .Lprobe_exit
+.Lprobe_second:
+    movl $1, %eax
+    andl $0, %eax
+    je .Lprobe_ok
+#endif
+    jmp .Lprobe_exit
+.Lprobe_ok:
+    xorl %edi, %edi
+.Lprobe_exit:
+    movl $60, %eax
+    syscall
+#else
     cmpq $2, (%rsp)
     je cmp_fault
     cmpq $3, (%rsp)
@@ -286,6 +323,7 @@ and_fault:
     movl $23, %edi
     jmp exit_guest
 
+#endif
     .data
     .p2align 3
 mem32:       .long 0

--- a/tests/integration/or-jcc.S
+++ b/tests/integration/or-jcc.S
@@ -1,0 +1,149 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+    .text
+    .globl _start
+_start:
+    cmpq $1, (%rsp)
+    jne fault_case
+
+    movl $1, %edi
+    movl $0x44, %r9d
+    xorl %eax, %eax
+    orb $0, %al
+    je 1f
+    jmp exit_guest
+1:  call check_flags
+
+    movl $2, %edi
+    movl $0x84, %r9d
+    movb $0x80, %al
+    orb $1, %al
+    js 2f
+    jmp exit_guest
+2:  call check_flags
+    cmpb $0x81, %al
+    jne exit_guest
+
+    movl $3, %edi
+    movw $0x7f00, %ax
+    orw $1, %ax
+    jns 3f
+    jmp exit_guest
+3:  cmpw $0x7f01, %ax
+    jne exit_guest
+
+    movl $4, %edi
+    movabsq $0x100000000, %rax
+    orl $0, %eax
+    je 4f
+    jmp exit_guest
+4:  testq %rax, %rax
+    jne exit_guest
+
+    movl $5, %edi
+    movq $0x1000, %rax
+    orq $1, %rax
+    jne 5f
+    jmp exit_guest
+5:  cmpq $0x1001, %rax
+    jne exit_guest
+
+    movl $6, %edi
+    movl $0, mem32(%rip)
+    orl $0x80000000, mem32(%rip)
+    js 6f
+    jmp exit_guest
+6:  cmpl $0x80000000, mem32(%rip)
+    jne exit_guest
+
+    movl $7, %edi
+    movq $0x100, %rax
+    movq $1, %r10
+    orq %r10, %rax
+    jne 7f
+    jmp exit_guest
+7:  cmpq $0x101, %rax
+    jne exit_guest
+
+    movl $8, %edi
+    movq $0x100, %rax
+    orq mem64(%rip), %rax
+    jne .Lmem_src_ok
+    jmp exit_guest
+.Lmem_src_ok:
+    cmpq $0x101, %rax
+    jne exit_guest
+
+    /* Not-taken sides. */
+    movl $9, %edi
+    movl $1, %eax
+    orl $0, %eax
+    je exit_guest
+    movl $10, %edi
+    xorl %eax, %eax
+    orl $0, %eax
+    jne exit_guest
+    movl $11, %edi
+    movl $1, %eax
+    orl $0, %eax
+    js exit_guest
+    movl $12, %edi
+    movl $0x80000000, %eax
+    orl $0, %eax
+    jns exit_guest
+
+    movl $13, %edi
+    movl $1, %eax
+    orl $2, %eax
+    nop
+    jne 8f
+    jmp exit_guest
+8:  cmpl $3, %eax
+    jne exit_guest
+
+    movl $14, %edi
+    movl $0, %eax
+    orl $0, %eax
+    jo exit_guest
+
+    movl $15, %edi
+    movl $0, lock_value(%rip)
+    lock orl $1, lock_value(%rip)
+    jne 9f
+    jmp exit_guest
+9:  cmpl $1, lock_value(%rip)
+    jne exit_guest
+
+    movl $100000, %ecx
+10:
+    movl $1, %eax
+    orl $2, %eax
+    jne 11f
+    jmp exit_guest
+11: decl %ecx
+    jne 10b
+
+    xorl %edi, %edi
+exit_guest:
+    movl $60, %eax
+    syscall
+
+check_flags:
+    pushfq
+    popq %r10
+    andq $0x8c5, %r10
+    cmpq %r9, %r10
+    jne exit_guest
+    ret
+
+fault_case:
+    xorl %eax, %eax
+    orq $1, (%rax)
+    jne 12f
+12: movl $16, %edi
+    jmp exit_guest
+
+    .data
+    .p2align 3
+mem32:       .long 0
+lock_value:  .long 0
+mem64:       .quad 1

--- a/tests/integration/or-xx-jcc.S
+++ b/tests/integration/or-xx-jcc.S
@@ -1,0 +1,294 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+    .equ __NR_rt_sigaction, 13
+    .equ __NR_rt_sigreturn, 15
+    .equ SIGSEGV, 11
+    .equ SA_SIGINFO, 0x00000004
+    .equ SA_RESTORER, 0x04000000
+    .equ UCONTEXT_RIP_OFFSET, 168
+    .equ UCONTEXT_EFL_OFFSET, 176
+
+    .data
+    .p2align 3
+segv_action:
+    .quad segv_handler
+    .quad (SA_SIGINFO | SA_RESTORER)
+    .quad signal_restorer
+    .quad 0
+expected_eflags:
+    .quad 0
+resume_rip:
+    .quad 0
+signal_count:
+    .quad 0
+
+    .text
+    .globl _start
+_start:
+    cmpq $2, (%rsp)
+    je fault_case
+    cmpq $3, (%rsp)
+    je .Lsignal_cases_ok
+
+    movl $__NR_rt_sigaction, %eax
+    movl $SIGSEGV, %edi
+    leaq segv_action(%rip), %rsi
+    xorl %edx, %edx
+    movl $8, %r10d
+    syscall
+    testq %rax, %rax
+    js install_failed
+
+    xorl %r15d, %r15d
+
+    /* Recover flags from the saved 8-bit OR result, not the overwritten AL. */
+    xorl %eax, %eax
+    movq $0x44, expected_eflags(%rip)
+    leaq .Lfault8_resume(%rip), %r10
+    movq %r10, resume_rip(%rip)
+    movb $0x80, %dl
+    addb %dl, %dl
+    orb $0, %al
+    movb $0x7f, %al
+    movl (%r15), %r11d
+.Lfault8_resume:
+    je .Lfault8_ok
+    movl $20, %edi
+    jmp exit_guest
+.Lfault8_ok:
+
+    /* Recover PF and SF from a 16-bit negative result. */
+    movw $0x8000, %ax
+    movq $0x84, expected_eflags(%rip)
+    leaq .Lfault16_resume(%rip), %r10
+    movq %r10, resume_rip(%rip)
+    movb $0x80, %dl
+    addb %dl, %dl
+    orw $0, %ax
+    movw $0, %ax
+    movl (%r15), %r11d
+.Lfault16_resume:
+    js .Lfault16_ok
+    movl $21, %edi
+    jmp exit_guest
+.Lfault16_ok:
+
+    /* Recover clear CF/PF/ZF/SF/OF from a 32-bit result of one. */
+    movl $1, %eax
+    movq $0, expected_eflags(%rip)
+    leaq .Lfault32_resume(%rip), %r10
+    movq %r10, resume_rip(%rip)
+    movb $0x80, %dl
+    addb %dl, %dl
+    orl $0, %eax
+    movl $-1, %eax
+    movl (%r15), %r11d
+.Lfault32_resume:
+    jne .Lfault32_ok
+    movl $22, %edi
+    jmp exit_guest
+.Lfault32_ok:
+
+    /* Recover PF and SF from a 64-bit negative result. */
+    movq $-1, %rax
+    movq $0x84, expected_eflags(%rip)
+    leaq .Lfault64_resume(%rip), %r10
+    movq %r10, resume_rip(%rip)
+    movb $0x80, %dl
+    addb %dl, %dl
+    orq $0, %rax
+    movq $0, %rax
+    movl (%r15), %r11d
+.Lfault64_resume:
+    js .Lfault64_ok
+    movl $23, %edi
+    jmp exit_guest
+.Lfault64_ok:
+    cmpq $4, signal_count(%rip)
+    je .Lsignal_cases_ok
+    movl $24, %edi
+    jmp exit_guest
+.Lsignal_cases_ok:
+
+    /* One neutral instruction, 8-bit zero result. */
+    movl $1, %edi
+    xorl %eax, %eax
+    orb $0, %al
+    nop
+    je .Lzero_ok
+    jmp exit_guest
+.Lzero_ok:
+
+    /* The fixed pattern register survives an overwrite of the guest GPR. */
+    movl $2, %edi
+    movw $1, %ax
+    orw $0, %ax
+    movw $0, %ax
+    jne .Loverwrite_ok
+    jmp exit_guest
+.Loverwrite_ok:
+
+    /* LEA is non-faulting and may consume ordinary itemps. */
+    movl $3, %edi
+    movl $0x80000000, %eax
+    orl $0, %eax
+    leaq 8(%r10,%r11,2), %r12
+    js .Lsign_ok
+    jmp exit_guest
+.Lsign_ok:
+
+    /* Multiple intervening instructions and JNS. */
+    movl $4, %edi
+    movq $1, %rax
+    orq $0, %rax
+    movq $2, %r10
+    movq %r10, %r11
+    leaq 1(%r11), %r12
+    nop
+    jns .Ldistance4_ok
+    jmp exit_guest
+.Ldistance4_ok:
+
+    /* Register-only extensions are safe neutral instructions. */
+    movl $5, %edi
+    movb $1, %r10b
+    movl $1, %eax
+    orl $0, %eax
+    movzbl %r10b, %r11d
+    movslq %r11d, %r12
+    jne .Lextensions_ok
+    jmp exit_guest
+.Lextensions_ok:
+
+    /* The fixed pattern register survives a 64-bit destination overwrite. */
+    movl $6, %edi
+    movq $1, %rax
+    orq $0, %rax
+    movq $0, %rax
+    jne .Lborrow_clobber_ok
+    jmp exit_guest
+.Lborrow_clobber_ok:
+
+    /* Flags needed by the successor must still be materialized. */
+    movl $7, %edi
+    movb $0x81, %al
+    orb $0, %al
+    nop
+    js .Lflags_live
+    jmp exit_guest
+.Lflags_live:
+    pushfq
+    popq %r10
+    andq $0x8c5, %r10
+    cmpq $0x84, %r10
+    jne exit_guest
+
+    /* A memory intermediate preserves the guest-visible result. */
+    movl $8, %edi
+    movl $1, %eax
+    orl $0, %eax
+    movl mem32(%rip), %r10d
+    jne .Lmemory_reject_ok
+    jmp exit_guest
+.Lmemory_reject_ok:
+
+    /* More than four intervening instructions. */
+    movl $9, %edi
+    movl $1, %eax
+    orl $0, %eax
+    nop
+    nop
+    nop
+    nop
+    nop
+    jne .Ldistance_reject_ok
+    jmp exit_guest
+.Ldistance_reject_ok:
+
+    /* A flag clobber must prevent the OR pattern from reaching this Jcc. */
+    movl $10, %edi
+    xorl %eax, %eax
+    orl $0, %eax
+    addl $1, %r10d
+    jne .Lclobber_reject_ok
+    jmp exit_guest
+.Lclobber_reject_ok:
+
+    /* PUSH can fault and therefore cannot be crossed. */
+    movl $11, %edi
+    movl $1, %eax
+    orl $0, %eax
+    pushq %rax
+    jne .Lpush_reject_ok
+    jmp exit_guest
+.Lpush_reject_ok:
+    addq $8, %rsp
+
+    /* Hot path with ordinary-itemp pressure between OR and Jcc. */
+    movl $200000, %ecx
+    xorl %r8d, %r8d
+.Lhot_loop:
+    orb $0, %r8b
+    leaq 1(%r10,%r11,2), %r12
+    movzbl %r12b, %r13d
+    movslq %r13d, %r14
+    nop
+    jne .Lhot_taken
+    xorb $1, %r8b
+    jmp .Lhot_count
+.Lhot_taken:
+    xorb $1, %r8b
+.Lhot_count:
+    decl %ecx
+    jne .Lhot_loop
+
+    xorl %edi, %edi
+exit_guest:
+    movl $60, %eax
+    syscall
+
+fault_case:
+    xorl %eax, %eax
+    movl $1, %r10d
+    orl $0, %r10d
+    movl (%rax), %r11d
+    jne .Lfault_unreachable
+.Lfault_unreachable:
+    movl $12, %edi
+    jmp exit_guest
+
+install_failed:
+    movl $13, %edi
+    jmp exit_guest
+
+    .type segv_handler, @function
+segv_handler:
+    cmpl $SIGSEGV, %edi
+    jne handler_wrong_signal
+    movq UCONTEXT_EFL_OFFSET(%rdx), %rax
+    andq $0x8c5, %rax
+    cmpq expected_eflags(%rip), %rax
+    jne handler_wrong_eflags
+    incq signal_count(%rip)
+    movq resume_rip(%rip), %rax
+    movq %rax, UCONTEXT_RIP_OFFSET(%rdx)
+    ret
+    .size segv_handler, .-segv_handler
+
+handler_wrong_signal:
+    movl $30, %edi
+    jmp exit_guest
+
+handler_wrong_eflags:
+    movl $31, %edi
+    jmp exit_guest
+
+    .type signal_restorer, @function
+signal_restorer:
+    movl $__NR_rt_sigreturn, %eax
+    syscall
+    .size signal_restorer, .-signal_restorer
+
+    .data
+    .p2align 2
+mem32:
+    .long 0

--- a/tests/integration/or-xx-jcc.S
+++ b/tests/integration/or-xx-jcc.S
@@ -21,6 +21,10 @@ resume_rip:
 signal_count:
     .quad 0
 
+#ifndef INSTPTN_LOOP_COUNT
+#define INSTPTN_LOOP_COUNT 200000
+#endif
+
     .text
     .globl _start
 _start:
@@ -224,7 +228,7 @@ _start:
     addq $8, %rsp
 
     /* Hot path with ordinary-itemp pressure between OR and Jcc. */
-    movl $200000, %ecx
+    movl $INSTPTN_LOOP_COUNT, %ecx
     xorl %r8d, %r8d
 .Lhot_loop:
     orb $0, %r8b

--- a/tests/integration/registrations/process/meson.build
+++ b/tests/integration/registrations/process/meson.build
@@ -24,6 +24,14 @@ if 'x86_64-linux-user' in target_dirs
     ],
   }]
   latx_integration_tests += [{
+    'name': 'test-xor-jcc',
+    'runner': find_program('../../test-xor-jcc.sh'),
+    'args': [
+      emulators['latx-x86_64'],
+      files('../../xor-jcc.S'),
+    ],
+  }]
+  latx_integration_tests += [{
     'name': 'test-or-xx-jcc',
     'runner': find_program('../../test-or-xx-jcc.sh'),
     'args': [

--- a/tests/integration/registrations/process/meson.build
+++ b/tests/integration/registrations/process/meson.build
@@ -8,6 +8,14 @@ if 'x86_64-linux-user' in target_dirs
     ],
   }]
   latx_integration_tests += [{
+    'name': 'test-dec-jcc',
+    'runner': find_program('../../test-dec-jcc.sh'),
+    'args': [
+      emulators['latx-x86_64'],
+      files('../../dec-jcc.S'),
+    ],
+  }]
+  latx_integration_tests += [{
     'name': 'test-shift-jcc',
     'runner': find_program('../../test-shift-jcc.sh'),
     'args': [

--- a/tests/integration/registrations/process/meson.build
+++ b/tests/integration/registrations/process/meson.build
@@ -16,6 +16,14 @@ if 'x86_64-linux-user' in target_dirs
     ],
   }]
   latx_integration_tests += [{
+    'name': 'test-or-jcc',
+    'runner': find_program('../../test-or-jcc.sh'),
+    'args': [
+      emulators['latx-x86_64'],
+      files('../../or-jcc.S'),
+    ],
+  }]
+  latx_integration_tests += [{
     'name': 'test-instptn-options',
     'runner': find_program('../../test-instptn-options.sh'),
     'args': [

--- a/tests/integration/registrations/process/meson.build
+++ b/tests/integration/registrations/process/meson.build
@@ -8,6 +8,14 @@ if 'x86_64-linux-user' in target_dirs
     ],
   }]
   latx_integration_tests += [{
+    'name': 'test-shift-jcc',
+    'runner': find_program('../../test-shift-jcc.sh'),
+    'args': [
+      emulators['latx-x86_64'],
+      files('../../shift-jcc.S'),
+    ],
+  }]
+  latx_integration_tests += [{
     'name': 'test-instptn-options',
     'runner': find_program('../../test-instptn-options.sh'),
     'args': [

--- a/tests/integration/registrations/process/meson.build
+++ b/tests/integration/registrations/process/meson.build
@@ -1,5 +1,13 @@
 if 'x86_64-linux-user' in target_dirs
   latx_integration_tests += [{
+    'name': 'test-instptn-options',
+    'runner': find_program('../../test-instptn-options.sh'),
+    'args': [
+      emulators['latx-x86_64'],
+      files('../../instptn-options-fork.S'),
+    ],
+  }]
+  latx_integration_tests += [{
     'name': 'test-proc-readdir',
     'runner': find_program('../../test-proc-readdir.sh'),
     'args': [

--- a/tests/integration/registrations/process/meson.build
+++ b/tests/integration/registrations/process/meson.build
@@ -24,6 +24,14 @@ if 'x86_64-linux-user' in target_dirs
     ],
   }]
   latx_integration_tests += [{
+    'name': 'test-or-xx-jcc',
+    'runner': find_program('../../test-or-xx-jcc.sh'),
+    'args': [
+      emulators['latx-x86_64'],
+      files('../../or-xx-jcc.S'),
+    ],
+  }]
+  latx_integration_tests += [{
     'name': 'test-jcc-conditions',
     'runner': find_program('../../test-jcc-conditions.sh'),
     'args': [

--- a/tests/integration/registrations/process/meson.build
+++ b/tests/integration/registrations/process/meson.build
@@ -24,6 +24,14 @@ if 'x86_64-linux-user' in target_dirs
     ],
   }]
   latx_integration_tests += [{
+    'name': 'test-jcc-conditions',
+    'runner': find_program('../../test-jcc-conditions.sh'),
+    'args': [
+      emulators['latx-x86_64'],
+      files('../../jcc-conditions.S'),
+    ],
+  }]
+  latx_integration_tests += [{
     'name': 'test-instptn-options',
     'runner': find_program('../../test-instptn-options.sh'),
     'args': [

--- a/tests/integration/registrations/process/meson.build
+++ b/tests/integration/registrations/process/meson.build
@@ -1,5 +1,13 @@
 if 'x86_64-linux-user' in target_dirs
   latx_integration_tests += [{
+    'name': 'test-add-jcc',
+    'runner': find_program('../../test-add-jcc.sh'),
+    'args': [
+      emulators['latx-x86_64'],
+      files('../../add-jcc.S'),
+    ],
+  }]
+  latx_integration_tests += [{
     'name': 'test-instptn-options',
     'runner': find_program('../../test-instptn-options.sh'),
     'args': [

--- a/tests/integration/shift-jcc.S
+++ b/tests/integration/shift-jcc.S
@@ -1,0 +1,292 @@
+/*
+ * SPDX-License-Identifier: GPL-2.0-only
+ *
+ * Exercise adjacent immediate SAR/SHR + Jcc patterns and x86 count masking.
+ */
+
+    .text
+    .globl _start
+_start:
+    cmpq $1, (%rsp)
+    jne fault_case
+
+    /* SAR: all supported conditions and operand widths. */
+    movl $1, %edi
+    movb $0x80, %al
+    sarb $1, %al
+    js 1f
+    jmp exit_guest
+1:
+    cmpb $0xc0, %al
+    jne exit_guest
+
+    movl $2, %edi
+    movw $1, %ax
+    sarw $1, %ax
+    je 2f
+    jmp exit_guest
+2:
+    cmpw $0, %ax
+    jne exit_guest
+
+    movl $3, %edi
+    movq $-1, %rax
+    sarl $31, %eax
+    jns exit_guest
+    movl $0xffffffff, %r10d
+    cmpq %r10, %rax
+    jne exit_guest
+
+    movl $4, %edi
+    movabsq $0x8000000000000000, %rax
+    sarq $63, %rax
+    je exit_guest
+    cmpq $-1, %rax
+    jne exit_guest
+
+    /* SHR: JE is new; JNE remains on its legacy independent option. */
+    movl $5, %edi
+    movb $1, %al
+    shrb $1, %al
+    je 3f
+    jmp exit_guest
+3:
+    testb %al, %al
+    jne exit_guest
+
+    movl $6, %edi
+    movw $0x8000, %ax
+    shrw $15, %ax
+    jne 4f
+    jmp exit_guest
+4:
+    cmpw $1, %ax
+    jne exit_guest
+
+    movl $7, %edi
+    movq $-1, %rax
+    shrl $31, %eax
+    jne 5f
+    jmp exit_guest
+5:
+    cmpq $1, %rax
+    jne exit_guest
+
+    movl $8, %edi
+    movq $-1, %rax
+    shrq $63, %rax
+    jne 6f
+    jmp exit_guest
+6:
+    cmpq $1, %rax
+    jne exit_guest
+
+    /* Counts at and beyond 8/16-bit widths are not modulo the width. */
+    movl $9, %edi
+    movb $0x80, %al
+    sarb $8, %al
+    js 7f
+    jmp exit_guest
+7:
+    cmpb $0xff, %al
+    jne exit_guest
+
+    movl $10, %edi
+    movb $0xff, %al
+    shrb $9, %al
+    je 8f
+    jmp exit_guest
+8:
+    testb %al, %al
+    jne exit_guest
+
+    movl $11, %edi
+    movw $0x8000, %ax
+    sarw $16, %ax
+    js 9f
+    jmp exit_guest
+9:
+    cmpw $0xffff, %ax
+    jne exit_guest
+
+    movl $12, %edi
+    movw $0xffff, %ax
+    shrw $17, %ax
+    je 10f
+    jmp exit_guest
+10:
+    testw %ax, %ax
+    jne exit_guest
+
+    /* 31/63 remain effective for narrow operands; 32/64 mask to zero. */
+    movl $13, %edi
+    movw $0x8000, %ax
+    sarw $31, %ax
+    js 11f
+    jmp exit_guest
+11:
+    cmpw $0xffff, %ax
+    jne exit_guest
+
+    movl $14, %edi
+    movb $0xff, %al
+    shrb $63, %al
+    je 12f
+    jmp exit_guest
+12:
+    testb %al, %al
+    jne exit_guest
+
+    /* Effective count zero must preserve both the destination and flags. */
+    movl $15, %edi
+    movl $0x12345678, %eax
+    cmpl %eax, %eax
+    sarl $32, %eax
+    jne exit_guest
+    pushfq
+    popq %r10
+    testq $0x40, %r10
+    je exit_guest
+    cmpl $0x12345678, %eax
+    jne exit_guest
+
+    movl $16, %edi
+    movabsq $0x8000000000000000, %rax
+    cmpq %rax, %rax
+    shrq $64, %rax
+    jne exit_guest
+    pushfq
+    popq %r10
+    testq $0x40, %r10
+    je exit_guest
+    movabsq $0x8000000000000000, %r10
+    cmpq %r10, %rax
+    jne exit_guest
+
+    movl $26, %edi
+    movl $0x87654321, %eax
+    cmpl %eax, %eax
+    shrl $32, %eax
+    je 23f
+    jmp exit_guest
+23:
+    pushfq
+    popq %r10
+    testq $0x40, %r10
+    je exit_guest
+    cmpl $0x87654321, %eax
+    jne exit_guest
+
+    /* width+1 becomes one for 32/64-bit operands. */
+    movl $17, %edi
+    movl $0x80000000, %eax
+    sarl $33, %eax
+    js 13f
+    jmp exit_guest
+13:
+    movl $0xc0000000, %r10d
+    cmpq %r10, %rax
+    jne exit_guest
+
+    movl $18, %edi
+    movq $2, %rax
+    shrq $65, %rax
+    jne 14f
+    jmp exit_guest
+14:
+    cmpq $1, %rax
+    jne exit_guest
+
+    /* Preserve defined flags when a successor reads them. */
+    movl $19, %edi
+    movl $0x85, %r9d
+    movb $0x81, %al
+    sarb $1, %al
+    js 15f
+    jmp exit_guest
+15:
+    call check_flags
+
+    movl $20, %edi
+    movl $0x45, %r9d
+    movb $1, %al
+    shrb $1, %al
+    je 16f
+    jmp exit_guest
+16:
+    call check_flags
+
+    /* Memory destination, plus scanner rejection paths. */
+    movl $21, %edi
+    movq $-2, mem64(%rip)
+    sarq $1, mem64(%rip)
+    js 17f
+    jmp exit_guest
+17:
+    cmpq $-1, mem64(%rip)
+    jne exit_guest
+
+    movl $22, %edi
+    movl $4, %eax
+    movb $1, %cl
+    shrl %cl, %eax
+    jne 18f
+    jmp exit_guest
+18:
+    cmpl $2, %eax
+    jne exit_guest
+
+    movl $23, %edi
+    movl $0x80000000, %eax
+    sarl $1, %eax
+    jo exit_guest
+
+    movl $24, %edi
+    movl $2, %eax
+    shrl $1, %eax
+    nop
+    jne 19f
+    jmp exit_guest
+19:
+    cmpl $1, %eax
+    jne exit_guest
+
+    /* Heat matching backward branches for TU/retranslation coverage. */
+    movl $0x40000000, %ecx
+20:
+    sarl $1, %ecx
+    jne 20b
+    cmpl $0, %ecx
+    jne exit_guest
+
+    movl $0x80000000, %ecx
+21:
+    shrl $1, %ecx
+    jne 21b
+
+    xorl %edi, %edi
+exit_guest:
+    movl $60, %eax
+    syscall
+
+/* Compare the defined CF/PF/ZF/SF/OF flags without perturbing them first. */
+check_flags:
+    pushfq
+    popq %r10
+    andq $0x8c5, %r10
+    cmpq %r9, %r10
+    jne exit_guest
+    ret
+
+fault_case:
+    xorl %eax, %eax
+    sarq $1, (%rax)
+    jne 24f
+24:
+    movl $25, %edi
+    jmp exit_guest
+
+    .data
+    .p2align 3
+mem64:
+    .quad 0

--- a/tests/integration/test-add-jcc.sh
+++ b/tests/integration/test-add-jcc.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+set -eu
+
+emulator=$(readlink -f "$1")
+source_file=$(readlink -f "$2")
+tmp_base=${TMPDIR:-"$HOME/tmp"}
+mkdir -p "$tmp_base"
+workdir=$(mktemp -d "$tmp_base/latx-add-jcc-test.XXXXXX")
+trap 'rm -rf "$workdir"' EXIT HUP INT TERM
+
+if command -v clang-19 >/dev/null 2>&1; then
+    clang=clang-19
+elif command -v clang >/dev/null 2>&1; then
+    clang=clang
+else
+    echo "SKIP: clang is required to build the x86_64 guest"
+    exit 77
+fi
+
+"$clang" --target=x86_64-linux-gnu -fuse-ld=lld -nostdlib -static \
+    -Wl,--build-id=none "$source_file" -o "$workdir/add-jcc"
+guest="$workdir/add-jcc"
+
+# JIT/TU path with only the reserved ADD_JCC option enabled.
+env LATX_AOT=0 LATX_INSTPTN_MASK=0x4000000 LATX_INSTPTN_STATS=1 \
+    "$emulator" "$guest" >"$workdir/enabled.log" 2>&1
+stats_re='add-jcc match=[1-9][0-9]* eflags-eliminated=0'
+stats_re="$stats_re eflags-fallback=[1-9][0-9]*"
+stats_re="$stats_re ir2=[1-9][0-9]* host=[1-9][0-9]*"
+grep -Eq "$stats_re" "$workdir/enabled.log"
+grep -Eq 'reject\.non-adjacent=[1-9][0-9]*' "$workdir/enabled.log"
+grep -Eq 'reject\.unsupported-cc=[1-9][0-9]*' "$workdir/enabled.log"
+grep -Eq 'reject\.fault-or-helper=[1-9][0-9]*' "$workdir/enabled.log"
+
+# The independent option must provide a complete behavior-preserving rollback.
+env LATX_AOT=0 LATX_INSTPTN_MASK=0x1 LATX_INSTPTN_STATS=1 \
+    "$emulator" "$guest" >"$workdir/disabled.log" 2>&1
+grep -Eq 'add-jcc match=0 ' "$workdir/disabled.log"
+grep -Eq 'reject\.disabled=[1-9][0-9]*' "$workdir/disabled.log"
+
+# Default AOT mode must generate and then load the candidate pattern
+# correctly.  The loop in add-jcc.S visits both successors and overwrites
+# EFLAGS on each, allowing TU flag reduction to eliminate the fused Jcc's ZF.
+mkdir -p "$workdir/aot-home"
+env HOME="$workdir/aot-home" LATX_AOT=1 LATX_INSTPTN_MASK=0x4000000 \
+    "$emulator" "$guest" >"$workdir/aot-generate.log" 2>&1
+
+attempt=0
+while [ "$attempt" -lt 100 ]; do
+    if find "$workdir/aot-home/.cache/latx" -type f \
+        -name 'v2-*.aot2' -size +0c -print -quit 2>/dev/null | \
+        grep -q .; then
+        break
+    fi
+    attempt=$((attempt + 1))
+    sleep 0.05
+done
+test "$attempt" -lt 100
+
+env HOME="$workdir/aot-home" LATX_AOT=1 LATX_INSTPTN_MASK=0x4000000 \
+    "$emulator" "$guest" >"$workdir/aot-load.log" 2>&1
+
+# A faulting memory destination must have the same external result with the
+# pattern enabled and disabled.
+set +e
+env LATX_AOT=0 LATX_INSTPTN_MASK=0x4000000 \
+    "$emulator" "$guest" fault >"$workdir/fault-enabled.log" 2>&1
+fault_enabled=$?
+env LATX_AOT=0 LATX_INSTPTN_MASK=0x1 \
+    "$emulator" "$guest" fault >"$workdir/fault-disabled.log" 2>&1
+fault_disabled=$?
+set -e
+test "$fault_enabled" -ne 0
+test "$fault_enabled" -eq "$fault_disabled"
+
+echo "PASS: ADD+Jcc widths, conditions, flags, memory, rollback," \
+    "fault, lock, JIT/TU and AOT"

--- a/tests/integration/test-dec-jcc.sh
+++ b/tests/integration/test-dec-jcc.sh
@@ -1,0 +1,75 @@
+#!/bin/sh
+set -eu
+
+emulator=$(readlink -f "$1")
+source_file=$(readlink -f "$2")
+tmp_base=${TMPDIR:-"$HOME/tmp"}
+mkdir -p "$tmp_base"
+workdir=$(mktemp -d "$tmp_base/latx-dec-jcc-test.XXXXXX")
+trap 'rm -rf "$workdir"' EXIT HUP INT TERM
+
+if command -v clang-19 >/dev/null 2>&1; then
+    clang=clang-19
+elif command -v clang >/dev/null 2>&1; then
+    clang=clang
+else
+    echo "SKIP: clang is required to build the x86_64 guest"
+    exit 77
+fi
+
+"$clang" --target=x86_64-linux-gnu -fuse-ld=lld -nostdlib -static \
+    -Wl,--build-id=none "$source_file" -o "$workdir/dec-jcc"
+guest="$workdir/dec-jcc"
+mask=0x40000000
+
+env LATX_AOT=0 LATX_INSTPTN_MASK="$mask" LATX_INSTPTN_STATS=1 \
+    "$emulator" "$guest" >"$workdir/enabled.log" 2>&1
+grep -Eq 'dec-jcc match=[1-9][0-9]* .*eflags-fallback=[1-9][0-9]*' \
+    "$workdir/enabled.log"
+grep -Eq 'reject\.non-adjacent=[1-9][0-9]*' "$workdir/enabled.log"
+grep -Eq 'reject\.unsupported-cc=[1-9][0-9]*' "$workdir/enabled.log"
+grep -Eq 'reject\.unsupported-operand=[1-9][0-9]*' \
+    "$workdir/enabled.log"
+
+env LATX_AOT=0 LATX_INSTPTN_MASK=0x1 LATX_INSTPTN_STATS=1 \
+    "$emulator" "$guest" >"$workdir/disabled.log" 2>&1
+grep -Eq 'dec-jcc match=0 ' "$workdir/disabled.log"
+grep -Eq 'reject\.disabled=[1-9][0-9]*' "$workdir/disabled.log"
+
+for unlink in 0 1; do
+    env LATX_UNLINK="$unlink" LATX_AOT=0 LATX_INSTPTN_MASK="$mask" \
+        "$emulator" "$guest" >"$workdir/unlink-$unlink.log" 2>&1
+done
+
+mkdir -p "$workdir/aot-home"
+env HOME="$workdir/aot-home" LATX_AOT=1 LATX_INSTPTN_MASK="$mask" \
+    "$emulator" "$guest" >"$workdir/aot-generate.log" 2>&1
+
+attempt=0
+while [ "$attempt" -lt 100 ]; do
+    if find "$workdir/aot-home/.cache/latx" -type f \
+        -name 'v2-*.aot2' -size +0c -print -quit 2>/dev/null | \
+        grep -q .; then
+        break
+    fi
+    attempt=$((attempt + 1))
+    sleep 0.05
+done
+test "$attempt" -lt 100
+
+env HOME="$workdir/aot-home" LATX_AOT=1 LATX_INSTPTN_MASK="$mask" \
+    "$emulator" "$guest" >"$workdir/aot-load.log" 2>&1
+
+set +e
+env LATX_AOT=0 LATX_INSTPTN_MASK="$mask" \
+    "$emulator" "$guest" fault >"$workdir/fault-enabled.log" 2>&1
+fault_enabled=$?
+env LATX_AOT=0 LATX_INSTPTN_MASK=0x1 \
+    "$emulator" "$guest" fault >"$workdir/fault-disabled.log" 2>&1
+fault_disabled=$?
+set -e
+test "$fault_enabled" -ne 0
+test "$fault_enabled" -eq "$fault_disabled"
+
+echo "PASS: DEC+Jcc widths, conditions, CF/flags, rollback, memory," \
+    "fault, LOCK, JIT/TU, unlink and AOT"

--- a/tests/integration/test-dec-jcc.sh
+++ b/tests/integration/test-dec-jcc.sh
@@ -36,9 +36,15 @@ env LATX_AOT=0 LATX_INSTPTN_MASK=0x1 LATX_INSTPTN_STATS=1 \
 grep -Eq 'dec-jcc match=0 ' "$workdir/disabled.log"
 grep -Eq 'reject\.disabled=[1-9][0-9]*' "$workdir/disabled.log"
 
+# Debug unlink flushes every TB; keep the hot-loop runs above unchanged.
+"$clang" --target=x86_64-linux-gnu -fuse-ld=lld -nostdlib -static \
+    -Wl,--build-id=none -DINSTPTN_LOOP_COUNT=4 "$source_file" \
+    -o "$workdir/dec-jcc-unlink"
+unlink_guest="$workdir/dec-jcc-unlink"
+
 for unlink in 0 1; do
     env LATX_UNLINK="$unlink" LATX_AOT=0 LATX_INSTPTN_MASK="$mask" \
-        "$emulator" "$guest" >"$workdir/unlink-$unlink.log" 2>&1
+        "$emulator" "$unlink_guest" >"$workdir/unlink-$unlink.log" 2>&1
 done
 
 mkdir -p "$workdir/aot-home"

--- a/tests/integration/test-instptn-options.sh
+++ b/tests/integration/test-instptn-options.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+set -eu
+
+emulator=$(readlink -f "$1")
+source_file=$(readlink -f "$2")
+tmp_base=${TMPDIR:-"$HOME/tmp"}
+mkdir -p "$tmp_base"
+workdir=$(mktemp -d "$tmp_base/latx-instptn-test.XXXXXX")
+trap 'rm -rf "$workdir"' EXIT HUP INT TERM
+
+if command -v clang-19 >/dev/null 2>&1; then
+    clang=clang-19
+elif command -v clang >/dev/null 2>&1; then
+    clang=clang
+else
+    echo "SKIP: clang is required to build the x86_64 guest"
+    exit 77
+fi
+
+"$clang" --target=x86_64-linux-gnu -fuse-ld=lld -nostdlib -static \
+    -Wl,--build-id=none "$source_file" -o "$workdir/instptn-options-fork"
+guest="$workdir/instptn-options-fork"
+
+expect_failure()
+{
+    name=$1
+    pattern=$2
+    shift 2
+    if "$@" >"$workdir/$name.log" 2>&1; then
+        echo "FAIL: $name unexpectedly succeeded" >&2
+        return 1
+    fi
+    grep -q "$pattern" "$workdir/$name.log"
+}
+
+expect_failure invalid-mask "LATX_INSTPTN_MASK must be" \
+    "$emulator" -latx-instptn-mask invalid "$guest"
+expect_failure invalid-stats "LATX_INSTPTN_STATS must be" \
+    env LATX_INSTPTN_STATS=2 "$emulator" "$guest"
+
+# A valid command-line value must override an invalid environment value.
+env LATX_INSTPTN_MASK=invalid LATX_AOT=0 "$emulator" \
+    -latx-instptn-mask 0x3ffffff "$guest" \
+    >"$workdir/precedence.log" 2>&1
+
+env LATX_AOT=0 LATX_INSTPTN_STATS=1 "$emulator" "$guest" \
+    >"$workdir/default.log" 2>&1
+grep -Eq 'sub-jcc match=[1-9][0-9]*' "$workdir/default.log"
+grep -q 'reject.unsupported-cc=' "$workdir/default.log"
+grep -q 'reject.non-adjacent=' "$workdir/default.log"
+grep -q 'reject.unsupported-operand=' "$workdir/default.log"
+grep -q 'reject.zero-shift-count=' "$workdir/default.log"
+
+# The child resets inherited history, so the pre-fork SUB record appears once.
+test "$(grep -c 'sub-jcc match=' "$workdir/default.log")" -eq 1
+test "$(sed -n 's/.*pid=\([0-9][0-9]*\) mask=.*/\1/p' \
+    "$workdir/default.log" | sort -u | wc -l)" -eq 2
+
+env LATX_AOT=0 LATX_INSTPTN_MASK=0x3dfffff LATX_INSTPTN_STATS=1 \
+    "$emulator" "$guest" >"$workdir/disabled.log" 2>&1
+grep -q 'sub-jcc match=0' "$workdir/disabled.log"
+grep -q 'reject.disabled=' "$workdir/disabled.log"
+
+env LATX_AOT=0 "$emulator" "$guest" >"$workdir/stats-off.log" 2>&1
+if grep -q '\[LATX\]\[instptn\]' "$workdir/stats-off.log"; then
+    echo "FAIL: statistics were printed while disabled" >&2
+    exit 1
+fi
+
+echo "PASS: instruction-pattern parsing, statistics, rejection," \
+    "and fork semantics"

--- a/tests/integration/test-jcc-conditions.sh
+++ b/tests/integration/test-jcc-conditions.sh
@@ -1,0 +1,90 @@
+#!/bin/sh
+set -eu
+
+emulator=$(readlink -f "$1")
+source_file=$(readlink -f "$2")
+tmp_base=${TMPDIR:-"$HOME/tmp"}
+mkdir -p "$tmp_base"
+workdir=$(mktemp -d "$tmp_base/latx-jcc-conditions-test.XXXXXX")
+trap 'rm -rf "$workdir"' EXIT HUP INT TERM
+
+if command -v clang-19 >/dev/null 2>&1; then
+    clang=clang-19
+elif command -v clang >/dev/null 2>&1; then
+    clang=clang
+else
+    echo "SKIP: clang is required to build the x86_64 guest"
+    exit 77
+fi
+
+"$clang" --target=x86_64-linux-gnu -fuse-ld=lld -nostdlib -static \
+    -Wl,--build-id=none "$source_file" -o "$workdir/jcc-conditions"
+guest="$workdir/jcc-conditions"
+
+# Existing CMP_JCC (0), SUB_JCC (21), AND_JCC (25), plus SHR_JE (34).
+conditions_mask=0x402200001
+positive='[1-9][0-9]*'
+reject_re="reject\.non-adjacent=$positive"
+reject_re="$reject_re|reject\.zero-shift-count=$positive"
+env LATX_AOT=0 LATX_INSTPTN_MASK="$conditions_mask" LATX_INSTPTN_STATS=1 \
+    "$emulator" "$guest" >"$workdir/enabled.log" 2>&1
+for pattern in cmp-jcc sub-jcc and-jcc shr-je; do
+    grep -Eq "$pattern match=[1-9][0-9]* .*eflags-fallback=[1-9][0-9]*" \
+        "$workdir/enabled.log"
+    grep -A1 "$pattern match=" "$workdir/enabled.log" | \
+        grep -Eq "$reject_re"
+done
+
+for entry in \
+    '0x1 cmp-jcc' \
+    '0x200000 sub-jcc' \
+    '0x2000000 and-jcc' \
+    '0x400000000 shr-je'; do
+    set -- $entry
+    mask=$1
+    pattern=$2
+    env LATX_AOT=0 LATX_INSTPTN_MASK="$mask" LATX_INSTPTN_STATS=1 \
+        "$emulator" "$guest" >"$workdir/$pattern-only.log" 2>&1
+    grep -Eq "$pattern match=[1-9][0-9]* " "$workdir/$pattern-only.log"
+done
+
+env LATX_AOT=0 LATX_INSTPTN_MASK=0x2 LATX_INSTPTN_STATS=1 \
+    "$emulator" "$guest" >"$workdir/disabled.log" 2>&1
+for pattern in cmp-jcc sub-jcc and-jcc shr-je; do
+    grep -Eq "$pattern match=0 " "$workdir/disabled.log"
+done
+grep -Eq 'reject\.disabled=[1-9][0-9]*' "$workdir/disabled.log"
+
+mkdir -p "$workdir/aot-home"
+env HOME="$workdir/aot-home" LATX_AOT=1 \
+    LATX_INSTPTN_MASK="$conditions_mask" \
+    "$emulator" "$guest" >"$workdir/aot-generate.log" 2>&1
+attempt=0
+while [ "$attempt" -lt 100 ]; do
+    if find "$workdir/aot-home/.cache/latx" -type f \
+        -name 'v2-*.aot2' -size +0c -print -quit 2>/dev/null | grep -q .; then
+        break
+    fi
+    attempt=$((attempt + 1))
+    sleep 0.05
+done
+test "$attempt" -lt 100
+env HOME="$workdir/aot-home" LATX_AOT=1 \
+    LATX_INSTPTN_MASK="$conditions_mask" \
+    "$emulator" "$guest" >"$workdir/aot-load.log" 2>&1
+
+for args in 'cmp' 'cmp sub' 'cmp sub and'; do
+    set +e
+    env LATX_AOT=0 LATX_INSTPTN_MASK="$conditions_mask" \
+        "$emulator" "$guest" $args >"$workdir/fault-enabled.log" 2>&1
+    fault_enabled=$?
+    env LATX_AOT=0 LATX_INSTPTN_MASK=0x2 \
+        "$emulator" "$guest" $args >"$workdir/fault-disabled.log" 2>&1
+    fault_disabled=$?
+    set -e
+    test "$fault_enabled" -ne 0
+    test "$fault_enabled" -eq "$fault_disabled"
+done
+
+echo "PASS: expanded Jcc widths, overflow, flags, memory, count=0," \
+    "LOCK, rollback, fault, JIT/TU and AOT"

--- a/tests/integration/test-jcc-conditions.sh
+++ b/tests/integration/test-jcc-conditions.sh
@@ -21,14 +21,23 @@ fi
     -Wl,--build-id=none "$source_file" -o "$workdir/jcc-conditions"
 guest="$workdir/jcc-conditions"
 
-# Existing CMP_JCC (0), SUB_JCC (21), AND_JCC (25), plus SHR_JE (34).
-conditions_mask=0x402200001
+# Compile isolated probes for the three independently selectable conditions.
+for entry in 'cmp CMP' 'sub SUB' 'and AND'; do
+    set -- $entry
+    "$clang" --target=x86_64-linux-gnu -fuse-ld=lld -nostdlib -static \
+        -Wl,--build-id=none -DINSTPTN_${2}_PROBE "$source_file" \
+        -o "$workdir/probe-$1"
+done
+sh "$(dirname "$0")/check-jcc-condition-options.sh" "$emulator" "$workdir"
+
+# Preserve the old conditions and enable new bits 31 through 34 explicitly.
+conditions_mask=0x782200001
 positive='[1-9][0-9]*'
 reject_re="reject\.non-adjacent=$positive"
 reject_re="$reject_re|reject\.zero-shift-count=$positive"
 env LATX_AOT=0 LATX_INSTPTN_MASK="$conditions_mask" LATX_INSTPTN_STATS=1 \
     "$emulator" "$guest" >"$workdir/enabled.log" 2>&1
-for pattern in cmp-jcc sub-jcc and-jcc shr-je; do
+for pattern in cmp-js-jns sub-js-jns and-je shr-je; do
     grep -Eq "$pattern match=[1-9][0-9]* .*eflags-fallback=[1-9][0-9]*" \
         "$workdir/enabled.log"
     grep -A1 "$pattern match=" "$workdir/enabled.log" | \
@@ -36,9 +45,9 @@ for pattern in cmp-jcc sub-jcc and-jcc shr-je; do
 done
 
 for entry in \
-    '0x1 cmp-jcc' \
-    '0x200000 sub-jcc' \
-    '0x2000000 and-jcc' \
+    '0x80000000 cmp-js-jns' \
+    '0x100000000 sub-js-jns' \
+    '0x200000000 and-je' \
     '0x400000000 shr-je'; do
     set -- $entry
     mask=$1
@@ -50,7 +59,7 @@ done
 
 env LATX_AOT=0 LATX_INSTPTN_MASK=0x2 LATX_INSTPTN_STATS=1 \
     "$emulator" "$guest" >"$workdir/disabled.log" 2>&1
-for pattern in cmp-jcc sub-jcc and-jcc shr-je; do
+for pattern in cmp-js-jns sub-js-jns and-je shr-je; do
     grep -Eq "$pattern match=0 " "$workdir/disabled.log"
 done
 grep -Eq 'reject\.disabled=[1-9][0-9]*' "$workdir/disabled.log"

--- a/tests/integration/test-or-jcc.sh
+++ b/tests/integration/test-or-jcc.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+set -eu
+
+emulator=$(readlink -f "$1")
+source_file=$(readlink -f "$2")
+tmp_base=${TMPDIR:-"$HOME/tmp"}
+mkdir -p "$tmp_base"
+workdir=$(mktemp -d "$tmp_base/latx-or-jcc-test.XXXXXX")
+trap 'rm -rf "$workdir"' EXIT HUP INT TERM
+
+if command -v clang-19 >/dev/null 2>&1; then
+    clang=clang-19
+elif command -v clang >/dev/null 2>&1; then
+    clang=clang
+else
+    echo "SKIP: clang is required to build the x86_64 guest"
+    exit 77
+fi
+
+"$clang" --target=x86_64-linux-gnu -fuse-ld=lld -nostdlib -static \
+    -Wl,--build-id=none "$source_file" -o "$workdir/or-jcc"
+guest="$workdir/or-jcc"
+
+env LATX_AOT=0 LATX_INSTPTN_MASK=0x8000000 LATX_INSTPTN_STATS=1 \
+    "$emulator" "$guest" >"$workdir/enabled.log" 2>&1
+grep -Eq 'or-jcc match=[1-9][0-9]* .*eflags-fallback=[1-9][0-9]*' \
+    "$workdir/enabled.log"
+grep -Eq 'reject\.non-adjacent=[1-9][0-9]*' "$workdir/enabled.log"
+grep -Eq 'reject\.unsupported-cc=[1-9][0-9]*' "$workdir/enabled.log"
+grep -Eq 'reject\.fault-or-helper=[1-9][0-9]*' "$workdir/enabled.log"
+
+env LATX_AOT=0 LATX_INSTPTN_MASK=0x1 LATX_INSTPTN_STATS=1 \
+    "$emulator" "$guest" >"$workdir/disabled.log" 2>&1
+grep -Eq 'or-jcc match=0 ' "$workdir/disabled.log"
+grep -Eq 'reject\.disabled=[1-9][0-9]*' "$workdir/disabled.log"
+
+mkdir -p "$workdir/aot-home"
+env HOME="$workdir/aot-home" LATX_AOT=1 LATX_INSTPTN_MASK=0x8000000 \
+    "$emulator" "$guest" >"$workdir/aot-generate.log" 2>&1
+attempt=0
+while [ "$attempt" -lt 100 ]; do
+    if find "$workdir/aot-home/.cache/latx" -type f \
+        -name 'v2-*.aot2' -size +0c -print -quit 2>/dev/null | grep -q .; then
+        break
+    fi
+    attempt=$((attempt + 1))
+    sleep 0.05
+done
+test "$attempt" -lt 100
+env HOME="$workdir/aot-home" LATX_AOT=1 LATX_INSTPTN_MASK=0x8000000 \
+    "$emulator" "$guest" >"$workdir/aot-load.log" 2>&1
+
+set +e
+env LATX_AOT=0 LATX_INSTPTN_MASK=0x8000000 "$emulator" "$guest" fault \
+    >"$workdir/fault-enabled.log" 2>&1
+fault_enabled=$?
+env LATX_AOT=0 LATX_INSTPTN_MASK=0x1 "$emulator" "$guest" fault \
+    >"$workdir/fault-disabled.log" 2>&1
+fault_disabled=$?
+set -e
+test "$fault_enabled" -ne 0
+test "$fault_enabled" -eq "$fault_disabled"
+
+echo "PASS: OR+Jcc widths, conditions, flags, memory, rollback, fault," \
+    "LOCK, JIT/TU and AOT"

--- a/tests/integration/test-or-xx-jcc.sh
+++ b/tests/integration/test-or-xx-jcc.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+set -eu
+
+emulator=$(readlink -f "$1")
+source_file=$(readlink -f "$2")
+tmp_base="$HOME/tmp"
+mkdir -p "$tmp_base"
+workdir=$(mktemp -d "$tmp_base/latx-or-xx-jcc-test.XXXXXX")
+trap 'rm -rf "$workdir"' EXIT HUP INT TERM
+
+if command -v clang-19 >/dev/null 2>&1; then
+    clang=clang-19
+elif command -v clang >/dev/null 2>&1; then
+    clang=clang
+else
+    echo "SKIP: clang is required to build the x86_64 guest"
+    exit 77
+fi
+
+"$clang" --target=x86_64-linux-gnu -fuse-ld=lld -nostdlib -static \
+    -Wl,--build-id=none "$source_file" -o "$workdir/or-xx-jcc"
+guest="$workdir/or-xx-jcc"
+mask=0x800000000
+
+env LATX_AOT=0 LATX_INSTPTN_MASK="$mask" LATX_INSTPTN_STATS=1 \
+    "$emulator" "$guest" >"$workdir/enabled.log" 2>&1
+grep -Eq 'or-xx-jcc match=[1-9][0-9]*' "$workdir/enabled.log"
+env LATX_AOT=0 LATX_INSTPTN_MASK=0x2 LATX_INSTPTN_STATS=1 \
+    "$emulator" "$guest" >"$workdir/disabled.log" 2>&1
+grep -Eq 'or-xx-jcc match=0' "$workdir/disabled.log"
+grep -A3 'or-xx-jcc match=' "$workdir/disabled.log" | \
+    grep -Eq 'reject\.disabled=[1-9][0-9]*'
+
+for unlink in 0 1; do
+    env LATX_UNLINK="$unlink" LATX_AOT=0 LATX_INSTPTN_MASK="$mask" \
+        "$emulator" "$guest" >"$workdir/unlink-$unlink.log" 2>&1
+done
+
+mkdir -p "$workdir/aot-home"
+env HOME="$workdir/aot-home" LATX_AOT=1 LATX_INSTPTN_MASK="$mask" \
+    "$emulator" "$guest" aot skip >"$workdir/aot-generate.log" 2>&1
+attempt=0
+while [ "$attempt" -lt 100 ]; do
+    if find "$workdir/aot-home/.cache/latx" -type f \
+        -name 'v2-*.aot2' -size +0c -print -quit 2>/dev/null | grep -q .; then
+        break
+    fi
+    attempt=$((attempt + 1))
+    sleep 0.05
+done
+test "$attempt" -lt 100
+env HOME="$workdir/aot-home" LATX_AOT=1 LATX_INSTPTN_MASK="$mask" \
+    "$emulator" "$guest" aot skip >"$workdir/aot-load.log" 2>&1
+
+set +e
+env LATX_AOT=0 LATX_INSTPTN_MASK="$mask" \
+    "$emulator" "$guest" fault >"$workdir/fault-enabled.log" 2>&1
+fault_enabled=$?
+env LATX_AOT=0 LATX_INSTPTN_MASK=0x2 \
+    "$emulator" "$guest" fault >"$workdir/fault-disabled.log" 2>&1
+fault_disabled=$?
+set -e
+test "$fault_enabled" -ne 0
+test "$fault_enabled" -eq "$fault_disabled"
+
+echo "PASS: OR+XX+Jcc fixed temp, flags," \
+    "fault, unlink, JIT/TU and AOT"

--- a/tests/integration/test-or-xx-jcc.sh
+++ b/tests/integration/test-or-xx-jcc.sh
@@ -31,9 +31,15 @@ grep -Eq 'or-xx-jcc match=0' "$workdir/disabled.log"
 grep -A3 'or-xx-jcc match=' "$workdir/disabled.log" | \
     grep -Eq 'reject\.disabled=[1-9][0-9]*'
 
+# Debug unlink flushes every TB; keep the hot-loop runs above unchanged.
+"$clang" --target=x86_64-linux-gnu -fuse-ld=lld -nostdlib -static \
+    -Wl,--build-id=none -DINSTPTN_LOOP_COUNT=4 "$source_file" \
+    -o "$workdir/or-xx-jcc-unlink"
+unlink_guest="$workdir/or-xx-jcc-unlink"
+
 for unlink in 0 1; do
     env LATX_UNLINK="$unlink" LATX_AOT=0 LATX_INSTPTN_MASK="$mask" \
-        "$emulator" "$guest" >"$workdir/unlink-$unlink.log" 2>&1
+        "$emulator" "$unlink_guest" >"$workdir/unlink-$unlink.log" 2>&1
 done
 
 mkdir -p "$workdir/aot-home"

--- a/tests/integration/test-shift-jcc.sh
+++ b/tests/integration/test-shift-jcc.sh
@@ -1,0 +1,92 @@
+#!/bin/sh
+set -eu
+
+emulator=$(readlink -f "$1")
+source_file=$(readlink -f "$2")
+tmp_base=${TMPDIR:-"$HOME/tmp"}
+mkdir -p "$tmp_base"
+workdir=$(mktemp -d "$tmp_base/latx-shift-jcc-test.XXXXXX")
+trap 'rm -rf "$workdir"' EXIT HUP INT TERM
+
+if command -v clang-19 >/dev/null 2>&1; then
+    clang=clang-19
+elif command -v clang >/dev/null 2>&1; then
+    clang=clang
+else
+    echo "SKIP: clang is required to build the x86_64 guest"
+    exit 77
+fi
+
+"$clang" --target=x86_64-linux-gnu -fuse-ld=lld -nostdlib -static \
+    -Wl,--build-id=none "$source_file" -o "$workdir/shift-jcc"
+guest="$workdir/shift-jcc"
+
+# SAR_JCC (bit 29), legacy SHR_JCC (bit 24), and SHR_JE (bit 34).
+shift_mask=0x421000000
+env LATX_AOT=0 LATX_INSTPTN_MASK="$shift_mask" LATX_INSTPTN_STATS=1 \
+    "$emulator" "$guest" >"$workdir/enabled.log" 2>&1
+for pattern in sar-jcc shr-jcc shr-je; do
+    grep -Eq "$pattern match=[1-9][0-9]* .*eflags-fallback=[1-9][0-9]*" \
+        "$workdir/enabled.log"
+done
+grep -Eq 'reject\.zero-shift-count=[1-9][0-9]*' "$workdir/enabled.log"
+grep -A1 'shr-je match=' "$workdir/enabled.log" | \
+    grep -Eq 'reject\.zero-shift-count=[1-9][0-9]*'
+grep -Eq 'reject\.unsupported-cc=[1-9][0-9]*' "$workdir/enabled.log"
+grep -Eq 'reject\.unsupported-operand=[1-9][0-9]*' "$workdir/enabled.log"
+grep -Eq 'reject\.non-adjacent=[1-9][0-9]*' "$workdir/enabled.log"
+
+# Each new option must roll back independently without changing behavior.
+env LATX_AOT=0 LATX_INSTPTN_MASK=0x1000000 LATX_INSTPTN_STATS=1 \
+    "$emulator" "$guest" >"$workdir/legacy-shr-only.log" 2>&1
+grep -Eq 'shr-jcc match=[1-9][0-9]* ' "$workdir/legacy-shr-only.log"
+grep -Eq 'sar-jcc match=0 ' "$workdir/legacy-shr-only.log"
+grep -Eq 'shr-je match=0 ' "$workdir/legacy-shr-only.log"
+grep -Eq 'reject\.disabled=[1-9][0-9]*' \
+    "$workdir/legacy-shr-only.log"
+
+env LATX_AOT=0 LATX_INSTPTN_MASK=0x400000000 LATX_INSTPTN_STATS=1 \
+    "$emulator" "$guest" >"$workdir/shr-je-only.log" 2>&1
+grep -Eq 'shr-je match=[1-9][0-9]* ' "$workdir/shr-je-only.log"
+grep -Eq 'shr-jcc match=0 ' "$workdir/shr-je-only.log"
+grep -Eq 'reject\.disabled=[1-9][0-9]*' "$workdir/shr-je-only.log"
+
+env LATX_AOT=0 LATX_INSTPTN_MASK=0x1 LATX_INSTPTN_STATS=1 \
+    "$emulator" "$guest" >"$workdir/disabled.log" 2>&1
+grep -Eq 'sar-jcc match=0 ' "$workdir/disabled.log"
+grep -Eq 'shr-je match=0 ' "$workdir/disabled.log"
+
+# Generate and load AOT code with all three shift patterns enabled.
+mkdir -p "$workdir/aot-home"
+env HOME="$workdir/aot-home" LATX_AOT=1 LATX_INSTPTN_MASK="$shift_mask" \
+    "$emulator" "$guest" >"$workdir/aot-generate.log" 2>&1
+
+attempt=0
+while [ "$attempt" -lt 100 ]; do
+    if find "$workdir/aot-home/.cache/latx" -type f \
+        -name 'v2-*.aot2' -size +0c -print -quit 2>/dev/null | \
+        grep -q .; then
+        break
+    fi
+    attempt=$((attempt + 1))
+    sleep 0.05
+done
+test "$attempt" -lt 100
+
+env HOME="$workdir/aot-home" LATX_AOT=1 LATX_INSTPTN_MASK="$shift_mask" \
+    "$emulator" "$guest" >"$workdir/aot-load.log" 2>&1
+
+# A matching faulting memory destination must fault identically after rollback.
+set +e
+env LATX_AOT=0 LATX_INSTPTN_MASK="$shift_mask" \
+    "$emulator" "$guest" fault >"$workdir/fault-enabled.log" 2>&1
+fault_enabled=$?
+env LATX_AOT=0 LATX_INSTPTN_MASK=0x1 \
+    "$emulator" "$guest" fault >"$workdir/fault-disabled.log" 2>&1
+fault_disabled=$?
+set -e
+test "$fault_enabled" -ne 0
+test "$fault_enabled" -eq "$fault_disabled"
+
+echo "PASS: SAR/SHR+Jcc count matrix, widths, flags, memory, rollback," \
+    "fault, JIT/TU and AOT"

--- a/tests/integration/test-xor-jcc.sh
+++ b/tests/integration/test-xor-jcc.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+set -eu
+
+emulator=$(readlink -f "$1")
+source_file=$(readlink -f "$2")
+tmp_base=${TMPDIR:-"$HOME/tmp"}
+mkdir -p "$tmp_base"
+workdir=$(mktemp -d "$tmp_base/latx-xor-jcc-test.XXXXXX")
+trap 'rm -rf "$workdir"' EXIT HUP INT TERM
+
+if command -v clang-19 >/dev/null 2>&1; then
+    clang=clang-19
+elif command -v clang >/dev/null 2>&1; then
+    clang=clang
+else
+    echo "SKIP: clang is required to build the x86_64 guest"
+    exit 77
+fi
+
+"$clang" --target=x86_64-linux-gnu -fuse-ld=lld -nostdlib -static \
+    -Wl,--build-id=none "$source_file" -o "$workdir/xor-jcc"
+guest="$workdir/xor-jcc"
+mask=0x10000000
+
+env LATX_AOT=0 LATX_INSTPTN_MASK="$mask" LATX_INSTPTN_STATS=1 \
+    "$emulator" "$guest" >"$workdir/enabled.log" 2>&1
+grep -Eq 'xor-jcc match=[1-9][0-9]* .*eflags-fallback=[1-9][0-9]*' \
+    "$workdir/enabled.log"
+grep -Eq 'reject\.non-adjacent=[1-9][0-9]*' "$workdir/enabled.log"
+grep -Eq 'reject\.unsupported-cc=[1-9][0-9]*' "$workdir/enabled.log"
+grep -Eq 'reject\.fault-or-helper=[1-9][0-9]*' "$workdir/enabled.log"
+
+env LATX_AOT=0 LATX_INSTPTN_MASK=0x1 LATX_INSTPTN_STATS=1 \
+    "$emulator" "$guest" >"$workdir/disabled.log" 2>&1
+grep -Eq 'xor-jcc match=0 ' "$workdir/disabled.log"
+grep -Eq 'reject\.disabled=[1-9][0-9]*' "$workdir/disabled.log"
+
+env LATX_AOT=0 LATX_INSTPTN_MASK=0x200 LATX_INSTPTN_STATS=1 \
+    "$emulator" "$guest" >"$workdir/xor-div.log" 2>&1
+
+for unlink in 0 1; do
+    env LATX_UNLINK="$unlink" LATX_AOT=0 LATX_INSTPTN_MASK="$mask" \
+        "$emulator" "$guest" >"$workdir/unlink-$unlink.log" 2>&1
+done
+
+mkdir -p "$workdir/aot-home"
+env HOME="$workdir/aot-home" LATX_AOT=1 LATX_INSTPTN_MASK="$mask" \
+    "$emulator" "$guest" >"$workdir/aot-generate.log" 2>&1
+attempt=0
+while [ "$attempt" -lt 100 ]; do
+    if find "$workdir/aot-home/.cache/latx" -type f \
+        -name 'v2-*.aot2' -size +0c -print -quit 2>/dev/null | grep -q .; then
+        break
+    fi
+    attempt=$((attempt + 1))
+    sleep 0.05
+done
+test "$attempt" -lt 100
+env HOME="$workdir/aot-home" LATX_AOT=1 LATX_INSTPTN_MASK="$mask" \
+    "$emulator" "$guest" >"$workdir/aot-load.log" 2>&1
+
+set +e
+env LATX_AOT=0 LATX_INSTPTN_MASK="$mask" "$emulator" "$guest" fault \
+    >"$workdir/fault-enabled.log" 2>&1
+fault_enabled=$?
+env LATX_AOT=0 LATX_INSTPTN_MASK=0x1 "$emulator" "$guest" fault \
+    >"$workdir/fault-disabled.log" 2>&1
+fault_disabled=$?
+set -e
+test "$fault_enabled" -ne 0
+test "$fault_enabled" -eq "$fault_disabled"
+
+echo "PASS: XOR+Jcc widths, conditions, flags, memory, XOR+DIV," \
+    "rollback, fault, LOCK, JIT/TU, unlink and AOT"

--- a/tests/integration/test-xor-jcc.sh
+++ b/tests/integration/test-xor-jcc.sh
@@ -38,9 +38,15 @@ grep -Eq 'reject\.disabled=[1-9][0-9]*' "$workdir/disabled.log"
 env LATX_AOT=0 LATX_INSTPTN_MASK=0x200 LATX_INSTPTN_STATS=1 \
     "$emulator" "$guest" >"$workdir/xor-div.log" 2>&1
 
+# Debug unlink flushes every TB; keep the hot-loop runs above unchanged.
+"$clang" --target=x86_64-linux-gnu -fuse-ld=lld -nostdlib -static \
+    -Wl,--build-id=none -DINSTPTN_LOOP_COUNT=4 "$source_file" \
+    -o "$workdir/xor-jcc-unlink"
+unlink_guest="$workdir/xor-jcc-unlink"
+
 for unlink in 0 1; do
     env LATX_UNLINK="$unlink" LATX_AOT=0 LATX_INSTPTN_MASK="$mask" \
-        "$emulator" "$guest" >"$workdir/unlink-$unlink.log" 2>&1
+        "$emulator" "$unlink_guest" >"$workdir/unlink-$unlink.log" 2>&1
 done
 
 mkdir -p "$workdir/aot-home"

--- a/tests/integration/xor-jcc.S
+++ b/tests/integration/xor-jcc.S
@@ -1,0 +1,212 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+    .text
+    .globl _start
+_start:
+    cmpq $1, (%rsp)
+    jne fault_case
+
+    /* Same-register clear, 8-bit zero result. */
+    movl $1, %edi
+    movl $0x44, %r9d
+    movb $0x5a, %al
+    xorb %al, %al
+    je 1f
+    jmp exit_guest
+1:  call check_flags
+
+    /* Nonzero 8-bit result catches XOR(result, result) flag rebuilds. */
+    movl $2, %edi
+    movl $0x84, %r9d
+    movb $0x81, %al
+    xorb $0, %al
+    js 2f
+    jmp exit_guest
+2:  call check_flags
+    cmpb $0x81, %al
+    jne exit_guest
+
+    movl $3, %edi
+    xorl %r9d, %r9d
+    movw $0x7f00, %ax
+    xorw $1, %ax
+    jns 3f
+    jmp exit_guest
+3:  call check_flags
+    cmpw $0x7f01, %ax
+    jne exit_guest
+
+    /* A 32-bit destination must clear the upper half of the GPR. */
+    movl $4, %edi
+    movl $0x44, %r9d
+    movq $-1, %rax
+    xorl $-1, %eax
+    je 4f
+    jmp exit_guest
+4:  call check_flags
+    testq %rax, %rax
+    jne exit_guest
+
+    movl $5, %edi
+    movl $0x84, %r9d
+    movq $-1, %rax
+    xorq $0, %rax
+    js 5f
+    jmp exit_guest
+5:  call check_flags
+    cmpq $-1, %rax
+    jne exit_guest
+
+    /* Same-register clear, 64-bit zero result. */
+    movl $6, %edi
+    movl $0x44, %r9d
+    movq $0x1234, %rax
+    xorq %rax, %rax
+    je 6f
+    jmp exit_guest
+6:  call check_flags
+
+    /* Different registers with a nonzero result and flags fallback. */
+    movl $7, %edi
+    xorl %r9d, %r9d
+    movq $0x100, %rax
+    movq $1, %r10
+    xorq %r10, %rax
+    jne 7f
+    jmp exit_guest
+7:  call check_flags
+    cmpq $0x101, %rax
+    jne exit_guest
+
+    movl $8, %edi
+    xorl %r9d, %r9d
+    movq $0x100, %rax
+    xorq mem64(%rip), %rax
+    jne 8f
+    jmp exit_guest
+8:  call check_flags
+    cmpq $0x101, %rax
+    jne exit_guest
+
+    movl $9, %edi
+    movl $0x84, %r9d
+    movl $0x80000000, mem32(%rip)
+    xorl $0, mem32(%rip)
+    js 9f
+    jmp exit_guest
+9:  call check_flags
+    cmpl $0x80000000, mem32(%rip)
+    jne exit_guest
+
+    movl $10, %edi
+    movl $0x44, %r9d
+    movq $1, mem64(%rip)
+    movq $1, %rax
+    xorq %rax, mem64(%rip)
+    je 10f
+    jmp exit_guest
+10: call check_flags
+    cmpq $0, mem64(%rip)
+    jne exit_guest
+
+    /* Not-taken sides. */
+    movl $11, %edi
+    movl $1, %eax
+    xorl $0, %eax
+    je exit_guest
+    movl $12, %edi
+    xorl %eax, %eax
+    xorl %eax, %eax
+    jne exit_guest
+    movl $13, %edi
+    movl $1, %eax
+    xorl $0, %eax
+    js exit_guest
+    movl $14, %edi
+    movl $0x80000000, %eax
+    xorl $0, %eax
+    jns exit_guest
+
+    /* Non-adjacent and unsupported-cc rejection paths. */
+    movl $15, %edi
+    movl $1, %eax
+    xorl $2, %eax
+    nop
+    jne 11f
+    jmp exit_guest
+11: cmpl $3, %eax
+    jne exit_guest
+
+    movl $16, %edi
+    xorl %eax, %eax
+    xorl $0, %eax
+    jo exit_guest
+
+    movl $17, %edi
+    movl $0, lock_value(%rip)
+    lock xorl $1, lock_value(%rip)
+    jne 12f
+    jmp exit_guest
+12: cmpl $1, lock_value(%rip)
+    jne exit_guest
+
+    /* Keep the existing XOR+DIV pattern independent. */
+    movl $18, %edi
+    movl $3, %r10d
+    movl $10, %eax
+    xorl %edx, %edx
+    divl %r10d
+    cmpl $3, %eax
+    jne exit_guest
+    cmpl $1, %edx
+    jne exit_guest
+
+    movl $100000, %ecx
+13:
+    movl $0x12345678, %eax
+    xorl $0x12345678, %eax
+    je 14f
+    jmp exit_guest
+14: decl %ecx
+    jne 13b
+
+    /* The taken TU successor consumes CF while fallthrough does not. */
+    xorl %r8d, %r8d
+    movl $100000, %ecx
+.Ltu_target_loop:
+    stc
+    movl $1, %eax
+    xorl $1, %eax
+    je .Ltu_target
+    jmp exit_guest
+.Ltu_target:
+    adcl $0, %r8d
+    decl %ecx
+    jne .Ltu_target_loop
+    testl %r8d, %r8d
+    jne exit_guest
+
+    xorl %edi, %edi
+exit_guest:
+    movl $60, %eax
+    syscall
+
+check_flags:
+    pushfq
+    popq %r10
+    andq $0x8c5, %r10
+    cmpq %r9, %r10
+    jne exit_guest
+    ret
+
+fault_case:
+    xorl %eax, %eax
+    xorq $1, (%rax)
+    jne 15f
+15: movl $19, %edi
+    jmp exit_guest
+
+    .data
+    .p2align 3
+mem32:       .long 0
+lock_value:  .long 0
+mem64:       .quad 1

--- a/tests/integration/xor-jcc.S
+++ b/tests/integration/xor-jcc.S
@@ -160,6 +160,25 @@ _start:
     cmpl $1, %edx
     jne exit_guest
 
+    /* The memory load is signed, while EAX has a zero-extended high half. */
+    movl $20, %edi
+    movl $0x44, %r9d
+    movl $0x80000000, %eax
+    movl %eax, mem32(%rip)
+    xorl %eax, mem32(%rip)
+    je .Lmem32_zero
+    jmp exit_guest
+.Lmem32_zero:
+    call check_flags
+    cmpl $0, mem32(%rip)
+    jne exit_guest
+
+    movl $21, %edi
+    movl %eax, mem32(%rip)
+    xorl %eax, mem32(%rip)
+    jne exit_guest
+    call check_flags
+
     movl $100000, %ecx
 13:
     movl $0x12345678, %eax

--- a/tests/integration/xor-jcc.S
+++ b/tests/integration/xor-jcc.S
@@ -1,4 +1,8 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
+#ifndef INSTPTN_LOOP_COUNT
+#define INSTPTN_LOOP_COUNT 100000
+#endif
+
     .text
     .globl _start
 _start:
@@ -179,7 +183,7 @@ _start:
     jne exit_guest
     call check_flags
 
-    movl $100000, %ecx
+    movl $INSTPTN_LOOP_COUNT, %ecx
 13:
     movl $0x12345678, %eax
     xorl $0x12345678, %eax
@@ -190,7 +194,7 @@ _start:
 
     /* The taken TU successor consumes CF while fallthrough does not. */
     xorl %r8d, %r8d
-    movl $100000, %ecx
+    movl $INSTPTN_LOOP_COUNT, %ecx
 .Ltu_target_loop:
     stc
     movl $1, %eax

--- a/tests/latx/latx-config-regression.c
+++ b/tests/latx/latx-config-regression.c
@@ -10,6 +10,9 @@
 #include "latx-string-utils.h"
 #include "latx-options.h"
 #include "latx-runtime.h"
+#ifdef CONFIG_LATX_INSTS_PATTERN
+#include "insts-pattern.h"
+#endif
 
 static bool config_option_registered(const char *expected)
 {
@@ -38,6 +41,21 @@ static void test_release_loader_prefix_config(void)
 {
     g_assert_true(config_option_registered("LAT_LD_PREFIX"));
 }
+
+#ifdef CONFIG_LATX_INSTS_PATTERN
+static void test_instptn_option_contract(void)
+{
+    g_assert_true(config_option_registered("LATX_INSTPTN_MASK"));
+    g_assert_true(config_option_registered("LATX_INSTPTN_STATS"));
+    g_assert_cmpuint(INSTPTN_DEFAULT_OPTIONS, ==, UINT64_C(0x3ffffff));
+    g_assert_cmpint(INSTPTN_OPT_ADD_JCC, ==, 26);
+    g_assert_cmpint(INSTPTN_OPT_OR_XX_JCC, <, 64);
+    g_assert_cmpuint(INSTPTN_OPTION_BIT(INSTPTN_OPT_ADD_JCC) &
+                     INSTPTN_OPTION_BIT(INSTPTN_OPT_OR_JCC), ==, 0);
+    g_assert_cmpuint(INSTPTN_DEFAULT_OPTIONS &
+                     INSTPTN_OPTION_BIT(INSTPTN_OPT_ADD_JCC), ==, 0);
+}
+#endif
 
 static void test_runtime_prefix_source(void)
 {
@@ -187,6 +205,10 @@ int main(int argc, char **argv)
                     test_target_config_files);
     g_test_add_func("/latx/config/release-loader-prefix",
                     test_release_loader_prefix_config);
+#ifdef CONFIG_LATX_INSTS_PATTERN
+    g_test_add_func("/latx/config/instptn-option-contract",
+                    test_instptn_option_contract);
+#endif
     g_test_add_func("/latx/config/runtime-prefix-source",
                     test_runtime_prefix_source);
     g_test_add_func("/latx/config/user-config-path",


### PR DESCRIPTION
## Summary

- decouple instruction-pattern opcodes from runtime option bits and add strict 64-bit mask parsing and statistics
- add adjacent ADD, SAR/SHR, OR, XOR, and DEC result-to-Jcc patterns, and extend safe conditions for existing patterns
- add the OR_XX_JCC pilot across safe intermediate instructions, including EFLAGS recovery on exception paths
- keep every new pattern independently selectable and disabled by the legacy default mask

## Commit series

1. `LATX, refactor: Decouple instruction pattern options`
2. `LATX, opt: Add adjacent ADD and Jcc pattern`
3. `LATX, opt: Add SAR and extend SHR Jcc patterns`
4. `LATX, opt: Add adjacent OR and Jcc pattern`
5. `LATX, opt: Expand safe Jcc pattern conditions`
6. `LATX, opt: Add OR XX Jcc pattern`
7. `LATX, opt: Add adjacent XOR and Jcc pattern`
8. `LATX, opt: Add adjacent DEC and Jcc pattern`

## Validation

- release, debug, and no-pattern-check builds
- instruction-pattern option parsing, statistics, rejection, and fork semantics
- directed integration tests for all eight commits, including operand widths, flags, faults, LOCK handling, rollback, TU, unlink, and AOT paths
- `git diff --check`
- strict `checkpatch.pl` on each commit: no errors; only the generic MAINTAINERS warning caused by adding integration test files
- targeted code-generation checks show fewer host instructions for the newly enabled patterns; directed microbenchmarks show an optimization effect for each new pattern

## Tracking

AgentsFlow: P-18 / T-298
