### PR TITLE
linux-user, fix: Handle AT_FDCWD when hiding helper threads

### DIFF
--- a/linux-user/main.c
+++ b/linux-user/main.c
@@ -219,6 +219,9 @@ void fork_start(void)
     mmap_fork_start();
     sigact_fork_start();
     path_fork_start();
+#ifdef CONFIG_LATX
+    latx_syscall_fs_fork_start();
+#endif
     fd_trans_fork_start();
     cpu_list_lock();
 }
@@ -229,6 +232,9 @@ void fork_end(int child)
     sigact_fork_end(child);
     path_fork_end(child);
     fd_trans_fork_end();
+#ifdef CONFIG_LATX
+    latx_syscall_fs_fork_end();
+#endif
     if (child) {
         CPUState *cpu, *next_cpu;
         /* Child processes created by fork() only have a single thread.

--- a/linux-user/qemu.h
+++ b/linux-user/qemu.h
@@ -380,6 +380,10 @@ void fork_start(void);
 void fork_end(int child);
 void fd_trans_fork_start(void);
 void fd_trans_fork_end(void);
+#ifdef CONFIG_LATX
+void latx_syscall_fs_fork_start(void);
+void latx_syscall_fs_fork_end(void);
+#endif
 
 /**
  * probe_guest_base:

--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -66,6 +66,7 @@
 #include <linux/in6.h>
 #include <linux/errqueue.h>
 #include <linux/random.h>
+#include <linux/magic.h>
 #include <linux/sctp.h>
 #ifdef CONFIG_TIMERFD
 #include <sys/timerfd.h>
@@ -12641,12 +12642,65 @@ static int is_proc_myself(const char *filename, const char *entry)
     return 0;
 }
 #ifdef CONFIG_LATX
+static bool latx_stat_same_object(const struct stat *a, const struct stat *b)
+{
+    return a->st_dev == b->st_dev && a->st_ino == b->st_ino;
+}
+
 static bool latx_stat_is_proc_self_task(const struct stat *st)
 {
     struct stat task_st;
 
     return stat("/proc/self/task", &task_st) == 0 &&
-           st->st_dev == task_st.st_dev && st->st_ino == task_st.st_ino;
+           latx_stat_same_object(st, &task_st);
+}
+
+static bool latx_stat_is_proc_self_task_fd(int fd, const struct stat *st)
+{
+    struct stat fd_st;
+    struct stat task_st;
+    struct statfs fs;
+
+    /*
+     * A saved /proc/self/task fd remains usable after a shared chroot makes
+     * the absolute procfs path unreachable.  Verify both the filesystem and
+     * the directory's identity: ../../self/task resolves to the current
+     * process task directory, while another process's task fd does not.
+     */
+    return fd >= 0 && fstatfs(fd, &fs) == 0 &&
+           fs.f_type == PROC_SUPER_MAGIC && fstat(fd, &fd_st) == 0 &&
+           latx_stat_same_object(st, &fd_st) &&
+           fstatat(fd, "../../self/task", &task_st, 0) == 0 &&
+           latx_stat_same_object(st, &task_st);
+}
+
+static bool latx_stat_is_proc_self_task_at(int dirfd, const char *pathname,
+                                           int flags,
+                                           const struct stat *st)
+{
+    struct stat task_st;
+    struct statfs fs;
+
+    if (latx_stat_is_proc_self_task(st)) {
+        return true;
+    }
+
+    if (pathname && pathname[0] == '\0') {
+        return (flags & AT_EMPTY_PATH) &&
+               latx_stat_is_proc_self_task_fd(dirfd, st);
+    }
+
+    /*
+     * Chromium keeps an fd for the procfs root before sharing a sandbox
+     * chroot with CLONE_FS.  At that point /proc/self/task is no longer
+     * reachable by an absolute path, but self/task remains reachable through
+     * the saved procfd.  Verify that the dirfd is procfs before using that
+     * relative reference so an ordinary self/task directory is not rewritten.
+     */
+    return pathname && pathname[0] != '/' && dirfd >= 0 &&
+           fstatfs(dirfd, &fs) == 0 && fs.f_type == PROC_SUPER_MAGIC &&
+           fstatat(dirfd, "self/task", &task_st, 0) == 0 &&
+           latx_stat_same_object(st, &task_st);
 }
 
 static bool latx_statx_is_proc_self_task(const struct target_statx *stx)
@@ -12659,9 +12713,58 @@ static bool latx_statx_is_proc_self_task(const struct target_statx *stx)
            stx->stx_ino == task_st.st_ino;
 }
 
+static bool latx_statx_is_proc_self_task_at(int dirfd, const char *pathname,
+                                            int flags,
+                                            const struct target_statx *stx)
+{
+    struct stat task_st;
+    struct statfs fs;
+
+    if ((stx->stx_mask & STATX_TYPE) && !S_ISDIR(stx->stx_mode)) {
+        return false;
+    }
+
+    if (latx_statx_is_proc_self_task(stx)) {
+        return true;
+    }
+
+    if (pathname && pathname[0] == '\0') {
+        return (flags & AT_EMPTY_PATH) && fstat(dirfd, &task_st) == 0 &&
+               latx_stat_is_proc_self_task_fd(dirfd, &task_st) &&
+               stx->stx_dev_major == major(task_st.st_dev) &&
+               stx->stx_dev_minor == minor(task_st.st_dev) &&
+               stx->stx_ino == task_st.st_ino;
+    }
+
+    return pathname && pathname[0] != '/' && dirfd >= 0 &&
+           fstatfs(dirfd, &fs) == 0 && fs.f_type == PROC_SUPER_MAGIC &&
+           fstatat(dirfd, "self/task", &task_st, 0) == 0 &&
+           stx->stx_dev_major == major(task_st.st_dev) &&
+           stx->stx_dev_minor == minor(task_st.st_dev) &&
+           stx->stx_ino == task_st.st_ino;
+}
+
 static void latx_adjust_proc_self_task_stat(struct stat *st)
 {
-    if (latx_stat_is_proc_self_task(st)) {
+    if (S_ISDIR(st->st_mode) && latx_stat_is_proc_self_task(st)) {
+        st->st_nlink = latx_guest_thread_count() + 2;
+    }
+}
+static void latx_adjust_proc_self_task_fstat(int fd, struct stat *st)
+{
+    if (S_ISDIR(st->st_mode) &&
+        (latx_stat_is_proc_self_task(st) ||
+         latx_stat_is_proc_self_task_fd(fd, st))) {
+        st->st_nlink = latx_guest_thread_count() + 2;
+    }
+}
+
+static void latx_adjust_proc_self_task_stat_at(int dirfd, const char *pathname,
+                                               int flags,
+                                               struct stat *st)
+{
+    if (S_ISDIR(st->st_mode) &&
+        latx_stat_is_proc_self_task_at(dirfd, pathname, flags, st)) {
         st->st_nlink = latx_guest_thread_count() + 2;
     }
 }
@@ -16979,7 +17082,7 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
             }
 #ifdef CONFIG_LATX
             if (!is_error(ret)) {
-                latx_adjust_proc_self_task_stat(&st);
+                latx_adjust_proc_self_task_fstat(arg1, &st);
             }
 #endif
 #if defined(TARGET_NR_stat) || defined(TARGET_NR_lstat)
@@ -18531,7 +18634,7 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
         }
 #ifdef CONFIG_LATX
         if (!is_error(ret)) {
-            latx_adjust_proc_self_task_stat(&st);
+            latx_adjust_proc_self_task_fstat(arg1, &st);
         }
 #endif
         if (!is_error(ret))
