### PR TITLE
LATX, AVX: write VPBLENDVB directly to the destination

### DIFF
--- a/target/i386/latx/translator/tr-avx.c
+++ b/target/i386/latx/translator/tr-avx.c
@@ -1929,15 +1929,15 @@ bool translate_vpblendvb(IR1_INST * pir1) {
         (ir1_opnd_is_ymm(opnd0) && ir1_opnd_is_ymm(opnd1)));
     IR2_OPND dest, src1, src2, src3;
     IR2_OPND temp = ra_alloc_ftemp();
-    dest = load_freg256_from_ir1(opnd0);
+    dest = ra_alloc_xmm(ir1_opnd_base_reg_num(opnd0));
     src1 = load_freg256_from_ir1(opnd1);
     src2 = load_freg256_from_ir1(opnd2);
     src3 = load_freg256_from_ir1(opnd3);
     la_xvslti_b(temp, src3, 0);
-    la_xvbitsel_v(temp, src1, src2, temp);
-    if (ir1_opnd_is_xmm(opnd0))
-        set_high128_xreg_to_zero(temp);
-    la_xvori_b(dest, temp, 0);
+    la_xvbitsel_v(dest, src1, src2, temp);
+    if (ir1_opnd_is_xmm(opnd0)) {
+        set_high128_xreg_to_zero(dest);
+    }
     return true;
 }
 


### PR DESCRIPTION
## Summary

- allocate the VPBLENDVB destination without loading its previous value
- write XVBITSEL.V directly to the architectural destination register
- preserve source/destination overlap and VEX.128 upper-half clearing semantics

## Validation

- clean 3A6000 build: passed
- 128-bit and 256-bit blends, including destination/source overlap: passed
- VEX.128 upper-half clearing: passed
- JIT, cold AOT, and hot AOT: passed with a non-empty AOT file and empty stderr
- `git diff --check`: passed