### PR TITLE
i386: expose SHA extensions for LATX AVX builds

### DIFF
--- a/target/i386/cpu.c
+++ b/target/i386/cpu.c
@@ -670,6 +670,7 @@ static void x86_cpu_vendor_words2str(char *dst, uint32_t vendor1,
 #ifdef CONFIG_LATX_AVX_OPT
 #define TCG_7_0_EBX_FEATURES (CPUID_7_0_EBX_SMEP | CPUID_7_0_EBX_SMAP | \
           CPUID_7_0_EBX_BMI1 | CPUID_7_0_EBX_BMI2 | CPUID_7_0_EBX_ADX | \
+          CPUID_7_0_EBX_SHA_NI |                                      \
           CPUID_7_0_EBX_PCOMMIT | CPUID_7_0_EBX_CLFLUSHOPT |            \
           CPUID_7_0_EBX_CLWB | CPUID_7_0_EBX_MPX | CPUID_7_0_EBX_FSGSBASE | \
           CPUID_7_0_EBX_ERMS | CPUID_7_0_EBX_AVX2 | CPUID_7_0_EBX_HLE)
@@ -1930,6 +1931,7 @@ static X86CPUDefinition builtin_x86_defs[] = {
 #ifdef CONFIG_LATX_AVX_OPT
         .features[FEAT_7_0_EBX] =
         CPUID_7_0_EBX_HLE |
+            CPUID_7_0_EBX_SHA_NI |
             CPUID_7_0_EBX_BMI1 |
             CPUID_7_0_EBX_AVX2 |
             CPUID_7_0_EBX_BMI2,


### PR DESCRIPTION
## Summary

- advertise SHA-NI in the LATX AVX-enabled `qemu64` CPU model
- add SHA-NI to the corresponding TCG feature mask so the advertised bit is retained

## Rationale

LATX already translates SHA1 and SHA256 extension instructions. Advertising the feature lets x86 applications select that implemented path instead of falling back to generic code. Builds without the LATX AVX option remain unchanged.

## Correctness

A standalone x86 fixture covers SHA1MSG1, SHA1MSG2, SHA1NEXTE, all four SHA1RNDS4 modes, SHA256MSG1, SHA256MSG2, and SHA256RNDS2. The LATX output on 3A6000 matched the reference output byte-for-byte.

## Validation

- SHA fixture output SHA-256: `8ba1420a69c5fb4a0a08b8e83a43912de6d3d1eaa2a4d12bbf1aef72abe1b30f`
- YMM writeback regression fixture: passed
- LATX fast suite: 24/24 passed on the integrated branch
- `git diff --check`: passed