@@ -18552,7 +18655,7 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
 
         if (!is_error(ret)) {
 #ifdef CONFIG_LATX
-            latx_adjust_proc_self_task_stat(&st);
+            latx_adjust_proc_self_task_stat_at(arg1, p, arg4, &st);
 #else
             if (rcu_call_thread_is_running() &&
                 (!strcmp((const char *)p, "self/task/") ||
@@ -18589,7 +18692,8 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
                 ret = get_errno(sys_statx(dirfd, p, flags, mask, &host_stx));
                 if (!is_error(ret)) {
 #ifdef CONFIG_LATX
-                    if (latx_statx_is_proc_self_task(&host_stx)) {
+                    if (latx_statx_is_proc_self_task_at(dirfd, p, flags,
+                                                        &host_stx)) {
                         host_stx.stx_nlink = latx_guest_thread_count() + 2;
                     }
 #endif
@@ -18609,7 +18713,7 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
 
 #ifdef CONFIG_LATX
             if (!is_error(ret)) {
-                latx_adjust_proc_self_task_stat(&st);
+                latx_adjust_proc_self_task_stat_at(dirfd, p, flags, &st);
             }
 #endif
             unlock_user(p, arg2, 0);

--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -12647,12 +12647,47 @@ static bool latx_stat_same_object(const struct stat *a, const struct stat *b)
     return a->st_dev == b->st_dev && a->st_ino == b->st_ino;
 }
 
+/*
+ * Serialize identity-sensitive stat sequences with guest changes to cwd,
+ * root, and descriptor bindings.  The fork hooks keep this lock consistent
+ * across a multithreaded fork.
+ */
+static pthread_mutex_t latx_syscall_fs_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+static void latx_syscall_fs_lock(void)
+{
+    pthread_mutex_lock(&latx_syscall_fs_mutex);
+}
+
+static void latx_syscall_fs_unlock(void)
+{
+    pthread_mutex_unlock(&latx_syscall_fs_mutex);
+}
+
+void latx_syscall_fs_fork_start(void)
+{
+    latx_syscall_fs_lock();
+}
+
+void latx_syscall_fs_fork_end(void)
+{
+    latx_syscall_fs_unlock();
+}
+
 static bool latx_stat_is_proc_self_task(const struct stat *st)
 {
     struct stat task_st;
 
     return stat("/proc/self/task", &task_st) == 0 &&
            latx_stat_same_object(st, &task_st);
+}
+
+static int latx_stat_dirfd_info(int dirfd, struct stat *st,
+                                struct statfs *fs)
+{
+    return dirfd == AT_FDCWD ?
+           (stat(".", st) == 0 && statfs(".", fs) == 0 ? 0 : -1) :
+           (fstat(dirfd, st) == 0 && fstatfs(dirfd, fs) == 0 ? 0 : -1);
 }
 
 static bool latx_stat_is_proc_self_task_fd(int fd, const struct stat *st)
@@ -12662,10 +12697,10 @@ static bool latx_stat_is_proc_self_task_fd(int fd, const struct stat *st)
     struct statfs fs;
 
     /*
-     * A saved /proc/self/task fd remains usable after a shared chroot makes
-     * the absolute procfs path unreachable.  Verify both the filesystem and
-     * the directory's identity: ../../self/task resolves to the current
-     * process task directory, while another process's task fd does not.
+     * A saved /proc/self/task fd remains usable after a shared chroot makes the
+     * absolute procfs path unreachable.  Verify both the filesystem and the
+     * directory's identity: ../../self/task resolves to the current process
+     * task directory, while another process's task directory does not.
      */
     return fd >= 0 && fstatfs(fd, &fs) == 0 &&
            fs.f_type == PROC_SUPER_MAGIC && fstat(fd, &fd_st) == 0 &&
@@ -12674,10 +12709,26 @@ static bool latx_stat_is_proc_self_task_fd(int fd, const struct stat *st)
            latx_stat_same_object(st, &task_st);
 }
 
+static char *latx_stat_self_task_path(const char *pathname, int flags)
+{
+    const char *target = pathname;
+
+    if (pathname[0] == '\0') {
+        if (!(flags & AT_EMPTY_PATH)) {
+            return NULL;
+        }
+        target = ".";
+    }
+    return g_strdup_printf("%s/../../self/task", target);
+}
+
 static bool latx_stat_is_proc_self_task_at(int dirfd, const char *pathname,
                                            int flags,
                                            const struct stat *st)
 {
+    char *task_path;
+    bool ret;
+    struct stat dir_st;
     struct stat task_st;
     struct statfs fs;
 
@@ -12685,22 +12736,25 @@ static bool latx_stat_is_proc_self_task_at(int dirfd, const char *pathname,
         return true;
     }
 
-    if (pathname && pathname[0] == '\0') {
-        return (flags & AT_EMPTY_PATH) &&
-               latx_stat_is_proc_self_task_fd(dirfd, st);
-    }
-
     /*
-     * Chromium keeps an fd for the procfs root before sharing a sandbox
-     * chroot with CLONE_FS.  At that point /proc/self/task is no longer
-     * reachable by an absolute path, but self/task remains reachable through
-     * the saved procfd.  Verify that the dirfd is procfs before using that
-     * relative reference so an ordinary self/task directory is not rewritten.
+     * The caller holds latx_syscall_fs_mutex from the original lookup through
+     * this check.  Resolve ../../self/task from the object named by the same
+     * private pathname snapshot, without exposing a temporary fd to the guest.
      */
-    return pathname && pathname[0] != '/' && dirfd >= 0 &&
-           fstatfs(dirfd, &fs) == 0 && fs.f_type == PROC_SUPER_MAGIC &&
-           fstatat(dirfd, "self/task", &task_st, 0) == 0 &&
-           latx_stat_same_object(st, &task_st);
+    if (!pathname || pathname[0] == '/' ||
+        (dirfd != AT_FDCWD && dirfd < 0) ||
+        latx_stat_dirfd_info(dirfd, &dir_st, &fs) < 0 ||
+        fs.f_type != PROC_SUPER_MAGIC || st->st_dev != dir_st.st_dev) {
+        return false;
+    }
+    task_path = latx_stat_self_task_path(pathname, flags);
+    if (!task_path) {
+        return false;
+    }
+    ret = fstatat(dirfd, task_path, &task_st, 0) == 0 &&
+          latx_stat_same_object(st, &task_st);
+    g_free(task_path);
+    return ret;
 }
 
 static bool latx_statx_is_proc_self_task(const struct target_statx *stx)
@@ -12717,6 +12771,9 @@ static bool latx_statx_is_proc_self_task_at(int dirfd, const char *pathname,
                                             int flags,
                                             const struct target_statx *stx)
 {
+    char *task_path;
+    bool ret;
+    struct stat dir_st;
     struct stat task_st;
     struct statfs fs;
 
@@ -12728,20 +12785,24 @@ static bool latx_statx_is_proc_self_task_at(int dirfd, const char *pathname,
         return true;
     }
 
-    if (pathname && pathname[0] == '\0') {
-        return (flags & AT_EMPTY_PATH) && fstat(dirfd, &task_st) == 0 &&
-               latx_stat_is_proc_self_task_fd(dirfd, &task_st) &&
-               stx->stx_dev_major == major(task_st.st_dev) &&
-               stx->stx_dev_minor == minor(task_st.st_dev) &&
-               stx->stx_ino == task_st.st_ino;
+    if (!pathname || pathname[0] == '/' ||
+        (dirfd != AT_FDCWD && dirfd < 0) ||
+        latx_stat_dirfd_info(dirfd, &dir_st, &fs) < 0 ||
+        fs.f_type != PROC_SUPER_MAGIC ||
+        stx->stx_dev_major != major(dir_st.st_dev) ||
+        stx->stx_dev_minor != minor(dir_st.st_dev)) {
+        return false;
     }
-
-    return pathname && pathname[0] != '/' && dirfd >= 0 &&
-           fstatfs(dirfd, &fs) == 0 && fs.f_type == PROC_SUPER_MAGIC &&
-           fstatat(dirfd, "self/task", &task_st, 0) == 0 &&
-           stx->stx_dev_major == major(task_st.st_dev) &&
-           stx->stx_dev_minor == minor(task_st.st_dev) &&
-           stx->stx_ino == task_st.st_ino;
+    task_path = latx_stat_self_task_path(pathname, flags);
+    if (!task_path) {
+        return false;
+    }
+    ret = fstatat(dirfd, task_path, &task_st, 0) == 0 &&
+          stx->stx_dev_major == major(task_st.st_dev) &&
+          stx->stx_dev_minor == minor(task_st.st_dev) &&
+          stx->stx_ino == task_st.st_ino;
+    g_free(task_path);
+    return ret;
 }
 
 static void latx_adjust_proc_self_task_stat(struct stat *st)
@@ -12750,6 +12811,21 @@ static void latx_adjust_proc_self_task_stat(struct stat *st)
         st->st_nlink = latx_guest_thread_count() + 2;
     }
 }
+
+static int latx_stat_path(const char *pathname, struct stat *st, bool follow)
+{
+    const char *host_pathname = path(pathname);
+    int ret;
+
+    latx_syscall_fs_lock();
+    ret = follow ? stat(host_pathname, st) : lstat(host_pathname, st);
+    if (ret == 0) {
+        latx_adjust_proc_self_task_stat(st);
+    }
+    latx_syscall_fs_unlock();
+    return ret;
+}
+
 static void latx_adjust_proc_self_task_fstat(int fd, struct stat *st)
 {
     if (S_ISDIR(st->st_mode) &&
@@ -14603,8 +14679,15 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
             return ret;
         }
 #endif
+#ifdef CONFIG_LATX
+        latx_syscall_fs_lock();
+#endif
         fd_trans_unregister(arg1);
-        return get_errno(close(arg1));
+        ret = get_errno(close(arg1));
+#ifdef CONFIG_LATX
+        latx_syscall_fs_unlock();
+#endif
+        return ret;
 
     case TARGET_NR_brk:
         return do_brk(arg1);
@@ -15233,7 +15316,13 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
     case TARGET_NR_chdir:
         if (!(p = lock_user_string(arg1)))
             return -TARGET_EFAULT;
+#ifdef CONFIG_LATX
+        latx_syscall_fs_lock();
+#endif
         ret = get_errno(chdir(p));
+#ifdef CONFIG_LATX
+        latx_syscall_fs_unlock();
+#endif
         unlock_user(p, arg1, 0);
         return ret;
 #ifdef TARGET_NR_time
@@ -15325,12 +15414,18 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
              * do that since it's not guaranteed to be a NULL-terminated
              * string.
              */
+#ifdef CONFIG_LATX
+            latx_syscall_fs_lock();
+#endif
             if (!arg5) {
                 ret = mount(p, p2, p3, (unsigned long)arg4, NULL);
             } else {
                 ret = mount(p, p2, p3, (unsigned long)arg4, g2h(cpu, arg5));
             }
             ret = get_errno(ret);
+#ifdef CONFIG_LATX
+            latx_syscall_fs_unlock();
+#endif
 
             if (arg1) {
                 unlock_user(p, arg1, 0);
@@ -15350,7 +15445,13 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
 #endif
         if (!(p = lock_user_string(arg1)))
             return -TARGET_EFAULT;
+#ifdef CONFIG_LATX
+        latx_syscall_fs_lock();
+#endif
         ret = get_errno(umount(p));
+#ifdef CONFIG_LATX
+        latx_syscall_fs_unlock();
+#endif
         unlock_user(p, arg1, 0);
         return ret;
 #endif
@@ -15753,7 +15854,13 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
     case TARGET_NR_umount2:
         if (!(p = lock_user_string(arg1)))
             return -TARGET_EFAULT;
+#ifdef CONFIG_LATX
+        latx_syscall_fs_lock();
+#endif
         ret = get_errno(umount2(p, arg2));
+#ifdef CONFIG_LATX
+        latx_syscall_fs_unlock();
+#endif
         unlock_user(p, arg1, 0);
         return ret;
 #endif
@@ -15779,7 +15886,13 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
     case TARGET_NR_chroot:
         if (!(p = lock_user_string(arg1)))
             return -TARGET_EFAULT;
+#ifdef CONFIG_LATX
+        latx_syscall_fs_lock();
+#endif
         ret = get_errno(chroot(p));
+#ifdef CONFIG_LATX
+        latx_syscall_fs_unlock();
+#endif
         unlock_user(p, arg1, 0);
         return ret;
 #ifdef TARGET_NR_dup2
@@ -15792,10 +15905,16 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
             }
         }
 #endif
+#ifdef CONFIG_LATX
+        latx_syscall_fs_lock();
+#endif
         ret = get_errno(dup2(arg1, arg2));
         if (ret >= 0) {
             fd_trans_dup(arg1, arg2);
         }
+#ifdef CONFIG_LATX
+        latx_syscall_fs_unlock();
+#endif
         return ret;
 #endif
 #if defined(CONFIG_DUP3) && defined(TARGET_NR_dup3)
@@ -15815,10 +15934,16 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
             }
         }
 #endif
+#ifdef CONFIG_LATX
+        latx_syscall_fs_lock();
+#endif
         ret = get_errno(dup3(arg1, arg2, host_flags));
         if (ret >= 0) {
             fd_trans_dup(arg1, arg2);
         }
+#ifdef CONFIG_LATX
+        latx_syscall_fs_unlock();
+#endif
         return ret;
     }
 #endif
@@ -17050,11 +17175,10 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
         if (!(p = lock_user_string(arg1))) {
             return -TARGET_EFAULT;
         }
-        ret = get_errno(stat(path(p), &st));
 #ifdef CONFIG_LATX
-        if (!is_error(ret)) {
-            latx_adjust_proc_self_task_stat(&st);
-        }
+        ret = get_errno(latx_stat_path(p, &st, true));
+#else
+        ret = get_errno(stat(path(p), &st));
 #endif
         unlock_user(p, arg1, 0);
         goto do_stat;
@@ -17064,11 +17188,10 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
         if (!(p = lock_user_string(arg1))) {
             return -TARGET_EFAULT;
         }
-        ret = get_errno(lstat(path(p), &st));
 #ifdef CONFIG_LATX
-        if (!is_error(ret)) {
-            latx_adjust_proc_self_task_stat(&st);
-        }
+        ret = get_errno(latx_stat_path(p, &st, false));
+#else
+        ret = get_errno(lstat(path(p), &st));
 #endif
         unlock_user(p, arg1, 0);
         goto do_stat;
