### PR TITLE
LATX, docs: Require upstream synchronization before PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,8 @@
 
 ## Builds and tests
 
+- Before opening or updating a PR, fetch upstream, rebase onto the latest
+  target branch, and validate the resulting candidate.
 - Before opening or updating a pull request, pass the complete `lat-pr-fast`
   suite and all affected focused tests locally, and include the commands and
   results in the pull request. Run affected `latx-integration` tests when the


### PR DESCRIPTION
## Summary / 变更说明

Require agents to fetch upstream, rebase onto the latest target branch, and validate the resulting candidate before opening or updating a PR.

Add the agreed sentence under `Builds and tests` in `AGENTS.md`, alongside the existing test requirements. This is a documentation-only change; it does not add tooling or change runtime behavior.

## Validation / 验证

- `git diff --check`: passed.
- Confirmed that the diff only adds the two-line instruction to `AGENTS.md`.
- Full `lat-pr-fast` suite: 24 passed, 0 failed, 0 skipped, 0 timed out.

Validation used an x86-64 Guest configuration on a LoongArch host:

```sh
mkdir -p build-tests
cd build-tests
../configure --target-list=x86_64-linux-user \
    --enable-latx --enable-kzt --enable-tests --disable-werror \
    --optimize-O1 --extra-ldflags=-ldl --disable-docs \
    --meson=meson --with-git-submodules=ignore
meson test --suite lat-pr-fast --print-errorlogs
```

## Checklist / 检查项

- [x] I have read `CONTRIBUTING.md`.
- [x] Every commit contains an author-authorized DCO sign-off.
- [x] Relevant validation results are included.
