### PR TITLE
LATX, fix: Release SMC backing after the last mapping disappears

### DIFF
--- a/accel/tcg/translate-all.c
+++ b/accel/tcg/translate-all.c
@@ -3973,81 +3973,27 @@ void page_protect(tb_page_addr_t address)
  *
  * For a guest page at @addr with @size = host page size
  *
- * 0. create shmm_fd with memfd and mmap to get @shmm_base
- * 1. alloc one page from shmm as @shmm_offset
- * 2. mmap(0, size, READ|WRITE, MAP_SHARED, shmm_fd, shmm_offset)
- * 3. munmap(addr, size) after copy data to shmm space
- * 4. mmap(addr, size, READ, MAP_FIXED | MAP_SHARED, shmm_fd, shmm_offset)
+ * 0. create a private memfd for this host page and size it to @size
+ * 1. mmap(0, size, READ|WRITE, MAP_SHARED, shmm_fd, 0)
+ * 2. copy the original guest page to the shadow mapping
+ * 3. mmap(addr, size, READ, MAP_FIXED | MAP_SHARED, shmm_fd, 0)
+ * 4. close shmm_fd; both mappings (including fork descendants) own the file
  *
  * guest space : +++++++++--------+++++++    shadow page +--------+
  *                       ^  size                         ^  size
  *                       addr                            ptr
  *                     /                                   \
- *            shared map --------->   offset   <---------- shared map
+ *            shared map --------->   offset 0 <---------- shared map
  *                                    |  size  |
- *  shmm space : ++++++++++++++++++++++--------+++++++
+ *  shmm space :                      +--------+
  *
- * 5. access with original guest address @addr or @shmm_base + shmm_offset
- */
-
-static int smc_shmm_fd;
-static int smc_shmm_npages;
-static int smc_shmm_pn;
-#define SMC_SHMM_INIT_PAGES     512
-#define SMC_SHMM_EXPAND_PAGES   128
-
-static inline void smc_shmm_create(void)
-{
-    if (smc_shmm_fd) return;
-
-    smc_shmm_fd = memfd_create("smc_shmm", 0);
-    if (smc_shmm_fd == -1) {
-        fprintf(stderr, "%s:%d SMC shmm create fail\n", __func__, __LINE__);
-        latx_smc_shmm_disable();
-        return;
-    }
-
-    smc_shmm_pn = 0; /* start index of pages */
-    smc_shmm_npages = SMC_SHMM_INIT_PAGES; /* total number of pages */
-    if (ftruncate(smc_shmm_fd, smc_shmm_npages * qemu_host_page_size) == -1) {
-        fprintf(stderr, "%s:%d SMC shmm ftruncate fail\n", __func__, __LINE__);
-        latx_smc_shmm_disable();
-        close(smc_shmm_fd);
-    }
-}
-
-/*
- * Alloc a new host page with smc_shmm_fd.
+ * 5. access with original guest address @addr or the shadow mapping
  *
- * On success, return the offset used with smc_shmm_fd.
- * On fail, return -1ULL.
+ * A process-global append-only memfd retains the contents of unmapped pages
+ * until process exit.  Per-page files release their backing automatically
+ * after the last guest/shadow VMA disappears, without truncating or punching
+ * holes in data that may still be mapped by a fork child.
  */
-static inline uint64_t smc_shmm_alloc_page(void)
-{
-    uint64_t offset = -1ULL;
-    uint64_t new_size;
-
-    smc_shmm_create();
-
-    if ((smc_shmm_pn + 1) < smc_shmm_npages) {
-        goto alloc_and_return;
-    }
-
-    smc_shmm_npages += SMC_SHMM_EXPAND_PAGES;
-    new_size = smc_shmm_npages * qemu_host_page_size;
-
-    if (ftruncate(smc_shmm_fd, new_size) == -1) {
-        fprintf(stderr, "%s:%d SMC shmm fail to expand\n", __func__, __LINE__);
-        smc_shmm_npages -= SMC_SHMM_EXPAND_PAGES;
-        goto just_return;
-    }
-
-alloc_and_return:
-    offset = (uint64_t)(smc_shmm_pn * qemu_host_page_size);
-    smc_shmm_pn += 1;
-just_return:
-    return offset;
-}
 
 /*
  * Check if the guest pages belonging to the same one host page are all anon
@@ -4090,10 +4036,9 @@ static inline int smc_shmm_check_page_anon(uint64_t start, int *prot)
 static int smc_create_shadow_page_shmm(uint64_t start)
 {
     uint64_t real_start, real_end, addr, len;
-    uint64_t shmm_offset;
     void *host_start, *ptr, *shmm_ptr;
     int64_t access_off;
-    int prot;
+    int prot, shmm_fd;
     ShadowPageDesc *spd;
 
     /* can NOT use shmm if guest page is not MAP_ANON */
