### PR TITLE
KZT, fix: Align x86-64 JUMP_SLOT relocation with glibc

### DIFF
--- a/target/i386/latx/context/elfloader.c
+++ b/target/i386/latx/context/elfloader.c
@@ -986,10 +986,10 @@ static int relocate_elf_rela(
                   ) {
                     if (offs){
                         if(p) {
-                            printf_log(LOG_INFO, "RelocateElfRELA : Apply %s R_X86_64_JUMP_SLOT @%p with sym=%s (%p -> %p)\n", (bind==STB_LOCAL)?"Local":"Global", p, symname, *(void**)p, (void*)(offs+rela[i].r_addend));
+                            printf_log(LOG_INFO, "RelocateElfRELA : Apply %s R_X86_64_JUMP_SLOT @%p with sym=%s (%p -> %p)\n", (bind==STB_LOCAL)?"Local":"Global", p, symname, *(void**)p, (void*)offs);
                             if (kzt_relocation_store(
                                     transaction, (uintptr_t *)p,
-                                    offs + rela[i].r_addend) != 0) {
+                                    offs) != 0) {
                                 printf_log(LOG_INFO,
                                            "Cannot write R_X86_64_JUMP_SLOT @%p\n",
                                            p);


### PR DESCRIPTION
## Summary / 变更说明

  Align x86-64 `R_X86_64_JUMP_SLOT` handling with glibc by writing the
  resolved symbol address without adding the RELA addend.

  glibc explicitly ignores the addend for this relocation type:
  `elf_machine_plt_value()` returns the symbol value unchanged, and
  `elf_machine_fixup_plt()` writes that value to the relocation slot.

  LATX previously added `r_addend` when applying an immediate JUMP_SLOT
  relocation. With a nonzero addend, this could shift a resolved KZT bridge
  address to an invalid entry point, as observed with a `realloc`
  relocation in guest libc when running Steam webhelper.

  This change also makes immediate binding consistent with LATX's existing
  lazy resolver. It applies to the shared x86-64 KZT relocation path and
  does not introduce Steam-specific handling.

  Reference:
  https://github.com/bminor/glibc/blob/master/sysdeps/x86_64/dl-machine.h

  ## Validation / 验证

  Validation recorded for this commit:

  - Completed the 64-bit build.
  - Tested a malloc/realloc/free probe with a nonzero addend injected into
    the `realloc` JUMP_SLOT relocation:
    - Before the fix: KZT=1 failed.
    - After the fix: KZT=0 and KZT=1 passed.
  - Steam webhelper progressed to browser initialization after the fix.

  ## Checklist / 检查项

- [x] I have read `CONTRIBUTING.md`. / 我已阅读 `CONTRIBUTING.md`。
- [x] Every commit contains a DCO sign-off (`git commit -s`). /
      每个提交都包含 DCO 签署（`git commit -s`）。
- [x] I have included relevant build or test results, or explained why they
      are not applicable. /
      我已提供相关构建或测试结果，或说明了不适用的原因。