### PR TITLE
LATX: remove redundant IR2 constants and address operations

### DIFF
--- a/target/i386/latx/optimization/ir2-optimization.c
+++ b/target/i386/latx/optimization/ir2-optimization.c
@@ -215,6 +215,54 @@ void tri_avoid_leading_label(void)
 #endif
 }
 
+/*
+ * Temporary vector registers are released at each x86 instruction boundary.
+ * Consecutive translations can therefore allocate the same physical register
+ * and reload the same LASX immediate even though the earlier value is still
+ * live in that register.  Keep the value across the boundary until an actual
+ * write or a control-flow join invalidates it.
+ */
+static void ir2_opt_redundant_xvldi(void)
+{
+    bool valid[32] = { false };
+    int imm[32] = { 0 };
+    IR2_INST *ir2 = lsenv->tr_data->first_ir2;
+
+    while (ir2) {
+        IR2_INST *next = ir2_next(ir2);
+        IR2_OPCODE opc = ir2_opcode(ir2);
+
+        if (opc == LISA_XVLDI) {
+            int reg = ir2->_opnd[0]._reg_num;
+            int value = ir2->_opnd[1]._imm32;
+
+            if (reg >= 0 && reg < ARRAY_SIZE(valid)) {
+                if (valid[reg] && imm[reg] == value) {
+                    ir2_remove(ir2_get_id(ir2));
+                    ir2 = next;
+                    continue;
+                }
+                valid[reg] = true;
+                imm[reg] = value;
+            }
+        } else {
+            if (ir2_opcode_is_branch(opc) || ir2_opcode_is_jirl(opc) ||
+                la_ir2_opcode_is_label(opc)) {
+                memset(valid, 0, sizeof(valid));
+            }
+            if (!la_ir2_opcode_is_store(opc) && ir2->op_count > 0 &&
+                ir2_opnd_is_freg(&ir2->_opnd[0])) {
+                int reg = ir2->_opnd[0]._reg_num;
+
+                if (reg >= 0 && reg < ARRAY_SIZE(valid)) {
+                    valid[reg] = false;
+                }
+            }
+        }
+        ir2 = next;
+    }
+}
+
 static int ir2_get_addi_rsp_offs(IR2_INST *ir2)
 {
     int rsp = reg_gpr_map[esp_index];
@@ -528,6 +576,7 @@ static void ir2_opt_push_pop(TranslationBlock *tb)
 
 void tr_ir2_optimize(TranslationBlock *tb)
 {
+    ir2_opt_redundant_xvldi();
 #ifdef CONFIG_LATX_OPT_PUSH_POP
     CPUX86State *env = (CPUX86State*)lsenv->cpu_state;
     CPUState *cpu = env_cpu(env);

--- a/target/i386/latx/translator/mem-interface.c
+++ b/target/i386/latx/translator/mem-interface.c
@@ -289,11 +289,24 @@ static IR2_OPND convert_mem_helper(IR1_OPND *opnd1, IR2_OPND *arg_dest_op,
             }
         }
 #endif
+        longx load_offset = 0;
+        target_ulong base_offset = offset;
+
+#ifdef CONFIG_LATX_AOT
+        bool aot_reloc = option_aot && in_pre_translate;
+#else
+        bool aot_reloc = false;
+#endif
+        if (host_off && !aot_reloc) {
+            load_offset = sextract64(offset, 0, 12);
+            base_offset -= load_offset;
+        }
         target_ulong call_offset __attribute__((unused)) =
-                aot_get_call_offset(offset);
-        aot_load_guest_addr(dest_op, offset, LOAD_CALL_TARGET, call_offset);
+                aot_get_call_offset(base_offset);
+        aot_load_guest_addr(dest_op, base_offset, LOAD_CALL_TARGET,
+                            call_offset);
         if (host_off) {
-            *host_off = 0;
+            *host_off = load_offset;
         }
         return dest_op;
     }


### PR DESCRIPTION
## Summary

- track LASX immediate values across adjacent guest instructions and omit repeated XVLDI operations
- invalidate tracked values on register writes, labels, branches, and indirect jumps
- split low signed 12-bit RIP-relative displacements from JIT address materialization
- use the low part directly as the host load/store displacement
- preserve the existing relocation form during AOT pre-translation

## Validation

- clean 3A6000 build: passed
- AVX conversion, packing, multiply, shuffle, extract, insert, and broadcast fixtures: passed
- JIT, cold AOT, and hot AOT modes: passed with non-empty AOT files
- DCO sign-offs present on all commits

This PR supersedes the separate RIP-relative displacement PR. It remains a draft while grouped checks run.