@@ -4101,10 +4046,14 @@ static int smc_create_shadow_page_shmm(uint64_t start)
         return -1;
     }
 
-    /* alloc the shmm space */
-    shmm_offset = smc_shmm_alloc_page();
-    if (shmm_offset == -1ULL) {
-        exit(-1);
+    shmm_fd = memfd_create("smc_shmm", MFD_CLOEXEC);
+    if (shmm_fd == -1) {
+        fprintf(stderr, "%s:%d SMC shmm create fail\n", __func__, __LINE__);
+        return -1;
+    }
+    if (ftruncate(shmm_fd, qemu_host_page_size) == -1) {
+        fprintf(stderr, "%s:%d SMC shmm ftruncate fail\n", __func__, __LINE__);
+        close(shmm_fd);
         return -1;
     }
 
@@ -4113,34 +4062,33 @@ static int smc_create_shadow_page_shmm(uint64_t start)
     len = qemu_host_page_size;
     real_end = real_start + qemu_host_page_size;
 
-    /* protect before memcpy */
-    mprotect(host_start, len, PROT_READ);
-
     /* create shadow page, which is shared mapped to shmm space */
     shmm_ptr = mmap(NULL, len,
                PAGE_READ | PAGE_WRITE, /* allow rw on shadow page */
-               MAP_SHARED,
-               smc_shmm_fd, shmm_offset);
+               MAP_SHARED, shmm_fd, 0);
     if (shmm_ptr == MAP_FAILED) {
         fprintf(stderr, "%s:%d SMC shmm map share fail\n", __func__, __LINE__);
-        fflush(stderr);
-        g_assert_not_reached();
+        close(shmm_fd);
+        return -1;
     }
+
+    /* Preparatory allocation failures leave the original page unchanged. */
+    mprotect(host_start, len, PROT_READ);
 
     /* copy original guest data into the shmm space */
     memcpy(shmm_ptr, g2h_untagged(real_start), len);
 
-    /* release the original guest space */
-    munmap(host_start, len);
-
-    /* create shared map from guest space to shmm space */
+    /* MAP_FIXED replaces the original guest mapping. */
     ptr = mmap(host_start, len,
                prot & PROT_READ, /* allow read on guest space */
-               MAP_SHARED | MAP_FIXED,
-               smc_shmm_fd, shmm_offset);
+               MAP_SHARED | MAP_FIXED, shmm_fd, 0);
+    /* Linux releases the descriptor even on close(EINTR); do not retry it. */
+    close(shmm_fd);
     if (ptr != host_start) {
+        munmap(shmm_ptr, len);
         fprintf(stderr, "%s:%d SMC shmm map guest fail\n", __func__, __LINE__);
         fflush(stderr);
+        /* A failed MAP_FIXED may already have removed the original VMA. */
         g_assert_not_reached();
     }
 