@@ -17076,6 +17199,9 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
 #ifdef TARGET_NR_fstat
     case TARGET_NR_fstat:
         {
+#ifdef CONFIG_LATX
+            latx_syscall_fs_lock();
+#endif
             ret = proc_self_fstat(arg1, &st);
             if (ret) {
                 ret = get_errno(fstat(arg1, &st));
@@ -17084,6 +17210,7 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
             if (!is_error(ret)) {
                 latx_adjust_proc_self_task_fstat(arg1, &st);
             }
+            latx_syscall_fs_unlock();
 #endif
 #if defined(TARGET_NR_stat) || defined(TARGET_NR_lstat)
         do_stat:
@@ -17396,7 +17523,14 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
     case TARGET_NR_getpgid:
         return get_errno(getpgid(arg1));
     case TARGET_NR_fchdir:
-        return get_errno(fchdir(arg1));
+#ifdef CONFIG_LATX
+        latx_syscall_fs_lock();
+#endif
+        ret = get_errno(fchdir(arg1));
+#ifdef CONFIG_LATX
+        latx_syscall_fs_unlock();
+#endif
+        return ret;
     case TARGET_NR_personality:
         return get_errno(personality(arg1));
 #ifdef TARGET_NR__llseek /* Not on alpha */
@@ -18599,11 +18733,10 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
         if (!(p = lock_user_string(arg1))) {
             return -TARGET_EFAULT;
         }
-        ret = get_errno(stat(path(p), &st));
 #ifdef CONFIG_LATX
-        if (!is_error(ret)) {
-            latx_adjust_proc_self_task_stat(&st);
-        }
+        ret = get_errno(latx_stat_path(p, &st, true));
+#else
+        ret = get_errno(stat(path(p), &st));
 #endif
         unlock_user(p, arg1, 0);
         if (!is_error(ret))
@@ -18615,11 +18748,10 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
         if (!(p = lock_user_string(arg1))) {
             return -TARGET_EFAULT;
         }
-        ret = get_errno(lstat(path(p), &st));
 #ifdef CONFIG_LATX
-        if (!is_error(ret)) {
-            latx_adjust_proc_self_task_stat(&st);
-        }
+        ret = get_errno(latx_stat_path(p, &st, false));
+#else
+        ret = get_errno(lstat(path(p), &st));
 #endif
         unlock_user(p, arg1, 0);
         if (!is_error(ret))
@@ -18628,6 +18760,9 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
 #endif
 #ifdef TARGET_NR_fstat64
     case TARGET_NR_fstat64:
+#ifdef CONFIG_LATX
+        latx_syscall_fs_lock();
+#endif
         ret = proc_self_fstat(arg1, &st);
         if (ret) {
             ret = get_errno(fstat(arg1, &st));
@@ -18636,6 +18771,7 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
         if (!is_error(ret)) {
             latx_adjust_proc_self_task_fstat(arg1, &st);
         }
+        latx_syscall_fs_unlock();
 #endif
         if (!is_error(ret))
             ret = host_to_target_stat64(cpu_env, arg2, &st);
@@ -18648,39 +18784,76 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
 #ifdef TARGET_NR_newfstatat
     case TARGET_NR_newfstatat:
 #endif
-        if (!(p = lock_user_string(arg2))) {
-            return -TARGET_EFAULT;
-        }
-        ret = get_errno(fstatat(arg1, path(p), &st, arg4));
-
-        if (!is_error(ret)) {
+        {
 #ifdef CONFIG_LATX
-            latx_adjust_proc_self_task_stat_at(arg1, p, arg4, &st);
-#else
-            if (rcu_call_thread_is_running() &&
-                (!strcmp((const char *)p, "self/task/") ||
-                 is_proc_myself((const char *)p, "task/"))) {
-                st.st_nlink--;
-            }
+            char *pathname;
+            const char *host_pathname;
 #endif
-        }
 
-        unlock_user(p, arg2, 0);
-        if (!is_error(ret))
-            ret = host_to_target_stat64(cpu_env, arg3, &st);
-        return ret;
+            p = lock_user_string(arg2);
+            if (!p) {
+                return -TARGET_EFAULT;
+            }
+#ifdef CONFIG_LATX
+            pathname = g_strdup(p);
+            unlock_user(p, arg2, 0);
+            host_pathname = path(pathname);
+            latx_syscall_fs_lock();
+            ret = get_errno(fstatat(arg1, host_pathname, &st, arg4));
+#else
+            ret = get_errno(fstatat(arg1, path(p), &st, arg4));
+#endif
+
+            if (!is_error(ret)) {
+#ifdef CONFIG_LATX
+                latx_adjust_proc_self_task_stat_at(arg1, pathname, arg4, &st);
+#else
+                if (rcu_call_thread_is_running() &&
+                    (!strcmp((const char *)p, "self/task/") ||
+                     is_proc_myself((const char *)p, "task/"))) {
+                    st.st_nlink--;
+                }
+#endif
+            }
+
+#ifdef CONFIG_LATX
+            latx_syscall_fs_unlock();
+            g_free(pathname);
+#else
+            unlock_user(p, arg2, 0);
+#endif
+            if (!is_error(ret)) {
+                ret = host_to_target_stat64(cpu_env, arg3, &st);
+            }
+            return ret;
+        }
 #endif
 #if defined(TARGET_NR_statx)
     case TARGET_NR_statx:
         {
+            const char *host_pathname;
+            const char *pathname;
             struct target_statx *target_stx;
             int dirfd = arg1;
             int flags = arg3;
+#ifdef CONFIG_LATX
+            char *pathname_snapshot;
+#endif
 
             p = lock_user_string(arg2);
             if (p == NULL) {
                 return -TARGET_EFAULT;
             }
+            pathname = p;
+#ifdef CONFIG_LATX
+            pathname_snapshot = g_strdup(p);
+            pathname = pathname_snapshot;
+            unlock_user(p, arg2, 0);
+            host_pathname = path(pathname);
+            latx_syscall_fs_lock();
+#else
+            host_pathname = path(pathname);
+#endif
 #if defined(__NR_statx)
             {
                 /*
@@ -18689,38 +18862,38 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
                 struct target_statx host_stx;
                 int mask = arg4;
 
-                ret = get_errno(sys_statx(dirfd, p, flags, mask, &host_stx));
+                ret = get_errno(sys_statx(dirfd, pathname, flags, mask,
+                                          &host_stx));
                 if (!is_error(ret)) {
 #ifdef CONFIG_LATX
-                    if (latx_statx_is_proc_self_task_at(dirfd, p, flags,
-                                                        &host_stx)) {
+                    if (latx_statx_is_proc_self_task_at(dirfd, pathname,
+                                                        flags, &host_stx)) {
                         host_stx.stx_nlink = latx_guest_thread_count() + 2;
                     }
 #endif
                     if (host_to_target_statx(&host_stx, arg5) != 0) {
-                        unlock_user(p, arg2, 0);
-                        return -TARGET_EFAULT;
+                        ret = -TARGET_EFAULT;
                     }
                 }
 
                 if (ret != -TARGET_ENOSYS) {
-                    unlock_user(p, arg2, 0);
-                    return ret;
+                    goto statx_done;
                 }
             }
 #endif
-            ret = get_errno(fstatat(dirfd, path(p), &st, flags));
+            ret = get_errno(fstatat(dirfd, host_pathname, &st, flags));
 
 #ifdef CONFIG_LATX
             if (!is_error(ret)) {
-                latx_adjust_proc_self_task_stat_at(dirfd, p, flags, &st);
+                latx_adjust_proc_self_task_stat_at(dirfd, pathname, flags,
+                                                   &st);
             }
 #endif
-            unlock_user(p, arg2, 0);
 
             if (!is_error(ret)) {
                 if (!lock_user_struct(VERIFY_WRITE, target_stx, arg5, 0)) {
-                    return -TARGET_EFAULT;
+                    ret = -TARGET_EFAULT;
+                    goto statx_done;
                 }
                 memset(target_stx, 0, sizeof(*target_stx));
                 __put_user(major(st.st_dev), &target_stx->stx_dev_major);
@@ -18740,8 +18913,15 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
                 __put_user(st.st_ctime, &target_stx->stx_ctime.tv_sec);
                 unlock_user_struct(target_stx, arg5, 1);
             }
+statx_done:
+#ifdef CONFIG_LATX
+            latx_syscall_fs_unlock();
+            g_free(pathname_snapshot);
+#else
+            unlock_user(p, arg2, 0);
+#endif
+            return ret;
         }
-        return ret;
 #endif
 #ifdef TARGET_NR_lchown
     case TARGET_NR_lchown:
@@ -19205,7 +19385,13 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
             if (!p || !p2) {
                 ret = -TARGET_EFAULT;
             } else {
+#ifdef CONFIG_LATX
+                latx_syscall_fs_lock();
+#endif
                 ret = get_errno(safe_pivot_root(p, p2));
+#ifdef CONFIG_LATX
+                latx_syscall_fs_unlock();
+#endif
             }
             unlock_user(p2, arg2, 0);
             unlock_user(p, arg1, 0);

--- a/tests/integration/cef-procfs-chroot.S
+++ b/tests/integration/cef-procfs-chroot.S
@@ -1,0 +1,307 @@
+.equ __NR_close, 3
+.equ __NR_fstat, 5
+.equ __NR_exit, 60
+.equ __NR_chroot, 161
+.equ __NR_openat, 257
+.equ __NR_newfstatat, 262
+.equ __NR_unshare, 272
+.equ __NR_statx, 332
+.equ AT_FDCWD, -100
+.equ AT_EMPTY_PATH, 0x1000
+.equ O_RDONLY, 0
+.equ O_DIRECTORY, 0x10000
+.equ STATX_BASIC_STATS, 0x7ff
+.equ CLONE_NEWUSER, 0x10000000
+
+.section .rodata
+proc_root:
+    .asciz "/proc"
+chroot_path:
+    .asciz "/proc/self/fdinfo"
+relative_task:
+    .asciz "self/task"
+empty_path:
+    .asciz ""
+
+.section .bss
+.align 8
+statbuf:
+    .space 144
+.align 8
+statxbuf:
+    .space 256
+other_task_path:
+    .space 64
+
+.section .text
+.global _start
+.type _start, @function
+_start:
+    mov 16(%rsp), %rsi
+    lea other_task_path(%rip), %rdi
+.Lcopy_other_pid:
+    lodsb
+    test %al, %al
+    je .Lappend_task
+    stosb
+    jmp .Lcopy_other_pid
+.Lappend_task:
+    movb $'/', (%rdi)
+    movb $'t', 1(%rdi)
+    movb $'a', 2(%rdi)
+    movb $'s', 3(%rdi)
+    movb $'k', 4(%rdi)
+    movb $0, 5(%rdi)
+
+    xor %r15d, %r15d
+    mov 24(%rsp), %rsi
+.Lparse_other_nlink:
+    movzbl (%rsi), %eax
+    test %al, %al
+    je .Lother_nlink_ready
+    sub $'0', %eax
+    imul $10, %r15
+    add %rax, %r15
+    inc %rsi
+    jmp .Lparse_other_nlink
+.Lother_nlink_ready:
+    cmp $4, %r15
+    jb other_task_initial_count_failed
+
+    mov $__NR_openat, %eax
+    mov $AT_FDCWD, %edi
+    lea proc_root(%rip), %rsi
+    mov $(O_RDONLY | O_DIRECTORY), %edx
+    xor %r10d, %r10d
+    syscall
+    test %rax, %rax
+    js open_proc_failed
+    mov %eax, %r12d
+
+    mov $__NR_openat, %eax
+    mov %r12d, %edi
+    lea relative_task(%rip), %rsi
+    mov $(O_RDONLY | O_DIRECTORY), %edx
+    xor %r10d, %r10d
+    syscall
+    test %rax, %rax
+    js open_task_failed
+    mov %eax, %r13d
+
+    mov $__NR_openat, %eax
+    mov %r12d, %edi
+    lea other_task_path(%rip), %rsi
+    mov $(O_RDONLY | O_DIRECTORY), %edx
+    xor %r10d, %r10d
+    syscall
+    test %rax, %rax
+    js open_other_task_failed
+    mov %eax, %r14d
+
+    /* Starting the namespace sandbox also starts LATX's host RCU helper. */
+    mov $__NR_unshare, %eax
+    mov $CLONE_NEWUSER, %edi
+    syscall
+    test %rax, %rax
+    js unshare_failed
+
+    /* Chromium shares this chroot through CLONE_FS before probing procfd. */
+    mov $__NR_chroot, %eax
+    lea chroot_path(%rip), %rdi
+    syscall
+    test %rax, %rax
+    js chroot_failed
+
+    mov $__NR_newfstatat, %eax
+    mov %r12d, %edi
+    lea relative_task(%rip), %rsi
+    lea statbuf(%rip), %rdx
+    xor %r10d, %r10d
+    syscall
+    test %rax, %rax
+    js task_stat_failed
+
+    /* One guest thread must be reported as '.' + '..' + one task. */
+    cmpq $3, statbuf+16(%rip)
+    jne task_count_failed
+
+    mov $__NR_fstat, %eax
+    mov %r13d, %edi
+    lea statbuf(%rip), %rsi
+    syscall
+    test %rax, %rax
+    js task_fstat_failed
+    cmpq $3, statbuf+16(%rip)
+    jne task_fstat_count_failed
+
+    mov $__NR_newfstatat, %eax
+    mov %r13d, %edi
+    lea empty_path(%rip), %rsi
+    lea statbuf(%rip), %rdx
+    mov $AT_EMPTY_PATH, %r10d
+    syscall
+    test %rax, %rax
+    js task_empty_fstatat_failed
+    cmpq $3, statbuf+16(%rip)
+    jne task_empty_fstatat_count_failed
+
+    mov $__NR_statx, %eax
+    mov %r13d, %edi
+    lea empty_path(%rip), %rsi
+    mov $AT_EMPTY_PATH, %edx
+    mov $STATX_BASIC_STATS, %r10d
+    lea statxbuf(%rip), %r8
+    syscall
+    test %rax, %rax
+    js task_empty_statx_failed
+    cmpl $3, statxbuf+16(%rip)
+    jne task_empty_statx_count_failed
+
+    mov $__NR_statx, %eax
+    mov %r12d, %edi
+    lea relative_task(%rip), %rsi
+    xor %edx, %edx
+    mov $STATX_BASIC_STATS, %r10d
+    lea statxbuf(%rip), %r8
+    syscall
+    test %rax, %rax
+    js task_relative_statx_failed
+    cmpl $3, statxbuf+16(%rip)
+    jne task_relative_statx_count_failed
+
+    mov $__NR_fstat, %eax
+    mov %r14d, %edi
+    lea statbuf(%rip), %rsi
+    syscall
+    test %rax, %rax
+    js other_task_fstat_failed
+    cmp statbuf+16(%rip), %r15
+    jne other_task_fstat_rewritten
+
+    mov $__NR_newfstatat, %eax
+    mov %r14d, %edi
+    lea empty_path(%rip), %rsi
+    lea statbuf(%rip), %rdx
+    mov $AT_EMPTY_PATH, %r10d
+    syscall
+    test %rax, %rax
+    js other_task_empty_fstatat_failed
+    cmp statbuf+16(%rip), %r15
+    jne other_task_empty_fstatat_rewritten
+
+    mov $__NR_statx, %eax
+    mov %r14d, %edi
+    lea empty_path(%rip), %rsi
+    mov $AT_EMPTY_PATH, %edx
+    mov $STATX_BASIC_STATS, %r10d
+    lea statxbuf(%rip), %r8
+    syscall
+    test %rax, %rax
+    js other_task_empty_statx_failed
+    cmp statxbuf+16(%rip), %r15d
+    jne other_task_empty_statx_rewritten
+
+    mov $__NR_statx, %eax
+    mov %r12d, %edi
+    lea other_task_path(%rip), %rsi
+    xor %edx, %edx
+    mov $STATX_BASIC_STATS, %r10d
+    lea statxbuf(%rip), %r8
+    syscall
+    test %rax, %rax
+    js other_task_relative_statx_failed
+    cmp statxbuf+16(%rip), %r15d
+    jne other_task_relative_statx_rewritten
+
+    mov $__NR_close, %eax
+    mov %r14d, %edi
+    syscall
+
+    mov $__NR_close, %eax
+    mov %r13d, %edi
+    syscall
+
+    mov $__NR_close, %eax
+    mov %r12d, %edi
+    syscall
+    xor %edi, %edi
+    jmp exit
+
+open_proc_failed:
+    mov $30, %edi
+    jmp exit
+unshare_failed:
+    mov $31, %edi
+    jmp exit
+chroot_failed:
+    mov $32, %edi
+    jmp exit
+task_stat_failed:
+    mov $33, %edi
+    jmp exit
+task_count_failed:
+    mov $34, %edi
+    jmp exit
+open_task_failed:
+    mov $35, %edi
+    jmp exit
+task_fstat_failed:
+    mov $36, %edi
+    jmp exit
+task_fstat_count_failed:
+    mov $37, %edi
+    jmp exit
+task_empty_fstatat_failed:
+    mov $38, %edi
+    jmp exit
+task_empty_fstatat_count_failed:
+    mov $39, %edi
+    jmp exit
+task_empty_statx_failed:
+    mov $40, %edi
+    jmp exit
+task_empty_statx_count_failed:
+    mov $41, %edi
+    jmp exit
+open_other_task_failed:
+    mov $42, %edi
+    jmp exit
+other_task_initial_count_failed:
+    mov $44, %edi
+    jmp exit
+other_task_fstat_failed:
+    mov $45, %edi
+    jmp exit
+other_task_fstat_rewritten:
+    mov $46, %edi
+    jmp exit
+other_task_empty_fstatat_failed:
+    mov $47, %edi
+    jmp exit
+other_task_empty_fstatat_rewritten:
+    mov $48, %edi
+    jmp exit
+other_task_empty_statx_failed:
+    mov $49, %edi
+    jmp exit
+other_task_empty_statx_rewritten:
+    mov $50, %edi
+    jmp exit
+task_relative_statx_failed:
+    mov $51, %edi
+    jmp exit
+task_relative_statx_count_failed:
+    mov $52, %edi
+    jmp exit
+other_task_relative_statx_failed:
+    mov $53, %edi
+    jmp exit
+other_task_relative_statx_rewritten:
+    mov $54, %edi
+
+exit:
+    mov $__NR_exit, %eax
+    syscall
+.size _start, .-_start
+
+.section .note.GNU-stack,"",@progbits

--- a/tests/integration/cef-procfs-chroot.S
+++ b/tests/integration/cef-procfs-chroot.S
@@ -1,7 +1,15 @@
 .equ __NR_close, 3
+.equ __NR_stat, 4
 .equ __NR_fstat, 5
+.equ __NR_lstat, 6
+.equ __NR_sched_yield, 24
+.equ __NR_dup, 32
+.equ __NR_dup2, 33
+.equ __NR_clone, 56
 .equ __NR_exit, 60
+.equ __NR_fchdir, 81
 .equ __NR_chroot, 161
+.equ __NR_futex, 202
 .equ __NR_openat, 257
 .equ __NR_newfstatat, 262
 .equ __NR_unshare, 272
@@ -11,15 +19,37 @@
 .equ O_RDONLY, 0
 .equ O_DIRECTORY, 0x10000
 .equ STATX_BASIC_STATS, 0x7ff
+.equ CLONE_VM, 0x00000100
+.equ CLONE_FS, 0x00000200
+.equ CLONE_FILES, 0x00000400
+.equ CLONE_SIGHAND, 0x00000800
+.equ CLONE_THREAD, 0x00010000
+.equ CLONE_SYSVSEM, 0x00040000
+.equ CLONE_CHILD_CLEARTID, 0x00200000
+.equ CLONE_CHILD_SETTID, 0x01000000
+.equ CLONE_THREAD_FLAGS, (CLONE_VM | CLONE_FS | CLONE_FILES | CLONE_SIGHAND)
+.equ CLONE_TID_FLAGS, (CLONE_THREAD | CLONE_SYSVSEM | CLONE_CHILD_CLEARTID)
+.equ FUTEX_WAIT, 0
 .equ CLONE_NEWUSER, 0x10000000
+.equ RACE_ITERATIONS, 10000
 
 .section .rodata
 proc_root:
     .asciz "/proc"
+host_root:
+    .asciz "/"
+absolute_task:
+    .asciz "/proc/self/task"
 chroot_path:
     .asciz "/proc/self/fdinfo"
 relative_task:
     .asciz "self/task"
+self_path:
+    .asciz "self"
+task_path:
+    .asciz "task"
+dot_path:
+    .asciz "."
 empty_path:
     .asciz ""
 
@@ -32,6 +62,39 @@ statxbuf:
     .space 256
 other_task_path:
     .space 64
+self_fd:
+    .long 0
+.align 16
+race_stack:
+    .space 65536
+.align 4
+race_child_tid:
+    .long 0
+race_ready:
+    .long 0
+race_stop:
+    .long 0
+race_error:
+    .long 0
+race_result:
+    .long 0
+race_seen:
+    .long 0
+race_path_seen:
+    .long 0
+.align 8
+race_path:
+    .space 8
+race_fd:
+    .long 0
+self_nlink:
+    .quad 0
+root_fd:
+    .long 0
+chroot_fd:
+    .long 0
+root_race_seen:
+    .long 0
 
 .section .text
 .global _start
@@ -79,6 +142,26 @@ _start:
     mov %eax, %r12d
 
     mov $__NR_openat, %eax
+    mov $AT_FDCWD, %edi
+    lea host_root(%rip), %rsi
+    mov $(O_RDONLY | O_DIRECTORY), %edx
+    xor %r10d, %r10d
+    syscall
+    test %rax, %rax
+    js open_root_failed
+    mov %eax, root_fd(%rip)
+
+    mov $__NR_openat, %eax
+    mov $AT_FDCWD, %edi
+    lea chroot_path(%rip), %rsi
+    mov $(O_RDONLY | O_DIRECTORY), %edx
+    xor %r10d, %r10d
+    syscall
+    test %rax, %rax
+    js open_chroot_failed
+    mov %eax, chroot_fd(%rip)
+
+    mov $__NR_openat, %eax
     mov %r12d, %edi
     lea relative_task(%rip), %rsi
     mov $(O_RDONLY | O_DIRECTORY), %edx
@@ -90,6 +173,16 @@ _start:
 
     mov $__NR_openat, %eax
     mov %r12d, %edi
+    lea self_path(%rip), %rsi
+    mov $(O_RDONLY | O_DIRECTORY), %edx
+    xor %r10d, %r10d
+    syscall
+    test %rax, %rax
+    js open_self_failed
+    mov %eax, self_fd(%rip)
+
+    mov $__NR_openat, %eax
+    mov %r12d, %edi
     lea other_task_path(%rip), %rsi
     mov $(O_RDONLY | O_DIRECTORY), %edx
     xor %r10d, %r10d
@@ -97,6 +190,26 @@ _start:
     test %rax, %rax
     js open_other_task_failed
     mov %eax, %r14d
+
+    mov $__NR_openat, %eax
+    mov $AT_FDCWD, %edi
+    mov 32(%rsp), %rsi
+    mov $(O_RDONLY | O_DIRECTORY), %edx
+    xor %r10d, %r10d
+    syscall
+    test %rax, %rax
+    js open_ordinary_root_failed
+    mov %eax, %ebx
+
+    mov $__NR_openat, %eax
+    mov %ebx, %edi
+    lea relative_task(%rip), %rsi
+    mov $(O_RDONLY | O_DIRECTORY), %edx
+    xor %r10d, %r10d
+    syscall
+    test %rax, %rax
+    js open_ordinary_task_failed
+    mov %eax, %ebp
 
     /* Starting the namespace sandbox also starts LATX's host RCU helper. */
     mov $__NR_unshare, %eax
@@ -213,6 +326,498 @@ _start:
     cmp statxbuf+16(%rip), %r15d
     jne other_task_relative_statx_rewritten
 
+    mov $__NR_fchdir, %eax
+    mov %r12d, %edi
+    syscall
+    test %rax, %rax
+    js fchdir_proc_failed
+
+    mov $__NR_newfstatat, %eax
+    mov $AT_FDCWD, %edi
+    lea relative_task(%rip), %rsi
+    lea statbuf(%rip), %rdx
+    xor %r10d, %r10d
+    syscall
+    test %rax, %rax
+    js cwd_task_fstatat_failed
+    cmpq $3, statbuf+16(%rip)
+    jne cwd_task_fstatat_count_failed
+
+    mov $__NR_statx, %eax
+    mov $AT_FDCWD, %edi
+    lea relative_task(%rip), %rsi
+    xor %edx, %edx
+    mov $STATX_BASIC_STATS, %r10d
+    lea statxbuf(%rip), %r8
+    syscall
+    test %rax, %rax
+    js cwd_task_statx_failed
+    cmpl $3, statxbuf+16(%rip)
+    jne cwd_task_statx_count_failed
+
+    mov $__NR_newfstatat, %eax
+    mov $AT_FDCWD, %edi
+    lea other_task_path(%rip), %rsi
+    lea statbuf(%rip), %rdx
+    xor %r10d, %r10d
+    syscall
+    test %rax, %rax
+    js cwd_other_task_fstatat_failed
+    cmp statbuf+16(%rip), %r15
+    jne cwd_other_task_fstatat_rewritten
+
+    mov $__NR_statx, %eax
+    mov $AT_FDCWD, %edi
+    lea other_task_path(%rip), %rsi
+    xor %edx, %edx
+    mov $STATX_BASIC_STATS, %r10d
+    lea statxbuf(%rip), %r8
+    syscall
+    test %rax, %rax
+    js cwd_other_task_statx_failed
+    cmp statxbuf+16(%rip), %r15d
+    jne cwd_other_task_statx_rewritten
+
+    mov $__NR_fchdir, %eax
+    mov self_fd(%rip), %edi
+    syscall
+    test %rax, %rax
+    js fchdir_self_failed
+
+    mov $__NR_newfstatat, %eax
+    mov $AT_FDCWD, %edi
+    lea task_path(%rip), %rsi
+    lea statbuf(%rip), %rdx
+    xor %r10d, %r10d
+    syscall
+    test %rax, %rax
+    js cwd_self_task_fstatat_failed
+    cmpq $3, statbuf+16(%rip)
+    jne cwd_self_task_fstatat_count_failed
+
+    mov $__NR_statx, %eax
+    mov $AT_FDCWD, %edi
+    lea task_path(%rip), %rsi
+    xor %edx, %edx
+    mov $STATX_BASIC_STATS, %r10d
+    lea statxbuf(%rip), %r8
+    syscall
+    test %rax, %rax
+    js cwd_self_task_statx_failed
+    cmpl $3, statxbuf+16(%rip)
+    jne cwd_self_task_statx_count_failed
+
+    mov $__NR_fchdir, %eax
+    mov %r13d, %edi
+    syscall
+    test %rax, %rax
+    js fchdir_task_failed
+
+    mov $__NR_newfstatat, %eax
+    mov $AT_FDCWD, %edi
+    lea dot_path(%rip), %rsi
+    lea statbuf(%rip), %rdx
+    xor %r10d, %r10d
+    syscall
+    test %rax, %rax
+    js cwd_dot_task_fstatat_failed
+    cmpq $3, statbuf+16(%rip)
+    jne cwd_dot_task_fstatat_count_failed
+
+    mov $__NR_statx, %eax
+    mov $AT_FDCWD, %edi
+    lea dot_path(%rip), %rsi
+    xor %edx, %edx
+    mov $STATX_BASIC_STATS, %r10d
+    lea statxbuf(%rip), %r8
+    syscall
+    test %rax, %rax
+    js cwd_dot_task_statx_failed
+    cmpl $3, statxbuf+16(%rip)
+    jne cwd_dot_task_statx_count_failed
+
+    mov $__NR_newfstatat, %eax
+    mov $AT_FDCWD, %edi
+    lea empty_path(%rip), %rsi
+    lea statbuf(%rip), %rdx
+    mov $AT_EMPTY_PATH, %r10d
+    syscall
+    test %rax, %rax
+    js cwd_empty_task_fstatat_failed
+    cmpq $3, statbuf+16(%rip)
+    jne cwd_empty_task_fstatat_count_failed
+
+    mov $__NR_statx, %eax
+    mov $AT_FDCWD, %edi
+    lea empty_path(%rip), %rsi
+    mov $AT_EMPTY_PATH, %edx
+    mov $STATX_BASIC_STATS, %r10d
+    lea statxbuf(%rip), %r8
+    syscall
+    test %rax, %rax
+    js cwd_empty_task_statx_failed
+    cmpl $3, statxbuf+16(%rip)
+    jne cwd_empty_task_statx_count_failed
+
+    mov $__NR_fchdir, %eax
+    mov %r14d, %edi
+    syscall
+    test %rax, %rax
+    js fchdir_other_task_failed
+
+    mov $__NR_newfstatat, %eax
+    mov $AT_FDCWD, %edi
+    lea empty_path(%rip), %rsi
+    lea statbuf(%rip), %rdx
+    mov $AT_EMPTY_PATH, %r10d
+    syscall
+    test %rax, %rax
+    js cwd_empty_other_task_fstatat_failed
+    cmp statbuf+16(%rip), %r15
+    jne cwd_empty_other_task_fstatat_rewritten
+
+    mov $__NR_statx, %eax
+    mov $AT_FDCWD, %edi
+    lea empty_path(%rip), %rsi
+    mov $AT_EMPTY_PATH, %edx
+    mov $STATX_BASIC_STATS, %r10d
+    lea statxbuf(%rip), %r8
+    syscall
+    test %rax, %rax
+    js cwd_empty_other_task_statx_failed
+    cmp statxbuf+16(%rip), %r15d
+    jne cwd_empty_other_task_statx_rewritten
+
+    mov $__NR_fchdir, %eax
+    mov %ebx, %edi
+    syscall
+    test %rax, %rax
+    js fchdir_ordinary_root_failed
+
+    mov $__NR_newfstatat, %eax
+    mov $AT_FDCWD, %edi
+    lea relative_task(%rip), %rsi
+    lea statbuf(%rip), %rdx
+    xor %r10d, %r10d
+    syscall
+    test %rax, %rax
+    js cwd_ordinary_task_fstatat_failed
+    cmpq $2, statbuf+16(%rip)
+    jne cwd_ordinary_task_fstatat_rewritten
+
+    mov $__NR_statx, %eax
+    mov $AT_FDCWD, %edi
+    lea relative_task(%rip), %rsi
+    xor %edx, %edx
+    mov $STATX_BASIC_STATS, %r10d
+    lea statxbuf(%rip), %r8
+    syscall
+    test %rax, %rax
+    js cwd_ordinary_task_statx_failed
+    cmpl $2, statxbuf+16(%rip)
+    jne cwd_ordinary_task_statx_rewritten
+
+    mov $__NR_fchdir, %eax
+    mov %ebp, %edi
+    syscall
+    test %rax, %rax
+    js fchdir_ordinary_task_failed
+
+    mov $__NR_newfstatat, %eax
+    mov $AT_FDCWD, %edi
+    lea empty_path(%rip), %rsi
+    lea statbuf(%rip), %rdx
+    mov $AT_EMPTY_PATH, %r10d
+    syscall
+    test %rax, %rax
+    js cwd_empty_ordinary_task_fstatat_failed
+    cmpq $2, statbuf+16(%rip)
+    jne cwd_empty_ordinary_task_fstatat_rewritten
+
+    mov $__NR_statx, %eax
+    mov $AT_FDCWD, %edi
+    lea empty_path(%rip), %rsi
+    mov $AT_EMPTY_PATH, %edx
+    mov $STATX_BASIC_STATS, %r10d
+    lea statxbuf(%rip), %r8
+    syscall
+    test %rax, %rax
+    js cwd_empty_ordinary_task_statx_failed
+    cmpl $2, statxbuf+16(%rip)
+    jne cwd_empty_ordinary_task_statx_rewritten
+
+    mov $__NR_fstat, %eax
+    mov self_fd(%rip), %edi
+    lea statbuf(%rip), %rsi
+    syscall
+    test %rax, %rax
+    js race_self_fstat_failed
+    mov statbuf+16(%rip), %rax
+    mov %rax, self_nlink(%rip)
+
+    mov $__NR_dup, %eax
+    mov self_fd(%rip), %edi
+    syscall
+    test %rax, %rax
+    js race_dup_failed
+    mov %eax, race_fd(%rip)
+
+    /* Race cwd, dirfd, and pathname changes against the stat lookups. */
+    mov $__NR_clone, %eax
+    mov $(CLONE_THREAD_FLAGS | CLONE_TID_FLAGS | CLONE_CHILD_SETTID), %edi
+    lea race_stack+65536(%rip), %rsi
+    xor %edx, %edx
+    lea race_child_tid(%rip), %r10
+    xor %r8d, %r8d
+    syscall
+    test %rax, %rax
+    js race_clone_failed
+    jz cwd_racer
+
+.Lwait_racer_ready:
+    cmpl $1, race_ready(%rip)
+    jne .Lwait_racer_ready
+
+    mov $RACE_ITERATIONS, %r9d
+.Lrace_stat_loop:
+    mov $__NR_newfstatat, %eax
+    mov $AT_FDCWD, %edi
+    lea task_path(%rip), %rsi
+    lea statbuf(%rip), %rdx
+    xor %r10d, %r10d
+    syscall
+    test %rax, %rax
+    js race_fstatat_failed
+    cmpq $2, statbuf+16(%rip)
+    jne .Lrace_fstatat_proc
+    orl $1, race_seen(%rip)
+    jmp .Lrace_statx
+.Lrace_fstatat_proc:
+    cmpq $4, statbuf+16(%rip)
+    jne race_fstatat_count_failed
+    orl $2, race_seen(%rip)
+
+.Lrace_statx:
+    mov $__NR_statx, %eax
+    mov $AT_FDCWD, %edi
+    lea task_path(%rip), %rsi
+    xor %edx, %edx
+    mov $STATX_BASIC_STATS, %r10d
+    lea statxbuf(%rip), %r8
+    syscall
+    test %rax, %rax
+    js race_statx_failed
+    cmpl $2, statxbuf+16(%rip)
+    jne .Lrace_statx_proc
+    orl $1, race_seen(%rip)
+    jmp .Lrace_dirfd_fstatat
+.Lrace_statx_proc:
+    cmpl $4, statxbuf+16(%rip)
+    jne race_statx_count_failed
+    orl $2, race_seen(%rip)
+
+.Lrace_dirfd_fstatat:
+    mov $__NR_newfstatat, %eax
+    mov race_fd(%rip), %edi
+    lea task_path(%rip), %rsi
+    lea statbuf(%rip), %rdx
+    xor %r10d, %r10d
+    syscall
+    test %rax, %rax
+    js race_dirfd_fstatat_failed
+    cmpq $2, statbuf+16(%rip)
+    je .Lrace_dirfd_statx
+    cmpq $4, statbuf+16(%rip)
+    jne race_dirfd_fstatat_count_failed
+
+.Lrace_dirfd_statx:
+    mov $__NR_statx, %eax
+    mov race_fd(%rip), %edi
+    lea task_path(%rip), %rsi
+    xor %edx, %edx
+    mov $STATX_BASIC_STATS, %r10d
+    lea statxbuf(%rip), %r8
+    syscall
+    test %rax, %rax
+    js race_dirfd_statx_failed
+    cmpl $2, statxbuf+16(%rip)
+    je .Lrace_path_fstatat
+    cmpl $4, statxbuf+16(%rip)
+    jne race_dirfd_statx_count_failed
+
+.Lrace_path_fstatat:
+    mov $__NR_newfstatat, %eax
+    mov self_fd(%rip), %edi
+    lea race_path(%rip), %rsi
+    lea statbuf(%rip), %rdx
+    xor %r10d, %r10d
+    syscall
+    test %rax, %rax
+    js race_path_fstatat_failed
+    cmpq $4, statbuf+16(%rip)
+    jne .Lrace_path_fstatat_self
+    orl $1, race_path_seen(%rip)
+    jmp .Lrace_path_statx
+.Lrace_path_fstatat_self:
+    mov self_nlink(%rip), %rax
+    cmp %rax, statbuf+16(%rip)
+    jne race_path_fstatat_count_failed
+    orl $2, race_path_seen(%rip)
+
+.Lrace_path_statx:
+    mov $__NR_statx, %eax
+    mov self_fd(%rip), %edi
+    lea race_path(%rip), %rsi
+    xor %edx, %edx
+    mov $STATX_BASIC_STATS, %r10d
+    lea statxbuf(%rip), %r8
+    syscall
+    test %rax, %rax
+    js race_path_statx_failed
+    cmpl $4, statxbuf+16(%rip)
+    jne .Lrace_path_statx_self
+    orl $1, race_path_seen(%rip)
+    jmp .Lrace_next
+.Lrace_path_statx_self:
+    mov self_nlink(%rip), %eax
+    cmp %eax, statxbuf+16(%rip)
+    jne race_path_statx_count_failed
+    orl $2, race_path_seen(%rip)
+
+.Lrace_next:
+    mov $__NR_sched_yield, %eax
+    syscall
+    dec %r9d
+    jne .Lrace_stat_loop
+    movl $1, race_stop(%rip)
+
+.Lwait_racer_stopped:
+    mov race_child_tid(%rip), %edx
+    test %edx, %edx
+    jz .Lracer_stopped
+    mov $__NR_futex, %eax
+    lea race_child_tid(%rip), %rdi
+    mov $FUTEX_WAIT, %esi
+    xor %r10d, %r10d
+    xor %r8d, %r8d
+    xor %r9d, %r9d
+    syscall
+    jmp .Lwait_racer_stopped
+
+.Lracer_stopped:
+    cmpl $1, race_error(%rip)
+    je race_fchdir_failed
+    cmpl $2, race_error(%rip)
+    je race_dup2_failed
+    cmpl $3, race_seen(%rip)
+    jne race_coverage_failed
+    cmpl $3, race_path_seen(%rip)
+    jne race_path_coverage_failed
+
+    movl $0, race_child_tid(%rip)
+    movl $0, race_ready(%rip)
+    movl $0, race_stop(%rip)
+    movl $0, race_error(%rip)
+
+    /* Race absolute stat lookups against repeated root changes. */
+    mov $__NR_clone, %eax
+    mov $(CLONE_THREAD_FLAGS | CLONE_TID_FLAGS | CLONE_CHILD_SETTID), %edi
+    lea race_stack+65536(%rip), %rsi
+    xor %edx, %edx
+    lea race_child_tid(%rip), %r10
+    xor %r8d, %r8d
+    syscall
+    test %rax, %rax
+    js root_race_clone_failed
+    jz root_racer
+
+.Lwait_root_racer_ready:
+    cmpl $1, race_ready(%rip)
+    jne .Lwait_root_racer_ready
+
+    mov $RACE_ITERATIONS, %r9d
+.Lroot_race_loop:
+    mov $__NR_stat, %eax
+    lea absolute_task(%rip), %rdi
+    lea statbuf(%rip), %rsi
+    syscall
+    test %rax, %rax
+    js .Lroot_race_stat_error
+    cmpq $4, statbuf+16(%rip)
+    jne root_race_stat_count_failed
+    orl $1, root_race_seen(%rip)
+    jmp .Lroot_race_lstat
+.Lroot_race_stat_error:
+    cmp $-2, %rax
+    jne root_race_stat_failed
+    orl $2, root_race_seen(%rip)
+
+.Lroot_race_lstat:
+    mov $__NR_lstat, %eax
+    lea absolute_task(%rip), %rdi
+    lea statbuf(%rip), %rsi
+    syscall
+    test %rax, %rax
+    js .Lroot_race_lstat_error
+    cmpq $4, statbuf+16(%rip)
+    jne root_race_lstat_count_failed
+    orl $1, root_race_seen(%rip)
+    jmp .Lroot_race_next
+.Lroot_race_lstat_error:
+    cmp $-2, %rax
+    jne root_race_lstat_failed
+    orl $2, root_race_seen(%rip)
+
+.Lroot_race_next:
+    mov $__NR_sched_yield, %eax
+    syscall
+    dec %r9d
+    jne .Lroot_race_loop
+    movl $1, race_stop(%rip)
+
+.Lwait_root_racer_stopped:
+    mov race_child_tid(%rip), %edx
+    test %edx, %edx
+    jz .Lroot_racer_stopped
+    mov $__NR_futex, %eax
+    lea race_child_tid(%rip), %rdi
+    mov $FUTEX_WAIT, %esi
+    xor %r10d, %r10d
+    xor %r8d, %r8d
+    xor %r9d, %r9d
+    syscall
+    jmp .Lwait_root_racer_stopped
+
+.Lroot_racer_stopped:
+    cmpl $0, race_error(%rip)
+    jne root_race_chroot_failed
+    cmpl $3, root_race_seen(%rip)
+    jne root_race_coverage_failed
+
+    mov $__NR_close, %eax
+    mov race_fd(%rip), %edi
+    syscall
+
+    mov $__NR_close, %eax
+    mov chroot_fd(%rip), %edi
+    syscall
+
+    mov $__NR_close, %eax
+    mov root_fd(%rip), %edi
+    syscall
+
+    mov $__NR_close, %eax
+    mov %ebp, %edi
+    syscall
+
+    mov $__NR_close, %eax
+    mov %ebx, %edi
+    syscall
+
+    mov $__NR_close, %eax
+    mov self_fd(%rip), %edi
+    syscall
+
     mov $__NR_close, %eax
     mov %r14d, %edi
     syscall
@@ -225,6 +830,140 @@ _start:
     mov %r12d, %edi
     syscall
     xor %edi, %edi
+    jmp exit
+
+cwd_racer:
+    mov $__NR_fchdir, %eax
+    mov self_fd(%rip), %edi
+    syscall
+    test %rax, %rax
+    js .Lcwd_racer_start_failed
+    mov $__NR_dup2, %eax
+    mov self_fd(%rip), %edi
+    mov race_fd(%rip), %esi
+    syscall
+    test %rax, %rax
+    js .Lcwd_racer_dup_failed
+    movabs $0x002f2e2f6b736174, %rax
+    mov %rax, race_path(%rip)
+    movl $1, race_ready(%rip)
+.Lcwd_racer_loop:
+    cmpl $1, race_stop(%rip)
+    je .Lcwd_racer_exit
+    mov $__NR_fchdir, %eax
+    mov self_fd(%rip), %edi
+    syscall
+    test %rax, %rax
+    js .Lcwd_racer_failed
+    mov $__NR_dup2, %eax
+    mov self_fd(%rip), %edi
+    mov race_fd(%rip), %esi
+    syscall
+    test %rax, %rax
+    js .Lcwd_racer_dup_failed
+    movb $'/', race_path+6(%rip)
+    mov $__NR_sched_yield, %eax
+    syscall
+    mov $__NR_fchdir, %eax
+    mov %ebx, %edi
+    syscall
+    test %rax, %rax
+    js .Lcwd_racer_failed
+    mov $__NR_dup2, %eax
+    mov %ebx, %edi
+    mov race_fd(%rip), %esi
+    syscall
+    test %rax, %rax
+    js .Lcwd_racer_dup_failed
+    movb $'.', race_path+6(%rip)
+    mov $__NR_sched_yield, %eax
+    syscall
+    jmp .Lcwd_racer_loop
+
+.Lcwd_racer_failed:
+    movl $1, race_error(%rip)
+.Lcwd_racer_exit:
+    xor %edi, %edi
+    jmp exit
+
+.Lcwd_racer_start_failed:
+    movl $1, race_error(%rip)
+    movl $1, race_ready(%rip)
+    jmp .Lcwd_racer_exit
+
+.Lcwd_racer_dup_failed:
+    movl $2, race_error(%rip)
+    movl $1, race_ready(%rip)
+    jmp .Lcwd_racer_exit
+
+root_racer:
+    call restore_host_root
+    test %rax, %rax
+    js .Lroot_racer_start_failed
+    movl $1, race_ready(%rip)
+.Lroot_racer_loop:
+    cmpl $1, race_stop(%rip)
+    je .Lroot_racer_exit
+    call restore_host_root
+    test %rax, %rax
+    js .Lroot_racer_failed
+    mov $__NR_sched_yield, %eax
+    syscall
+    mov $__NR_fchdir, %eax
+    mov chroot_fd(%rip), %edi
+    syscall
+    test %rax, %rax
+    js .Lroot_racer_failed
+    mov $__NR_chroot, %eax
+    lea dot_path(%rip), %rdi
+    syscall
+    test %rax, %rax
+    js .Lroot_racer_failed
+    mov $__NR_sched_yield, %eax
+    syscall
+    jmp .Lroot_racer_loop
+
+.Lroot_racer_failed:
+    movl $1, race_error(%rip)
+.Lroot_racer_exit:
+    call restore_host_root
+    xor %edi, %edi
+    jmp exit
+
+.Lroot_racer_start_failed:
+    movl $1, race_error(%rip)
+    movl $1, race_ready(%rip)
+    jmp .Lroot_racer_exit
+
+restore_host_root:
+    mov $__NR_fchdir, %eax
+    mov root_fd(%rip), %edi
+    syscall
+    test %rax, %rax
+    js .Lrestore_host_root_done
+    mov $__NR_chroot, %eax
+    lea dot_path(%rip), %rdi
+    syscall
+.Lrestore_host_root_done:
+    ret
+
+.Lstop_racer_after_error:
+    mov %edi, race_result(%rip)
+    movl $1, race_stop(%rip)
+.Lwait_racer_after_error:
+    mov race_child_tid(%rip), %edx
+    test %edx, %edx
+    jz .Lreturn_race_error
+    mov $__NR_futex, %eax
+    lea race_child_tid(%rip), %rdi
+    mov $FUTEX_WAIT, %esi
+    xor %r10d, %r10d
+    xor %r8d, %r8d
+    xor %r9d, %r9d
+    syscall
+    jmp .Lwait_racer_after_error
+.Lreturn_race_error:
+    mov race_result(%rip), %edi
     jmp exit
 
 open_proc_failed:
@@ -298,6 +1037,213 @@ other_task_relative_statx_failed:
     jmp exit
 other_task_relative_statx_rewritten:
     mov $54, %edi
+    jmp exit
+open_ordinary_root_failed:
+    mov $55, %edi
+    jmp exit
+open_ordinary_task_failed:
+    mov $56, %edi
+    jmp exit
+fchdir_proc_failed:
+    mov $57, %edi
+    jmp exit
+cwd_task_fstatat_failed:
+    mov $58, %edi
+    jmp exit
+cwd_task_fstatat_count_failed:
+    mov $59, %edi
+    jmp exit
+cwd_task_statx_failed:
+    mov $60, %edi
+    jmp exit
+cwd_task_statx_count_failed:
+    mov $61, %edi
+    jmp exit
+cwd_other_task_fstatat_failed:
+    mov $62, %edi
+    jmp exit
+cwd_other_task_fstatat_rewritten:
+    mov $63, %edi
+    jmp exit
+cwd_other_task_statx_failed:
+    mov $64, %edi
+    jmp exit
+cwd_other_task_statx_rewritten:
+    mov $65, %edi
+    jmp exit
+fchdir_task_failed:
+    mov $66, %edi
+    jmp exit
+cwd_empty_task_fstatat_failed:
+    mov $67, %edi
+    jmp exit
+cwd_empty_task_fstatat_count_failed:
+    mov $68, %edi
+    jmp exit
+cwd_empty_task_statx_failed:
+    mov $69, %edi
+    jmp exit
+cwd_empty_task_statx_count_failed:
+    mov $70, %edi
+    jmp exit
+fchdir_other_task_failed:
+    mov $71, %edi
+    jmp exit
+cwd_empty_other_task_fstatat_failed:
+    mov $72, %edi
+    jmp exit
+cwd_empty_other_task_fstatat_rewritten:
+    mov $73, %edi
+    jmp exit
+cwd_empty_other_task_statx_failed:
+    mov $74, %edi
+    jmp exit
+cwd_empty_other_task_statx_rewritten:
+    mov $75, %edi
+    jmp exit
+fchdir_ordinary_root_failed:
+    mov $76, %edi
+    jmp exit
+cwd_ordinary_task_fstatat_failed:
+    mov $77, %edi
+    jmp exit
+cwd_ordinary_task_fstatat_rewritten:
+    mov $78, %edi
+    jmp exit
+cwd_ordinary_task_statx_failed:
+    mov $79, %edi
+    jmp exit
+cwd_ordinary_task_statx_rewritten:
+    mov $80, %edi
+    jmp exit
+fchdir_ordinary_task_failed:
+    mov $81, %edi
+    jmp exit
+cwd_empty_ordinary_task_fstatat_failed:
+    mov $82, %edi
+    jmp exit
+cwd_empty_ordinary_task_fstatat_rewritten:
+    mov $83, %edi
+    jmp exit
+cwd_empty_ordinary_task_statx_failed:
+    mov $84, %edi
+    jmp exit
+cwd_empty_ordinary_task_statx_rewritten:
+    mov $85, %edi
+    jmp exit
+open_self_failed:
+    mov $86, %edi
+    jmp exit
+fchdir_self_failed:
+    mov $87, %edi
+    jmp exit
+cwd_self_task_fstatat_failed:
+    mov $88, %edi
+    jmp exit
+cwd_self_task_fstatat_count_failed:
+    mov $89, %edi
+    jmp exit
+cwd_self_task_statx_failed:
+    mov $90, %edi
+    jmp exit
+cwd_self_task_statx_count_failed:
+    mov $91, %edi
+    jmp exit
+cwd_dot_task_fstatat_failed:
+    mov $92, %edi
+    jmp exit
+cwd_dot_task_fstatat_count_failed:
+    mov $93, %edi
+    jmp exit
+cwd_dot_task_statx_failed:
+    mov $94, %edi
+    jmp exit
+cwd_dot_task_statx_count_failed:
+    mov $95, %edi
+    jmp exit
+race_clone_failed:
+    mov $96, %edi
+    jmp exit
+race_fstatat_failed:
+    mov $97, %edi
+    jmp .Lstop_racer_after_error
+race_fstatat_count_failed:
+    mov $98, %edi
+    jmp .Lstop_racer_after_error
+race_statx_failed:
+    mov $99, %edi
+    jmp .Lstop_racer_after_error
+race_statx_count_failed:
+    mov $100, %edi
+    jmp .Lstop_racer_after_error
+race_fchdir_failed:
+    mov $101, %edi
+    jmp exit
+race_coverage_failed:
+    mov $102, %edi
+    jmp exit
+race_dirfd_fstatat_failed:
+    mov $103, %edi
+    jmp .Lstop_racer_after_error
+race_dirfd_fstatat_count_failed:
+    mov $104, %edi
+    jmp .Lstop_racer_after_error
+race_dirfd_statx_failed:
+    mov $105, %edi
+    jmp .Lstop_racer_after_error
+race_dirfd_statx_count_failed:
+    mov $106, %edi
+    jmp .Lstop_racer_after_error
+race_dup_failed:
+    mov $107, %edi
+    jmp exit
+race_dup2_failed:
+    mov $108, %edi
+    jmp exit
+race_self_fstat_failed:
+    mov $109, %edi
+    jmp exit
+race_path_fstatat_failed:
+    mov $110, %edi
+    jmp .Lstop_racer_after_error
+race_path_fstatat_count_failed:
+    mov $111, %edi
+    jmp .Lstop_racer_after_error
+race_path_statx_failed:
+    mov $112, %edi
+    jmp .Lstop_racer_after_error
+race_path_statx_count_failed:
+    mov $113, %edi
+    jmp .Lstop_racer_after_error
+race_path_coverage_failed:
+    mov $114, %edi
+    jmp exit
+open_root_failed:
+    mov $115, %edi
+    jmp exit
+open_chroot_failed:
+    mov $116, %edi
+    jmp exit
+root_race_clone_failed:
+    mov $117, %edi
+    jmp exit
+root_race_stat_failed:
+    mov $118, %edi
+    jmp .Lstop_racer_after_error
+root_race_stat_count_failed:
+    mov $119, %edi
+    jmp .Lstop_racer_after_error
+root_race_lstat_failed:
+    mov $120, %edi
+    jmp .Lstop_racer_after_error
+root_race_lstat_count_failed:
+    mov $121, %edi
+    jmp .Lstop_racer_after_error
+root_race_chroot_failed:
+    mov $122, %edi
+    jmp exit
+root_race_coverage_failed:
+    mov $123, %edi
 
 exit:
     mov $__NR_exit, %eax

--- a/tests/integration/cef-procfs-other-task.c
+++ b/tests/integration/cef-procfs-other-task.c
@@ -1,0 +1,24 @@
+#include <pthread.h>
+#include <signal.h>
+#include <unistd.h>
+
+static void *wait_forever(void *opaque)
+{
+    (void)opaque;
+    for (;;) {
+        pause();
+    }
+    return NULL;
+}
+
+int main(void)
+{
+    pthread_t thread;
+
+    if (pthread_create(&thread, NULL, wait_forever, NULL) != 0) {
+        return 1;
+    }
+
+    raise(SIGSTOP);
+    return 1;
+}

--- a/tests/integration/registrations/sandbox/meson.build
+++ b/tests/integration/registrations/sandbox/meson.build
@@ -1,5 +1,14 @@
 if 'x86_64-linux-user' in target_dirs
   latx_integration_tests += [{
+    'name': 'test-cef-procfs-chroot',
+    'runner': find_program('../../test-cef-procfs-chroot.sh'),
+    'args': [
+      emulators['latx-x86_64'],
+      files('../../cef-procfs-chroot.S'),
+      files('../../cef-procfs-other-task.c'),
+    ],
+  }]
+  latx_integration_tests += [{
     'name': 'test-cef-userns-nested',
     'runner': find_program('../../test-cef-userns-nested.sh'),
     'args': [

--- a/tests/integration/test-cef-procfs-chroot.sh
+++ b/tests/integration/test-cef-procfs-chroot.sh
@@ -1,0 +1,141 @@
+#!/bin/sh
+set -eu
+
+emulator=$1
+source_file=$2
+helper_source=$3
+workdir=$(mktemp -d)
+helper_pid=
+helper_nlink=
+
+cleanup()
+{
+    if [ -n "$helper_pid" ]; then
+        kill -KILL "$helper_pid" 2>/dev/null || true
+        wait "$helper_pid" 2>/dev/null || true
+    fi
+    rm -rf "$workdir"
+}
+trap cleanup EXIT HUP INT TERM
+
+if ! command -v unshare >/dev/null 2>&1 || ! unshare -Ur true 2>/dev/null; then
+    echo "SKIP: unprivileged user namespaces are unavailable"
+    exit 77
+fi
+
+if command -v clang-19 >/dev/null 2>&1; then
+    clang=clang-19
+elif command -v clang >/dev/null 2>&1; then
+    clang=clang
+else
+    echo "SKIP: clang is required to build the x86_64 guest"
+    exit 77
+fi
+
+"$clang" --target=x86_64-linux-gnu -fuse-ld=lld -nostdlib -static \
+    -Wl,--build-id=none "$source_file" -o "$workdir/cef-procfs-chroot"
+
+"${CC:-cc}" -Wall -Wextra -Werror -pthread "$helper_source" \
+    -o "$workdir/cef-procfs-other-task"
+"$workdir/cef-procfs-other-task" &
+helper_pid=$!
+
+i=0
+while [ "$(stat -c %h "/proc/$helper_pid/task")" -lt 4 ]; do
+    if ! kill -0 "$helper_pid" 2>/dev/null || [ "$i" -ge 100 ]; then
+        echo "FAIL: native helper did not start two threads" >&2
+        exit 1
+    fi
+    i=$((i + 1))
+    sleep 0.05
+done
+helper_nlink=$(stat -c %h "/proc/$helper_pid/task")
+
+set +e
+SBX_USER_NS=1 LATX_AOT=0 LATX_KZT=0 \
+    "$emulator" "$workdir/cef-procfs-chroot" "$helper_pid" "$helper_nlink"
+ret=$?
+set -e
+
+case $ret in
+0)
+    echo "PASS: procfd hides translator threads after sandbox chroot"
+    ;;
+30)
+    echo "FAIL: opening /proc failed" >&2
+    ;;
+31)
+    echo "FAIL: unshare(CLONE_NEWUSER) failed" >&2
+    ;;
+32)
+    echo "FAIL: sandbox chroot failed" >&2
+    ;;
+33)
+    echo "FAIL: fstatat relative to the saved procfd failed" >&2
+    ;;
+34)
+    echo "FAIL: procfd exposed translator-only threads after chroot" >&2
+    ;;
+35)
+    echo "FAIL: opening /proc/self/task relative to the saved procfd failed" >&2
+    ;;
+36)
+    echo "FAIL: fstat on the saved task fd failed after chroot" >&2
+    ;;
+37)
+    echo "FAIL: fstat on the saved task fd exposed translator-only threads" >&2
+    ;;
+38)
+    echo "FAIL: fstatat(AT_EMPTY_PATH) on the saved task fd failed" >&2
+    ;;
+39)
+    echo "FAIL: fstatat(AT_EMPTY_PATH) exposed translator-only threads" >&2
+    ;;
+40)
+    echo "FAIL: statx(AT_EMPTY_PATH) on the saved task fd failed" >&2
+    ;;
+41)
+    echo "FAIL: statx(AT_EMPTY_PATH) exposed translator-only threads" >&2
+    ;;
+42)
+    echo "FAIL: opening another process task directory failed" >&2
+    ;;
+44)
+    echo "FAIL: invalid native helper task link count" >&2
+    ;;
+45)
+    echo "FAIL: fstat on another process task fd failed after chroot" >&2
+    ;;
+46)
+    echo "FAIL: fstat rewrote another process task count" >&2
+    ;;
+47)
+    echo "FAIL: fstatat(AT_EMPTY_PATH) on another task fd failed" >&2
+    ;;
+48)
+    echo "FAIL: fstatat(AT_EMPTY_PATH) rewrote another task count" >&2
+    ;;
+49)
+    echo "FAIL: statx(AT_EMPTY_PATH) on another task fd failed" >&2
+    ;;
+50)
+    echo "FAIL: statx(AT_EMPTY_PATH) rewrote another task count" >&2
+    ;;
+51)
+    echo "FAIL: statx relative to the saved procfd failed" >&2
+    ;;
+52)
+    echo "FAIL: relative statx exposed translator-only threads" >&2
+    ;;
+53)
+    echo "FAIL: relative statx on another task directory failed" >&2
+    ;;
+54)
+    echo "FAIL: relative statx rewrote another task count" >&2
+    ;;
+*)
+    echo "FAIL: unexpected guest exit status $ret" >&2
+    ;;
+esac
+
+exit "$ret"

