### PR TITLE
LATX, fix: Abort on itemp register exhaustion

### DIFF
--- a/target/i386/latx/translator/reg-alloc.c
+++ b/target/i386/latx/translator/reg-alloc.c
@@ -298,6 +298,17 @@ IR2_OPND ra_alloc_itemp(void)
     int itemp_reg_num;
 
     itemp_reg_num = ra_alloc_itemp_num();
+    if (unlikely(itemp_reg_num < 0)) {
+        /*
+         * Do not let a failed allocation propagate as register number -1
+         * into the immediate cache lookup or IR2 operand construction.  It
+         * would otherwise cause undefined behavior or corrupt generated code.
+         */
+        fprintf(stderr,
+                "[LATX] itemp register exhausted, status=0x%x\n",
+                lsenv->tr_data->itemp_status);
+        abort();
+    }
 #ifdef CONFIG_LATX_IMM_REG
     if (option_imm_reg) {
         int itemp_num = reg_itemp_reverse_map[itemp_reg_num];


### PR DESCRIPTION
ra_alloc_itemp_num() returns -1 when all integer temporary registers are in use. Passing that value into the immediate-cache lookup or IR2 operand construction can cause an out-of-bounds access or generate an invalid register operand, making the translator fail later and obscuring the actual cause.

Detect exhaustion at the allocation site, report the current itemp status, and abort explicitly in release builds.
