### PR TITLE
LATX, AVX: write shuffle and byte-shift results directly

### DIFF
--- a/target/i386/latx/translator/tr-avx-shift.c
+++ b/target/i386/latx/translator/tr-avx-shift.c
@@ -21,7 +21,7 @@ bool translate_vpslldq(IR1_INST * pir1) {
     lsassert((ir1_opnd_is_xmm(opnd0) && ir1_opnd_is_xmm(opnd1)) ||
         (ir1_opnd_is_ymm(opnd0) && ir1_opnd_is_ymm(opnd1)));
     lsassert(ir1_opnd_is_imm(opnd2));
-    IR2_OPND dest = load_freg256_from_ir1(opnd0);
+    IR2_OPND dest = ra_alloc_xmm(ir1_opnd_base_reg_num(opnd0));
     IR2_OPND src = load_freg256_from_ir1(opnd1);
     uint8_t imm = ir1_opnd_uimm(opnd2);
     if (imm > 15) {
@@ -118,7 +118,7 @@ bool translate_vpsrldq(IR1_INST * pir1) {
     lsassert((ir1_opnd_is_xmm(opnd0) && ir1_opnd_is_xmm(opnd1)) ||
         (ir1_opnd_is_ymm(opnd0) && ir1_opnd_is_ymm(opnd1)));
     lsassert(ir1_opnd_is_imm(opnd2));
-    IR2_OPND dest = load_freg256_from_ir1(opnd0);
+    IR2_OPND dest = ra_alloc_xmm(ir1_opnd_base_reg_num(opnd0));
     IR2_OPND src = load_freg256_from_ir1(opnd1);
     uint8_t imm = ir1_opnd_uimm(opnd2);
     if (imm > 15) {

--- a/target/i386/latx/translator/tr-avx.c
+++ b/target/i386/latx/translator/tr-avx.c
@@ -4107,15 +4107,13 @@ bool translate_vpshufd(IR1_INST * pir1) {
         IR2_OPND dest = load_freg128_from_ir1(opnd0);
         IR2_OPND src1 = load_freg128_from_ir1(opnd1);
         uint8_t imm = ir1_opnd_uimm(opnd2);
-        la_xvori_b(dest, src1, 0x00);
-        la_vpermi_w(dest, src1, imm);
+        la_xvshuf4i_w(dest, src1, imm);
         set_high128_xreg_to_zero(dest);
     } else {
         IR2_OPND dest = load_freg256_from_ir1(opnd0);
         IR2_OPND src1 = load_freg256_from_ir1(opnd1);
         uint8_t imm = ir1_opnd_uimm(opnd2);
-        la_xvori_b(dest, src1, 0x00);
-        la_xvpermi_w(dest, src1, imm);
+        la_xvshuf4i_w(dest, src1, imm);
     }
     return true;
 }
@@ -4844,13 +4842,18 @@ bool translate_vpshufhw(IR1_INST *pir1)
     IR1_OPND *opnd1 = ir1_get_opnd(pir1, 1);
     IR1_OPND *opnd2 = ir1_get_opnd(pir1, 2);
 
+    uint64_t imm8 = ir1_opnd_uimm(opnd2);
     IR2_OPND dest = load_freg256_from_ir1(opnd0);
     IR2_OPND src = load_freg256_from_ir1(opnd1);
-    IR2_OPND temp = ra_alloc_ftemp();
-    uint64_t imm8 = ir1_opnd_uimm(opnd2);
-    la_xvshuf4i_h(temp, src, imm8);
-    la_xvshuf4i_d(temp, src, 0x66);
-    la_xvori_b(dest, temp, 0);
+    if (dest._reg_num != src._reg_num) {
+        la_xvshuf4i_h(dest, src, imm8);
+        la_xvshuf4i_d(dest, src, 0x66);
+    } else {
+        IR2_OPND temp = ra_alloc_ftemp();
+        la_xvshuf4i_h(temp, src, imm8);
+        la_xvshuf4i_d(temp, src, 0x66);
+        la_xvori_b(dest, temp, 0);
+    }
     if(ir1_opnd_is_xmm(opnd0)){
         set_high128_xreg_to_zero(dest);
     }
@@ -4869,13 +4872,18 @@ bool translate_vpshuflw(IR1_INST *pir1)
     IR1_OPND *opnd1 = ir1_get_opnd(pir1, 1);
     IR1_OPND *opnd2 = ir1_get_opnd(pir1, 2);
 
+    uint64_t imm8 = ir1_opnd_uimm(opnd2);
     IR2_OPND dest = load_freg256_from_ir1(opnd0);
     IR2_OPND src = load_freg256_from_ir1(opnd1);
-    IR2_OPND temp = ra_alloc_ftemp();
-    uint64_t imm8 = ir1_opnd_uimm(opnd2);
-    la_xvshuf4i_h(temp, src, imm8);
-    la_xvshuf4i_d(temp, src, 0xcc);
-    la_xvori_b(dest, temp, 0);
+    if (dest._reg_num != src._reg_num) {
+        la_xvshuf4i_h(dest, src, imm8);
+        la_xvshuf4i_d(dest, src, 0xcc);
+    } else {
+        IR2_OPND temp = ra_alloc_ftemp();
+        la_xvshuf4i_h(temp, src, imm8);
+        la_xvshuf4i_d(temp, src, 0xcc);
+        la_xvori_b(dest, temp, 0);
+    }
     if(ir1_opnd_is_xmm(opnd0)){
         set_high128_xreg_to_zero(dest);
     }


### PR DESCRIPTION
## Summary

- allocate VPSLLDQ and VPSRLDQ destinations without loading overwritten values
- translate VPSHUFD with the direct LASX immediate shuffle
- write VPSHUFHW and VPSHUFLW directly to distinct destination registers while retaining a temporary for aliasing cases

## Validation

- clean 3A6000 build: passed
- 128-bit-lane byte shifts and immediate dword/halfword shuffles: passed
- JIT, cold AOT, and hot AOT: passed with a non-empty AOT file
- `git diff --check`: passed