--- a/tests/integration/test-cef-procfs-chroot.sh
+++ b/tests/integration/test-cef-procfs-chroot.sh
@@ -7,6 +7,7 @@ helper_source=$3
 workdir=$(mktemp -d)
 helper_pid=
 helper_nlink=
+ordinary_root="$workdir/ordinary"
 
 cleanup()
 {
@@ -39,6 +40,7 @@ fi
     -o "$workdir/cef-procfs-other-task"
 "$workdir/cef-procfs-other-task" &
 helper_pid=$!
+mkdir -p "$ordinary_root/self/task" "$ordinary_root/task"
 
 i=0
 while [ "$(stat -c %h "/proc/$helper_pid/task")" -lt 4 ]; do
@@ -53,7 +55,8 @@ helper_nlink=$(stat -c %h "/proc/$helper_pid/task")
 
 set +e
 SBX_USER_NS=1 LATX_AOT=0 LATX_KZT=0 \
-    "$emulator" "$workdir/cef-procfs-chroot" "$helper_pid" "$helper_nlink"
+    "$emulator" "$workdir/cef-procfs-chroot" "$helper_pid" "$helper_nlink" \
+    "$ordinary_root"
 ret=$?
 set -e
 
@@ -132,6 +135,213 @@ case $ret in
     ;;
 54)
     echo "FAIL: relative statx rewrote another task count" >&2
