### PR TITLE
LATX, AVX: avoid loading overwritten VPMOVSX destinations

### DIFF
--- a/target/i386/latx/translator/tr-avx.c
+++ b/target/i386/latx/translator/tr-avx.c
@@ -519,7 +519,10 @@ bool translate_vaddsubpd(IR1_INST * pir1) {
     IR1_OPND * opnd2 = ir1_get_opnd(pir1, 2);
     lsassert((ir1_opnd_is_xmm(opnd0) && ir1_opnd_is_xmm(opnd1)) ||
         (ir1_opnd_is_ymm(opnd0) && ir1_opnd_is_ymm(opnd1)));
-    IR2_OPND dest = load_freg256_from_ir1(opnd0);
+    /* VPMOVSX* overwrites its destination.  Loading a YMM destination here
+     * needlessly materializes its previous high half before the full result
+     * replaces it. */
+    IR2_OPND dest = ra_alloc_xmm(ir1_opnd_base_reg_num(opnd0));
     IR2_OPND src1 = load_freg256_from_ir1(opnd1);
     IR2_OPND src2 = load_freg256_from_ir1(opnd2);
     IR2_OPND add_src1 = ra_alloc_ftemp();

--- a/tests/integration/meson.build
+++ b/tests/integration/meson.build
@@ -8,6 +8,7 @@ if host_machine.cpu_family() == 'loongarch64'
   subdir('registrations/process-vm')
   subdir('registrations/prctl')
   subdir('registrations/seccomp')
+  subdir('registrations/simd')
 endif
 
 subdir('registrations')

--- a/tests/integration/registrations/simd/meson.build
+++ b/tests/integration/registrations/simd/meson.build
@@ -1,0 +1,11 @@
+if 'x86_64-linux-user' in target_dirs
+  latx_integration_tests += [{
+    'name': 'test-vpmovsx-overwrite',
+    'runner': find_program('../../test-vpmovsx-overwrite.sh'),
+    'args': [
+      emulators['latx-x86_64'],
+      files('../../vpmovsx-overwrite.S'),
+    ],
+    'timeout': 120,
+  }]
+endif

--- a/tests/integration/test-vpmovsx-overwrite.sh
+++ b/tests/integration/test-vpmovsx-overwrite.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+set -eu
+
+emulator=$(readlink -f "$1")
+source_file=$(readlink -f "$2")
+workdir=$(mktemp -d)
+trap 'rm -rf "$workdir"' EXIT HUP INT TERM
+
+if command -v clang-19 >/dev/null 2>&1; then
+    clang=clang-19
+elif command -v clang >/dev/null 2>&1; then
+    clang=clang
+else
+    echo "SKIP: clang is required to build the x86_64 guest"
+    exit 77
+fi
+
+guest="$workdir/vpmovsx-overwrite"
+"$clang" --target=x86_64-linux-gnu -fuse-ld=lld -nostdlib -static \
+    -Wl,--build-id=none "$source_file" -o "$guest"
+
+LATX_AOT=0 LATX_TU=0 "$emulator" "$guest"
+
+aot_home="$workdir/aot-home"
+mkdir -p "$aot_home"
+HOME="$aot_home" LATX_AOT=1 LATX_TU=1 "$emulator" "$guest"
+
+aot_file=
+for unused in $(seq 1 100); do
+    aot_file=$(find "$aot_home/.cache/latx" -type f -name '*.aot2' \
+        -size +0c -print -quit 2>/dev/null || true)
+    test -n "$aot_file" && break
+    sleep 0.1
+done
+if test -z "$aot_file"; then
+    echo "FAIL: no non-empty AOT file generated" >&2
+    exit 1
+fi
+
+HOME="$aot_home" LATX_AOT=1 LATX_TU=1 "$emulator" "$guest"
+echo "PASS: VPMOVSX overwrite semantics in JIT, cold AOT, and hot AOT"

--- a/tests/integration/vpmovsx-overwrite.S
+++ b/tests/integration/vpmovsx-overwrite.S
@@ -1,0 +1,88 @@
+.intel_syntax noprefix
+.global _start
+
+.section .rodata
+.balign 2
+.Lword:
+    .word 0x807f
+.Lexpected_extended:
+    .rept 8
+    .word 0x007f, 0xff80
+    .endr
+.Lexpected_broadcast:
+    .rept 8
+    .word 0x807f
+    .endr
+    .zero 16
+
+.section .bss
+.balign 32
+.Lactual:
+    .zero 32
+
+.section .text
+_start:
+    /* The destination may alias the 128-bit source. */
+    vpcmpeqd ymm0, ymm0, ymm0
+    vpbroadcastw xmm0, word ptr [rip + .Lword]
+    vpmovsxbw ymm0, xmm0
+    vmovdqu ymmword ptr [rip + .Lactual], ymm0
+    lea rsi, [rip + .Lactual]
+    lea rdi, [rip + .Lexpected_extended]
+    call .Lcompare_32
+    test eax, eax
+    jne .Lfail_alias
+
+    /* A distinct destination must not consume the source's upper-zero state. */
+    vpcmpeqd ymm1, ymm1, ymm1
+    vpbroadcastw xmm1, word ptr [rip + .Lword]
+    vpcmpeqd ymm2, ymm2, ymm2
+    vxorps xmm2, xmm2, xmm2
+    vpmovsxbw ymm2, xmm1
+    vmovdqu ymmword ptr [rip + .Lactual], ymm2
+    lea rsi, [rip + .Lactual]
+    lea rdi, [rip + .Lexpected_extended]
+    call .Lcompare_32
+    test eax, eax
+    jne .Lfail_distinct
+
+    /* Reading YMM1 must observe the VEX.128 zeroed high half. */
+    vmovdqu ymmword ptr [rip + .Lactual], ymm1
+    lea rsi, [rip + .Lactual]
+    lea rdi, [rip + .Lexpected_broadcast]
+    call .Lcompare_32
+    test eax, eax
+    jne .Lfail_source_high
+
+    xor edi, edi
+    jmp .Lexit
+
+.Lcompare_32:
+    xor eax, eax
+    mov ecx, 4
+.Lcompare_loop:
+    mov r8, qword ptr [rsi]
+    cmp r8, qword ptr [rdi]
+    jne .Lcompare_fail
+    add rsi, 8
+    add rdi, 8
+    dec ecx
+    jne .Lcompare_loop
+    ret
+.Lcompare_fail:
+    mov eax, 1
+    ret
+
+.Lfail_alias:
+    mov edi, 1
+    jmp .Lexit
+.Lfail_distinct:
+    mov edi, 2
+    jmp .Lexit
+.Lfail_source_high:
+    mov edi, 3
+.Lexit:
+    mov eax, 60
+    syscall
+
+.section .note.GNU-stack,"",@progbits


### PR DESCRIPTION
## Summary

- allocate VPMOVSX destinations without loading their previous YMM contents
- preserve source upper-half state when source and destination differ
- add an x86-64 assembly regression covering aliased and distinct registers

VPMOVSX fully overwrites its destination. Loading the old destination can materialize upper-half state that the extension immediately replaces.

## Validation

- clean LoongArch release build with GCC -O2 and LATX optimize O1
- native x86-64 assembly fixture: pass
- LATX JIT: pass
- LATX cold AOT: pass, non-empty AOT file generated
- LATX hot AOT: pass