@@ -4513,7 +4461,6 @@ no_pageflags_cache:
         if (inv_one_tb) {
             /* === create shadow page for smc === */
             if (latx_smc_shmm()) {
-                smc_shmm_create();
                 SMC_CREATE_SHADOW_PAGE_SHMM(address, p);
                 if (is_cross_host) {
                     SMC_CREATE_SHADOW_PAGE_SHMM(address2, p2);

--- a/tests/unit/meson.build
+++ b/tests/unit/meson.build
@@ -78,6 +78,13 @@ if 'CONFIG_LATX' in config_host and host_machine.cpu_family() == 'loongarch64'
 endif
 
 test(
+  'test-latx-smc-shmm',
+  python,
+  args: [files('test-latx-smc-shmm.py'), project_source_root],
+  suite: 'lat-pr-fast',
+)
+
+test(
   'test-x11-synchronize-callback',
   python,
   args: [

--- a/tests/unit/test-latx-smc-shmm.py
+++ b/tests/unit/test-latx-smc-shmm.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-2.0-or-later
+"""Production SMC backing ownership with real memfd, mmap, unmap and fork.
+
+Only guest page metadata is simplified. Syscall wrappers inject failures before
+side effects, except close(EINTR), which models Linux's already-closed fd.
+The guest MAP_FIXED failure remains fatal and is intercepted for cleanup checks.
+The standalone guest SMC probe separately verifies the translator entry path.
+"""
+import argparse
+from pathlib import Path
+import shlex
+import subprocess
+import tempfile
+
+
+def function(source, signature):
+    start = source.index(signature)
+    return source[start:source.index('\n}', start) + 2] + '\n'
+
+
+PRELUDE = r'''
+#define _GNU_SOURCE
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <setjmp.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#define CHECK(x) do { if (!(x)) { fprintf(stderr, "%d: %s (errno=%d)\n", \
+    __LINE__, #x, errno); exit(1); } } while (0)
+#define TARGET_PAGE_SIZE 4096
+#define PAGE_READ PROT_READ
+#define PAGE_WRITE PROT_WRITE
+static size_t qemu_host_page_size;
+static uintptr_t qemu_host_page_mask;
+typedef struct { void *p_addr; int64_t access_off; int is_shmm; } ShadowPageDesc;
+static ShadowPageDesc descriptors[16];
+static uintptr_t guest_base;
+static int fail_kind, shadow_mappings, last_memfd = -1, expected_fatal;
+static int reject_nonanon;
+static jmp_buf fatal_env;
+static void fatal(void) {
+    CHECK(expected_fatal);
+    longjmp(fatal_env, 1);
+}
+#define g_assert_not_reached() fatal()
+static void *g2h_untagged(uintptr_t address) { return (void *)address; }
+static int smc_shmm_check_page_anon(uint64_t start, int *prot) {
+    CHECK(start == guest_base);
+    *prot = PROT_READ | PROT_WRITE;
+    return reject_nonanon;
+}
+static ShadowPageDesc *set_shadow_page(uint64_t address, void *ptr, int64_t off) {
+    size_t index = (address - guest_base) / TARGET_PAGE_SIZE;
+    CHECK(index < 16 && !descriptors[index].p_addr);
+    descriptors[index].p_addr = ptr;
+    descriptors[index].access_off = off;
+    return &descriptors[index];
+}
+static void latx_smc_shmm_disable(void) {}
+static int test_memfd_create(const char *name, unsigned flags) {
+    if (fail_kind == 1) { errno = EMFILE; return -1; }
+    last_memfd = memfd_create(name, flags);
+    return last_memfd;
+}
+static int test_ftruncate(int fd, off_t size) {
+    if (fail_kind == 2) { errno = ENOSPC; return -1; }
+    return ftruncate(fd, size);
+}
+static void *test_mmap(void *addr, size_t len, int prot, int flags,
+                       int fd, off_t offset) {
+    if ((fail_kind == 3 && !addr) || (fail_kind == 4 && addr)) {
+        errno = ENOMEM; return MAP_FAILED;
+    }
+    void *result = mmap(addr, len, prot, flags, fd, offset);
+    if (result != MAP_FAILED && !addr) shadow_mappings++;
+    return result;
+}
+static int test_munmap(void *addr, size_t len) {
+    int result = munmap(addr, len);
+    if (!result && addr != (void *)guest_base) shadow_mappings--;
+    return result;
+}
+static int test_close(int fd) {
+    int result = close(fd);
+    if (fail_kind == 5 && !result) { errno = EINTR; return -1; }
+    return result;
+}
+static int count_smc_fds(void) {
+    DIR *dir = opendir("/proc/self/fd");
+    struct dirent *entry;
+    int count = 0;
+    CHECK(dir);
+    while ((entry = readdir(dir))) {
+        char path[512], target[512];
+        snprintf(path, sizeof(path), "/proc/self/fd/%s", entry->d_name);
+        ssize_t n = readlink(path, target, sizeof(target) - 1);
+        if (n < 0) continue;
+        target[n] = 0;
+        if (strstr(target, "smc_shmm")) count++;
+    }
+    CHECK(!closedir(dir));
+    return count;
+}
+static void check_mapping_permissions(uintptr_t address, int writable) {
+    FILE *maps = fopen("/proc/self/maps", "r");
+    char line[512], permissions[5];
+    unsigned long start, end;
+    int found = 0;
+    CHECK(maps);
+    while (fgets(line, sizeof(line), maps)) {
+        if (sscanf(line, "%lx-%lx %4s", &start, &end, permissions) == 3 &&
+            start <= address && address < end) {
+            CHECK(permissions[0] == 'r');
+            CHECK((permissions[1] == 'w') == writable);
+            CHECK(permissions[2] != 'x' && permissions[3] == 's');
+            found = 1;
+            break;
+        }
+    }
+    CHECK(!fclose(maps) && found);
+}
+#define memfd_create test_memfd_create
+#define ftruncate test_ftruncate
+#define mmap test_mmap
+#define munmap test_munmap
+#define close test_close
+'''
+
+TEST = r'''
+#undef memfd_create
+#undef ftruncate
+#undef mmap
+#undef munmap
+#undef close
+static void new_guest(void) {
+    void *p = mmap(NULL, qemu_host_page_size, PROT_READ | PROT_WRITE,
+                   MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    CHECK(p != MAP_FAILED);
+    guest_base = (uintptr_t)p;
+    memset(p, 0x31, qemu_host_page_size);
+    memset(descriptors, 0, sizeof(descriptors));
+}
+static void release_guest(void) {
+    CHECK(!munmap((void *)guest_base, qemu_host_page_size));
+    if (descriptors[0].p_addr) {
+        CHECK(!test_munmap(descriptors[0].p_addr, qemu_host_page_size));
+    }
+    memset(descriptors, 0, sizeof(descriptors));
+    CHECK(shadow_mappings == 0 && count_smc_fds() == 0);
+}
+static void check_aliases(void) {
+    CHECK(count_smc_fds() == 0 && shadow_mappings == 1);
+    check_mapping_permissions(guest_base, 0);
+    check_mapping_permissions((uintptr_t)descriptors[0].p_addr, 1);
+    for (unsigned i = 0; i < qemu_host_page_size / TARGET_PAGE_SIZE; i++) {
+        CHECK(descriptors[i].is_shmm);
+        CHECK(descriptors[i].p_addr == descriptors[0].p_addr);
+    }
+    CHECK(*(unsigned char *)guest_base == 0x31);
+    *(unsigned char *)descriptors[0].p_addr = 0x42;
+    CHECK(*(unsigned char *)guest_base == 0x42);
+}
+static void fork_lifetime(void) {
+    int sync[2], status;
+    new_guest();
+    CHECK(!smc_create_shadow_page_shmm(guest_base));
+    check_aliases();
+    CHECK(!pipe(sync));
+    pid_t child = fork();
+    CHECK(child >= 0);
+    if (!child) {
+        char token;
+        CHECK(!close(sync[1]));
+        CHECK(read(sync[0], &token, 1) == 1);
+        CHECK(!close(sync[0]));
+        /* Parent has unmapped both aliases; the child's mappings own data. */
+        CHECK(*(unsigned char *)guest_base == 0x42);
+        *(unsigned char *)descriptors[0].p_addr = 0x53;
+        CHECK(*(unsigned char *)guest_base == 0x53);
+        release_guest();
+        new_guest();
+        CHECK(!smc_create_shadow_page_shmm(guest_base));
+        check_aliases(); release_guest();
+        _exit(0);
+    }
+    CHECK(!close(sync[0]));
+    release_guest();
+    CHECK(write(sync[1], "x", 1) == 1);
+    CHECK(!close(sync[1]));
+    CHECK(waitpid(child, &status, 0) == child);
+    CHECK(WIFEXITED(status) && WEXITSTATUS(status) == 0);
+}
+int main(void) {
+    qemu_host_page_size = sysconf(_SC_PAGESIZE);
+    qemu_host_page_mask = ~(qemu_host_page_size - 1);
+    CHECK(qemu_host_page_size >= TARGET_PAGE_SIZE);
+    CHECK(qemu_host_page_size / TARGET_PAGE_SIZE <= 16);
+    for (int i = 0; i < 1024; i++) {
+        new_guest();
+        CHECK(!smc_create_shadow_page_shmm(guest_base));
+        check_aliases(); release_guest();
+    }
+    fork_lifetime();
+    reject_nonanon = 1; new_guest();
+    CHECK(smc_create_shadow_page_shmm(guest_base) == -1);
+    CHECK(!descriptors[0].p_addr && !shadow_mappings);
+    CHECK(*(unsigned char *)guest_base == 0x31);
+    *(unsigned char *)guest_base = 0x62;
+    release_guest(); reject_nonanon = 0;
+    for (fail_kind = 1; fail_kind <= 3; fail_kind++) {
+        new_guest();
+        CHECK(smc_create_shadow_page_shmm(guest_base) == -1);
+        CHECK(!descriptors[0].p_addr && !shadow_mappings);
+        CHECK(count_smc_fds() == 0);
+        /* Preparatory failures must leave the original mapping usable. */
+        CHECK(*(unsigned char *)guest_base == 0x31);
+        *(unsigned char *)guest_base = 0x62;
+        release_guest();
+    }
+    fail_kind = 4; expected_fatal = 1; new_guest();
+    if (!setjmp(fatal_env)) {
+        smc_create_shadow_page_shmm(guest_base);
+        CHECK(0);
+    }
+    CHECK(count_smc_fds() == 0 && shadow_mappings == 0);
+    /* MAP_FIXED failure is fatal: no assumption about the guest VMA. */
+    CHECK(!munmap((void *)guest_base, qemu_host_page_size));
+    expected_fatal = 0;
+    fail_kind = 5; new_guest();
+    CHECK(!smc_create_shadow_page_shmm(guest_base));
+    check_aliases(); release_guest();
+    fail_kind = 0;
+    int saved_stdin = dup(STDIN_FILENO);
+    CHECK(!close(STDIN_FILENO) || errno == EBADF);
+    new_guest();
+    CHECK(!smc_create_shadow_page_shmm(guest_base));
+    CHECK(last_memfd == 0);
+    CHECK(fcntl(STDIN_FILENO, F_GETFD) == -1 && errno == EBADF);
+    check_aliases(); release_guest();
+    if (saved_stdin != -1) {
+        CHECK(dup2(saved_stdin, STDIN_FILENO) == STDIN_FILENO);
+        CHECK(!close(saved_stdin));
+    }
+    puts("SMC backing: 1024 lifecycles, alias permissions, fork, fd=0 and failure cleanup passed");
+    return 0;
+}
+'''
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('repo', type=Path)
+    parser.add_argument('--cc', default='cc')
+    parser.add_argument('--source', type=Path,
+                        help='optional saved translate-all.c for RED comparison')
+    args = parser.parse_args()
+    source_path = args.source or args.repo / 'accel/tcg/translate-all.c'
+    source = source_path.read_text()
+    # Also compile the old append-only allocator when testing a baseline file.
+    allocator = ''
+    if 'static int smc_shmm_fd;' in source:
+        start = source.index('static int smc_shmm_fd;')
+        end = source.index('/*\n * Check if the guest pages', start)
+        allocator = source[start:end]
+    unit = PRELUDE + allocator + function(
+        source, 'static int smc_create_shadow_page_shmm(') + TEST
+    with tempfile.TemporaryDirectory(prefix='latx-smc-shmm-') as directory:
+        path = Path(directory)
+        (path / 'test.c').write_text(unit)
+        for flags in ([], ['-DNDEBUG']):
+            subprocess.run(shlex.split(args.cc) + [
+                '-std=gnu11', '-O1', '-g', '-Wall', '-Wextra',
+                '-Wno-unused-function', *flags, str(path / 'test.c'),
+                '-o', str(path / 'test')], check=True)
+            subprocess.run([str(path / 'test')], check=True, timeout=30)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Scope

Based on upstream `bfe17ae7c1`. Replace the append-only, process-global SMC memfd allocator with one backing file per converted host page. Close the descriptor after creating the guest and shadow mappings; the kernel retains the backing while any mapping, including a fork descendant's mapping, still owns it.

This prevents unmapped pages from retaining their contents in an ever-growing open memfd. It does not punch holes or truncate backing that a child may still use. Preparatory memfd/ftruncate/shadow-mmap failures clean up and use the existing fallback; guest MAP_FIXED failure remains fatal because the original mapping may already have been removed. Handle fd 0 and do not retry Linux close(EINTR).

The default `LATX_SMC=0` is unchanged. Per-page memfd/ftruncate/close operations have an unmeasured throughput cost when this optional shared-backing mode is enabled; this is a resource-lifetime fix, not a speedup claim.

## Author self-review and combined validation

The actual published diffs were reviewed individually and checked against the local candidates. Follow-up corrections were folded into their existing commits; author/sign-off metadata updates preserved the per-PR source trees. The series remains six commits across #472, #473, #474, #475 and #476.

All five branches merge without conflicts on `bfe17ae7c1`. The combined source tree `80aaaaf13688387640f528d1c0bccb6a800f8d6e` builds and passes **33/33 lat-pr-fast tests**. On that combined binary, the 500-cycle KZT unload and retained-handle checks, 520-cycle SMC/fork checks, and 512 successful TSYNC operations alongside thread creation also complete successfully. A tests-disabled configuration registers no tests.

The integration suite still reports **27 skips**, including after selecting the available guest sysroot with `LATX_X86_64_SYSROOT`: 25 require clang and two require the x86 cross compiler. These are not passes. This author self-review does not substitute for the upstream CI matrix, maintainer review or real-application acceptance.

## Validation

LoongArch64, GCC 15.3, x86_64-linux-user, LAT O1, KZT compiled in, release:

```sh
./configure --target-list=x86_64-linux-user --enable-latx --optimize-O1 \
  --extra-ldflags=-ldl --enable-kzt --enable-tests --disable-docs \
  --disable-werror --meson=meson
ninja -C build -j2 all meson-test-prereq
env -u LAT_LD_PREFIX meson test -C build --no-rebuild \
  --suite lat-pr-fast --print-errorlogs --num-processes 2
env -u LAT_LD_PREFIX meson test -C build --no-rebuild \
  --suite latx-integration --print-errorlogs --num-processes 2
```

- Isolated PR branch: **25/25 lat-pr-fast passed**.
- Maintained production-body regression uses real memfd/mmap/fork for 1,024 lifecycles, alias permissions, parent-unmap/child-use, fd 0, close(EINTR) and allocation/fatal-map failure cleanup. The original allocator fails the no-retained-fd check. ASan/UBSan runs pass in debug and NDEBUG configurations.
- Actual x86 guest code performed **520 map/execute/self-modify/unmap cycles**, checking results 1 then 2 with `LATX_AOT=0`, `LATX_KZT=0`, `LATX_SMC=2`. The final live sample has two SMC mappings and no retained SMC descriptor; after unmap it has zero mappings. After fork and parent unmap, the child still executes result 2, writes the code and executes result 3, then exits successfully. The `LATX_SMC=0` control also succeeds.
- Integration suite: **27 skipped (exit 77)** because the configured guest-building environment is unavailable (missing clang and the suite's default guest sysroot). Skips are not passes; broader guest compatibility and enabled-mode performance remain gates.

Independent of the other memory-lifetime PRs. No installed runtime replacement or application restart.