+    ;;
+55)
+    echo "FAIL: opening the ordinary directory root failed" >&2
+    ;;
+56)
+    echo "FAIL: opening the ordinary self/task directory failed" >&2
+    ;;
+57)
+    echo "FAIL: fchdir to the saved procfd failed" >&2
+    ;;
+58)
+    echo "FAIL: fstatat relative to AT_FDCWD failed" >&2
+    ;;
+59)
+    echo "FAIL: relative AT_FDCWD fstatat exposed translator threads" >&2
+    ;;
+60)
+    echo "FAIL: statx relative to AT_FDCWD failed" >&2
+    ;;
+61)
+    echo "FAIL: relative AT_FDCWD statx exposed translator threads" >&2
+    ;;
+62)
+    echo "FAIL: relative AT_FDCWD fstatat on another task failed" >&2
+    ;;
+63)
+    echo "FAIL: relative AT_FDCWD fstatat rewrote another task" >&2
+    ;;
+64)
+    echo "FAIL: relative AT_FDCWD statx on another task failed" >&2
+    ;;
+65)
+    echo "FAIL: relative AT_FDCWD statx rewrote another task" >&2
+    ;;
+66)
+    echo "FAIL: fchdir to the saved self-task fd failed" >&2
+    ;;
+67)
+    echo "FAIL: AT_EMPTY_PATH fstatat through AT_FDCWD failed" >&2
+    ;;
+68)
+    echo "FAIL: AT_FDCWD empty-path fstatat exposed translator threads" >&2
+    ;;
+69)
+    echo "FAIL: AT_EMPTY_PATH statx through AT_FDCWD failed" >&2
+    ;;
+70)
+    echo "FAIL: AT_FDCWD empty-path statx exposed translator threads" >&2
+    ;;
+71)
+    echo "FAIL: fchdir to another process task fd failed" >&2
+    ;;
+72)
+    echo "FAIL: AT_FDCWD empty-path fstatat on another task failed" >&2
+    ;;
+73)
+    echo "FAIL: AT_FDCWD empty-path fstatat rewrote another task" >&2
+    ;;
+74)
+    echo "FAIL: AT_FDCWD empty-path statx on another task failed" >&2
+    ;;
+75)
+    echo "FAIL: AT_FDCWD empty-path statx rewrote another task" >&2
+    ;;
+76)
+    echo "FAIL: fchdir to the ordinary directory root failed" >&2
+    ;;
+77)
+    echo "FAIL: relative fstatat on an ordinary directory failed" >&2
+    ;;
+78)
+    echo "FAIL: relative AT_FDCWD fstatat rewrote an ordinary directory" >&2
+    ;;
+79)
+    echo "FAIL: relative statx on an ordinary directory failed" >&2
+    ;;
+80)
+    echo "FAIL: relative AT_FDCWD statx rewrote an ordinary directory" >&2
+    ;;
+81)
+    echo "FAIL: fchdir to the ordinary self/task directory failed" >&2
+    ;;
+82)
+    echo "FAIL: empty-path fstatat on an ordinary directory failed" >&2
+    ;;
+83)
+    echo "FAIL: empty-path AT_FDCWD fstatat rewrote an ordinary directory" >&2
+    ;;
+84)
+    echo "FAIL: empty-path statx on an ordinary directory failed" >&2
+    ;;
+85)
+    echo "FAIL: empty-path AT_FDCWD statx rewrote an ordinary directory" >&2
+    ;;
+86)
+    echo "FAIL: opening /proc/self relative to the saved procfd failed" >&2
+    ;;
+87)
+    echo "FAIL: fchdir to the saved /proc/self fd failed" >&2
+    ;;
+88)
+    echo "FAIL: fstatat of task relative to /proc/self failed" >&2
+    ;;
+89)
+    echo "FAIL: /proc/self-relative fstatat exposed translator threads" >&2
+    ;;
+90)
+    echo "FAIL: statx of task relative to /proc/self failed" >&2
+    ;;
+91)
+    echo "FAIL: /proc/self-relative statx exposed translator threads" >&2
+    ;;
+92)
+    echo "FAIL: fstatat of dot from /proc/self/task failed" >&2
+    ;;
+93)
+    echo "FAIL: dot-relative fstatat exposed translator threads" >&2
+    ;;
+94)
+    echo "FAIL: statx of dot from /proc/self/task failed" >&2
+    ;;
+95)
+    echo "FAIL: dot-relative statx exposed translator threads" >&2
+    ;;
+96)
+    echo "FAIL: cloning the cwd-racing guest thread failed" >&2
+    ;;
+97)
+    echo "FAIL: fstatat failed while another thread changed cwd" >&2
+    ;;
+98)
+    echo "FAIL: racing fstatat returned an invalid task link count" >&2
+    ;;
+99)
+    echo "FAIL: statx failed while another thread changed cwd" >&2
+    ;;
+100)
+    echo "FAIL: racing statx returned an invalid task link count" >&2
+    ;;
+101)
+    echo "FAIL: the cwd-racing guest thread could not change cwd" >&2
+    ;;
+102)
+    echo "FAIL: cwd race missed a task-directory case" >&2
+    ;;
+103)
+    echo "FAIL: fstatat failed while another thread replaced dirfd" >&2
+    ;;
+104)
+    echo "FAIL: racing dirfd fstatat returned an invalid link count" >&2
+    ;;
+105)
+    echo "FAIL: statx failed while another thread replaced dirfd" >&2
+    ;;
+106)
+    echo "FAIL: racing dirfd statx returned an invalid link count" >&2
+    ;;
+107)
+    echo "FAIL: duplicating the race dirfd failed" >&2
+    ;;
+108)
+    echo "FAIL: the racing guest thread could not replace dirfd" >&2
+    ;;
+109)
+    echo "FAIL: fstat on /proc/self before the race failed" >&2
+    ;;
+110)
+    echo "FAIL: fstatat failed while another thread changed pathname" >&2
+    ;;
+111)
+    echo "FAIL: racing pathname fstatat returned an invalid link count" >&2
+    ;;
+112)
+    echo "FAIL: statx failed while another thread changed pathname" >&2
+    ;;
+113)
+    echo "FAIL: racing pathname statx returned an invalid link count" >&2
+    ;;
+114)
+    echo "FAIL: pathname race missed one of the valid target paths" >&2
+    ;;
+115)
+    echo "FAIL: opening the host root failed" >&2
+    ;;
+116)
+    echo "FAIL: opening the sandbox root failed" >&2
+    ;;
+117)
+    echo "FAIL: cloning the root-racing guest thread failed" >&2
+    ;;
+118)
+    echo "FAIL: stat returned an unexpected error during root changes" >&2
+    ;;
+119)
+    echo "FAIL: racing stat exposed translator-only threads" >&2
+    ;;
+120)
+    echo "FAIL: lstat returned an unexpected error during root changes" >&2
+    ;;
+121)
+    echo "FAIL: racing lstat exposed translator-only threads" >&2
+    ;;
+122)
+    echo "FAIL: the root-racing guest thread could not change root" >&2
+    ;;
+123)
+    echo "FAIL: root race did not exercise both root views" >&2
     ;;
 *)
     echo "FAIL: unexpected guest exit status $ret" >&2


