### PR TITLE
LATX, AVX: avoid redundant vector copies and lane inserts

### DIFF
--- a/target/i386/latx/translator/tr-avx.c
+++ b/target/i386/latx/translator/tr-avx.c
@@ -1272,14 +1272,12 @@ bool translate_vextractf128(IR1_INST * pir1) {
     uint8 imm = ir1_opnd_uimm(ir1_get_opnd(pir1, 2)) & 0x1;
     if (ir1_opnd_is_xmm(ir1_get_opnd(pir1, 0))) {
         IR2_OPND dest = load_freg128_from_ir1(ir1_get_opnd(pir1, 0));
-        IR2_OPND temp = ra_alloc_ftemp();
         if (!imm) {
-            la_xvpermi_q(temp, src, VEXTRINS_IMM_4_0(3, 0));
+            la_xvpermi_q(dest, src, VEXTRINS_IMM_4_0(3, 0));
         } else {
-            la_xvpermi_q(temp, src, VEXTRINS_IMM_4_0(3, 1));
+            la_xvpermi_q(dest, src, VEXTRINS_IMM_4_0(3, 1));
         }
-        set_high128_xreg_to_zero(temp);
-        la_xvori_b(dest, temp, 0);
+        set_high128_xreg_to_zero(dest);
     } else {
         if (!imm) {
             store_freg128_to_ir1_mem(src, ir1_get_opnd(pir1, 0));
@@ -1374,14 +1372,25 @@ bool translate_vinserti128(IR1_INST * pir1) {
     IR2_OPND src1 = load_freg256_from_ir1(ir1_get_opnd(pir1, 1));
     IR2_OPND src2 = load_freg128_from_ir1(ir1_get_opnd(pir1, 2));
     uint8 imm = ir1_opnd_uimm(ir1_get_opnd(pir1, 3)) & 0x1;
-    IR2_OPND temp = ra_alloc_ftemp();
-    la_xvori_b(temp, src1, 0);
-    if (!imm) {
-        la_xvpermi_q(temp, src2, VEXTRINS_IMM_4_0(3, 0));
-    } else {
-        la_xvpermi_q(temp, src2, VEXTRINS_IMM_4_0(0, 2));
+    bool dest_is_src1 = ir1_opnd_base_reg_num(ir1_get_opnd(pir1, 0)) ==
+                        ir1_opnd_base_reg_num(ir1_get_opnd(pir1, 1));
+    bool dest_is_src2 = ir1_opnd_is_xmm(ir1_get_opnd(pir1, 2)) &&
+                        ir1_opnd_base_reg_num(ir1_get_opnd(pir1, 0)) ==
+                        ir1_opnd_base_reg_num(ir1_get_opnd(pir1, 2));
+    IR2_OPND result = dest_is_src2 && !dest_is_src1 ?
+                      ra_alloc_ftemp() : dest;
+
+    if (!dest_is_src1) {
+        la_xvori_b(result, src1, 0);
     }
-    la_xvori_b(dest, temp, 0);
+    if (!imm) {
+        la_xvpermi_q(result, src2, VEXTRINS_IMM_4_0(3, 0));
+    } else {
+        la_xvpermi_q(result, src2, VEXTRINS_IMM_4_0(0, 2));
+    }
+    if (dest_is_src2 && !dest_is_src1) {
+        la_xvori_b(dest, result, 0);
+    }
     return true;
 }
 
@@ -3495,8 +3504,6 @@ bool translate_vpbroadcastd(IR1_INST *pir1)
         la_xvreplve0_w(dest, src);
     } else if (ir1_opnd_is_ymm(opnd0)) {
         la_xvreplve0_w(dest, src);
-        la_xvinsve0_d(dest, dest, 2);
-        la_xvinsve0_d(dest, dest, 3);
     } else {
         lsassert(0);
     }
@@ -6467,8 +6474,6 @@ bool translate_vpbroadcastb(IR1_INST *pir1)
         la_xvreplve0_b(dest, src);
     } else if (ir1_opnd_is_ymm(opnd0)) {
         la_xvreplve0_b(dest, src);
-        la_xvinsve0_d(dest, dest, 2);
-        la_xvinsve0_d(dest, dest, 3);
     } else {
         lsassert(0);
     }
@@ -6503,8 +6508,6 @@ bool translate_vpbroadcastw(IR1_INST *pir1)
         la_xvreplve0_h(dest, src);
     } else if (ir1_opnd_is_ymm(opnd0)) {
         la_xvreplve0_h(dest, src);
-        la_xvinsve0_d(dest, dest, 2);
-        la_xvinsve0_d(dest, dest, 3);
     } else {
         lsassert(0);
     }


### PR DESCRIPTION
## Summary

- write VEXTRACTF128 register results directly to the destination
- handle VINSERTI128 source/destination overlap without an unconditional temporary and final copy
- remove redundant upper-lane inserts after full-width VPBROADCASTB/W/D operations

## Validation

- clean 3A6000 build: passed
- explicit VEXTRACTI128/VINSERTI128 overlap cases: passed
- 256-bit byte, word, and doubleword broadcasts: passed
- JIT, cold AOT, and hot AOT: passed with a non-empty AOT file and empty stderr
- `git diff --check`: passed