### PR DESCRIPTION
Depends on #419. This is a stacked follow-up; review commit `36c629ac348b4e27be4d9565a71a032958905597`.

## Summary

- handle relative and `AT_EMPTY_PATH` stat-family lookups through `AT_FDCWD` after a shared sandbox chroot
- snapshot guest pathnames and serialize identity checks with cwd, root, mount, and fd-binding changes without exposing translator-owned file descriptors
- cover alternate relative spellings plus concurrent cwd, dirfd, pathname, and root changes

## Validation

- `ninja -C build64 latx-x86_64`
- `ninja -C build32 latx-i386`
- `TMPDIR="$HOME/tmp" tests/integration/test-cef-procfs-chroot.sh ...` (three consecutive passes)
- `TMPDIR="$HOME/tmp" tests/integration/test-proc-thread-count.sh ...`
- `TMPDIR="$HOME/tmp" tests/integration/test-cef-userns-exec.sh ...`
- `TMPDIR="$HOME/tmp" tests/integration/test-fd-transform-race-i386.sh ...`
- `scripts/checkpatch.pl --no-tree --strict --no-signoff`: 0 errors, 0 warnings

`test-cef-userns-nested.sh` retains the pre-existing `longjmp causes uninitialized stack frame` failure and exits 12; the same failure is present without this patch.