### PR TITLE
LATX, opt: Fast-path common instruction decoding

### DIFF
--- a/target/i386/latx/ir1/ir1-decode.h
+++ b/target/i386/latx/ir1/ir1-decode.h
@@ -1,0 +1,465 @@
+/*
+ * SPDX-FileCopyrightText: 2026 LAT Project Authors
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#ifndef LATX_IR1_DECODE_H
+#define LATX_IR1_DECODE_H
+
+#define IR1_DECODE_TEMPLATE_CACHE_SIZE 16384
+
+/*
+ * Translation decodes repeated position-independent instruction encodings.
+ * Keep exact decoded instructions as templates after the hot decoder declines
+ * them, and retain the full decoder for unsupported forms and cache misses.
+ */
+typedef struct Ir1DecodeTemplate {
+    uint8_t mode;
+    uint8_t size;
+    uint8_t bytes[15];
+    struct la_dt_insn decoded;
+} Ir1DecodeTemplate;
+
+static __thread Ir1DecodeTemplate *ir1_decode_templates;
+static __thread uint8_t *ir1_decode_template_valid;
+static GPrivate ir1_decode_templates_owner = G_PRIVATE_INIT(g_free);
+static GPrivate ir1_decode_template_valid_owner = G_PRIVATE_INIT(g_free);
+
+static uint32_t ir1_decode_template_hash(const uint8_t *code, size_t size,
+                                         int mode)
+{
+    uint32_t hash = 2166136261u ^ (uint32_t)mode;
+    for (size_t i = 0; i < size; i++) {
+        hash = (hash ^ code[i]) * 16777619u;
+    }
+    return hash & (IR1_DECODE_TEMPLATE_CACHE_SIZE - 1);
+}
+
+static struct la_dt_insn *ir1_decode_template_output(int ir1_num,
+                                                     void *pir1_base)
+{
+    return (void *)((uintptr_t)pir1_base +
+                    ir1_num * sizeof(struct la_dt_insn));
+}
+
+/*
+ * Decode the common, regular x86-64 forms directly.  This path runs before the
+ * cache, has no lookup or warm-up cost, and rejects prefixes and forms that it
+ * does not model exactly.  Rejected instructions continue through the exact
+ * cache and then the full decoder.
+ */
+static const dt_x86_reg ir1_hot_gpr64[16] = {
+    dt_X86_REG_RAX, dt_X86_REG_RCX, dt_X86_REG_RDX, dt_X86_REG_RBX,
+    dt_X86_REG_RSP, dt_X86_REG_RBP, dt_X86_REG_RSI, dt_X86_REG_RDI,
+    dt_X86_REG_R8, dt_X86_REG_R9, dt_X86_REG_R10, dt_X86_REG_R11,
+    dt_X86_REG_R12, dt_X86_REG_R13, dt_X86_REG_R14, dt_X86_REG_R15,
+};
+
+static const dt_x86_reg ir1_hot_gpr32[16] = {
+    dt_X86_REG_EAX, dt_X86_REG_ECX, dt_X86_REG_EDX, dt_X86_REG_EBX,
+    dt_X86_REG_ESP, dt_X86_REG_EBP, dt_X86_REG_ESI, dt_X86_REG_EDI,
+    dt_X86_REG_R8D, dt_X86_REG_R9D, dt_X86_REG_R10D, dt_X86_REG_R11D,
+    dt_X86_REG_R12D, dt_X86_REG_R13D, dt_X86_REG_R14D, dt_X86_REG_R15D,
+};
+
+static int64_t ir1_hot_read_simm(const uint8_t *code, uint8_t size)
+{
+    if (size == 1) {
+        return *(const int8_t *)code;
+    }
+    int32_t value;
+    memcpy(&value, code, sizeof(value));
+    return value;
+}
+
+static void ir1_hot_finish(struct la_dt_insn *info, const uint8_t *code,
+                           uint8_t size, uint64_t address, uint8_t rex,
+                           uint8_t opcode0, uint8_t opcode1)
+{
+    info->size = size;
+    info->address = address;
+    info->x86.addr_size = 8;
+    info->x86.rex = rex;
+    info->x86.opcode[0] = opcode0;
+    info->x86.opcode[1] = opcode1;
+    memcpy(info->bytes, code, size);
+#ifdef CONFIG_LATX_CAPSTONE_OP_ACCESS
+    for (int i = 0; i < info->x86.op_count; i++) {
+        dt_cs_x86_op *operand = &info->x86.operands[i];
+        if (operand->type != dt_X86_OP_IMM) {
+            operand->access = dt_CS_AC_READ;
+        }
+    }
+    switch (info->id) {
+    case dt_X86_INS_MOV:
+    case dt_X86_INS_LEA:
+    case dt_X86_INS_POP:
+        info->x86.operands[0].access = dt_CS_AC_WRITE;
+        break;
+    case dt_X86_INS_ADD:
+    case dt_X86_INS_OR:
+    case dt_X86_INS_ADC:
+    case dt_X86_INS_SBB:
+    case dt_X86_INS_AND:
+    case dt_X86_INS_SUB:
+    case dt_X86_INS_XOR:
+        info->x86.operands[0].access = dt_CS_AC_READ | dt_CS_AC_WRITE;
+        break;
+    default:
+        break;
+    }
+#endif
+}
+
+static uint8_t ir1_hot_decode_rm(const uint8_t *code, uint8_t offset,
+                                 uint8_t rex, uint8_t width,
+                                 dt_cs_x86_op *operand)
+{
+    uint8_t modrm = code[offset++];
+    uint8_t mod = modrm >> 6;
+    uint8_t rm = modrm & 7;
+    if (mod == 3) {
+        const dt_x86_reg *regs = width == 8 ? ir1_hot_gpr64 : ir1_hot_gpr32;
+        operand->type = dt_X86_OP_REG;
+        operand->size = width;
+        operand->reg = regs[rm | ((rex & 1) << 3)];
+        return offset;
+    }
+
+    operand->type = dt_X86_OP_MEM;
+    operand->size = width;
+    operand->mem.segment = dt_X86_REG_INVALID;
+    operand->mem.default_segment = dt_X86_REG_INVALID;
+    operand->mem.base = dt_X86_REG_INVALID;
+    operand->mem.index = dt_X86_REG_INVALID;
+    operand->mem.scale = 1;
+    operand->mem.disp = 0;
+
+    bool disp32 = false;
+    if (rm == 4) {
+        uint8_t sib = code[offset++];
+        uint8_t index = (sib >> 3) & 7;
+        uint8_t base = sib & 7;
+        operand->mem.scale = 1 << (sib >> 6);
+        if (index != 4 || (rex & 2)) {
+            operand->mem.index = ir1_hot_gpr64[index | ((rex & 2) << 2)];
+        }
+        if (mod == 0 && base == 5) {
+            disp32 = true;
+        } else {
+            operand->mem.base = ir1_hot_gpr64[base | ((rex & 1) << 3)];
+        }
+        /* Match Capstone's explicit zero-index marker for redundant SIBs. */
+        if (operand->mem.index == dt_X86_REG_INVALID &&
+            (operand->mem.scale != 1 ||
+             (operand->mem.base != dt_X86_REG_INVALID &&
+              operand->mem.base != dt_X86_REG_RSP &&
+              operand->mem.base != dt_X86_REG_R12))) {
+            operand->mem.index = dt_X86_REG_RIZ;
+        }
+    } else if (mod == 0 && rm == 5) {
+        operand->mem.base = dt_X86_REG_RIP;
+        disp32 = true;
+    } else {
+        operand->mem.base = ir1_hot_gpr64[rm | ((rex & 1) << 3)];
+    }
+    if (mod == 1) {
+        operand->mem.disp = ir1_hot_read_simm(code + offset, 1);
+        offset++;
+    } else if (mod == 2 || disp32) {
+        operand->mem.disp = ir1_hot_read_simm(code + offset, 4);
+        offset += 4;
+    }
+    return offset;
+}
+
+static struct la_dt_insn *ir1_hot_decode(const uint8_t *code,
+                                         uint64_t address, int ir1_num,
+                                         void *pir1_base, int mode)
+{
+    static const unsigned int jcc[16] = {
+        dt_X86_INS_JO, dt_X86_INS_JNO, dt_X86_INS_JB, dt_X86_INS_JAE,
+        dt_X86_INS_JE, dt_X86_INS_JNE, dt_X86_INS_JBE, dt_X86_INS_JA,
+        dt_X86_INS_JS, dt_X86_INS_JNS, dt_X86_INS_JP, dt_X86_INS_JNP,
+        dt_X86_INS_JL, dt_X86_INS_JGE, dt_X86_INS_JLE, dt_X86_INS_JG,
+    };
+    /* Other backends and debug disassembly retain their complete metadata. */
+#if !defined(CONFIG_LATX_CAPSTONE_GIT) || defined(CONFIG_LATX_DEBUG)
+    return NULL;
+#endif
+    if (mode != 1 || !pir1_base) {
+        return NULL;
+    }
+    uint8_t offset = 0;
+    uint8_t rex = 0;
+    if (code[offset] >= 0x40 && code[offset] <= 0x4f) {
+        rex = code[offset++];
+    }
+    uint8_t opcode = code[offset++];
+    struct la_dt_insn *info;
+
+    if (!rex && opcode >= 0x70 && opcode <= 0x7f) {
+        info = ir1_decode_template_output(ir1_num, pir1_base);
+        memset(info, 0, sizeof(*info));
+        info->id = jcc[opcode & 0xf];
+        info->x86.op_count = 1;
+        info->x86.operands[0].type = dt_X86_OP_IMM;
+        info->x86.operands[0].size = 8;
+        info->x86.operands[0].imm = address + 2 +
+                                     ir1_hot_read_simm(code + 1, 1);
+        ir1_hot_finish(info, code, 2, address, 0, opcode, 0);
+        return info;
+    }
+    if (!rex && opcode == 0x0f && code[1] >= 0x80 && code[1] <= 0x8f) {
+        info = ir1_decode_template_output(ir1_num, pir1_base);
+        memset(info, 0, sizeof(*info));
+        info->id = jcc[code[1] & 0xf];
+        info->x86.op_count = 1;
+        info->x86.operands[0].type = dt_X86_OP_IMM;
+        info->x86.operands[0].size = 8;
+        info->x86.operands[0].imm = address + 6 +
+                                     ir1_hot_read_simm(code + 2, 4);
+        ir1_hot_finish(info, code, 6, address, 0, 0x0f, code[1]);
+        return info;
+    }
+    if (!rex && (opcode == 0xe8 || opcode == 0xe9 || opcode == 0xeb)) {
+        uint8_t imm_size = opcode == 0xeb ? 1 : 4;
+        uint8_t size = 1 + imm_size;
+        info = ir1_decode_template_output(ir1_num, pir1_base);
+        memset(info, 0, sizeof(*info));
+        info->id = opcode == 0xe8 ? dt_X86_INS_CALL : dt_X86_INS_JMP;
+        info->x86.op_count = 1;
+        info->x86.operands[0].type = dt_X86_OP_IMM;
+        info->x86.operands[0].size = 8;
+        info->x86.operands[0].imm = address + size +
+                                     ir1_hot_read_simm(code + 1, imm_size);
+        ir1_hot_finish(info, code, size, address, 0, opcode, 0);
+        return info;
+    }
+    if (!rex && (opcode == 0x90 || opcode == 0xc3)) {
+        info = ir1_decode_template_output(ir1_num, pir1_base);
+        memset(info, 0, sizeof(*info));
+        info->id = opcode == 0x90 ? dt_X86_INS_NOP : dt_X86_INS_RET;
+        ir1_hot_finish(info, code, 1, address, 0, opcode, 0);
+        return info;
+    }
+    if (opcode >= 0x50 && opcode <= 0x5f && !(rex & 0x0e)) {
+        unsigned int reg = (opcode & 7) | ((rex & 1) << 3);
+        info = ir1_decode_template_output(ir1_num, pir1_base);
+        memset(info, 0, sizeof(*info));
+        info->id = opcode < 0x58 ? dt_X86_INS_PUSH : dt_X86_INS_POP;
+        info->x86.op_count = 1;
+        info->x86.operands[0].type = dt_X86_OP_REG;
+        info->x86.operands[0].size = 8;
+        info->x86.operands[0].reg = ir1_hot_gpr64[reg];
+        ir1_hot_finish(info, code, offset, address, rex, opcode, 0);
+        return info;
+    }
+    if (opcode >= 0xb8 && opcode <= 0xbf) {
+        uint8_t width = rex & 8 ? 8 : 4;
+        uint64_t imm = 0;
+        memcpy(&imm, code + offset, width);
+        unsigned int reg = (opcode & 7) | ((rex & 1) << 3);
+        const dt_x86_reg *regs = width == 8 ? ir1_hot_gpr64 : ir1_hot_gpr32;
+        info = ir1_decode_template_output(ir1_num, pir1_base);
+        memset(info, 0, sizeof(*info));
+        info->id = dt_X86_INS_MOV;
+        info->x86.op_count = 2;
+        info->x86.operands[0].type = dt_X86_OP_REG;
+        info->x86.operands[0].size = width;
+        info->x86.operands[0].reg = regs[reg];
+        info->x86.operands[1].type = dt_X86_OP_IMM;
+        info->x86.operands[1].size = width;
+        info->x86.operands[1].imm = imm;
+        ir1_hot_finish(info, code, offset + width, address, rex, opcode, 0);
+        return info;
+    }
+
+    if (opcode == 0x83) {
+        uint8_t modrm = code[offset];
+        uint8_t group = (modrm >> 3) & 7;
+        static const unsigned int group_ids[8] = {
+            dt_X86_INS_ADD, dt_X86_INS_OR, dt_X86_INS_ADC, dt_X86_INS_SBB,
+            dt_X86_INS_AND, dt_X86_INS_SUB, dt_X86_INS_XOR, dt_X86_INS_CMP,
+        };
+        uint8_t width = rex & 8 ? 8 : 4;
+        dt_cs_x86_op rm_operand = { 0 };
+        uint8_t end = ir1_hot_decode_rm(code, offset, rex, width, &rm_operand);
+        info = ir1_decode_template_output(ir1_num, pir1_base);
+        memset(info, 0, sizeof(*info));
+        info->id = group_ids[group];
+        info->x86.modrm = modrm;
+        info->x86.op_count = 2;
+        info->x86.operands[0] = rm_operand;
+        info->x86.operands[1].type = dt_X86_OP_IMM;
+        info->x86.operands[1].size = width;
+        int64_t imm = ir1_hot_read_simm(code + end, 1);
+        bool logical = group == 1 || group == 4 || group == 6;
+        info->x86.operands[1].imm = width == 4 && logical ?
+                                     (uint32_t)imm : imm;
+        ir1_hot_finish(info, code, end + 1, address, rex, opcode, 0);
+        return info;
+    }
+
+    uint8_t modrm = code[offset];
+    bool reverse = false;
+    bool lea = false;
+    unsigned int id;
+    switch (opcode) {
+    case 0x89:
+        id = dt_X86_INS_MOV;
+        break;
+    case 0x8b:
+        id = dt_X86_INS_MOV;
+        reverse = true;
+        break;
+    case 0x8d:
+        id = dt_X86_INS_LEA;
+        reverse = true;
+        lea = true;
+        break;
+    case 0x85:
+        id = dt_X86_INS_TEST;
+        break;
+    case 0x31:
+        id = dt_X86_INS_XOR;
+        break;
+    case 0x33:
+        id = dt_X86_INS_XOR;
+        reverse = true;
+        break;
+    case 0x39:
+        id = dt_X86_INS_CMP;
+        break;
+    case 0x3b:
+        id = dt_X86_INS_CMP;
+        reverse = true;
+        break;
+    case 0x01:
+        id = dt_X86_INS_ADD;
+        break;
+    case 0x03:
+        id = dt_X86_INS_ADD;
+        reverse = true;
+        break;
+    case 0x29:
+        id = dt_X86_INS_SUB;
+        break;
+    case 0x2b:
+        id = dt_X86_INS_SUB;
+        reverse = true;
+        break;
+    case 0x21:
+        id = dt_X86_INS_AND;
+        break;
+    case 0x23:
+        id = dt_X86_INS_AND;
+        reverse = true;
+        break;
+    case 0x09:
+        id = dt_X86_INS_OR;
+        break;
+    case 0x0b:
+        id = dt_X86_INS_OR;
+        reverse = true;
+        break;
+    default: return NULL;
+    }
+    unsigned int reg_index = ((modrm >> 3) & 7) | ((rex & 4) << 1);
+    uint8_t width = rex & 8 ? 8 : 4;
+    const dt_x86_reg *regs = width == 8 ? ir1_hot_gpr64 : ir1_hot_gpr32;
+    dt_cs_x86_op rm_operand = { 0 };
+    uint8_t end = ir1_hot_decode_rm(code, offset, rex, width, &rm_operand);
+    if (lea && rm_operand.type != dt_X86_OP_MEM) {
+        return NULL;
+    }
+    /* Leave memory TEST's backend-specific access metadata to Capstone. */
+    if (id == dt_X86_INS_TEST && rm_operand.type == dt_X86_OP_MEM) {
+        return NULL;
+    }
+    dt_cs_x86_op reg_operand = { 0 };
+    reg_operand.type = dt_X86_OP_REG;
+    reg_operand.size = width;
+    reg_operand.reg = regs[reg_index];
+    info = ir1_decode_template_output(ir1_num, pir1_base);
+    memset(info, 0, sizeof(*info));
+    info->id = id;
+    info->x86.modrm = modrm;
+    info->x86.op_count = 2;
+    info->x86.operands[0] = reverse ? reg_operand : rm_operand;
+    info->x86.operands[1] = reverse ? rm_operand : reg_operand;
+    ir1_hot_finish(info, code, end, address, rex, opcode, 0);
+    return info;
+}
+
+static struct la_dt_insn *ir1_decode_template_lookup(const uint8_t *code,
+                                                     size_t code_size,
+                                                     uint64_t address,
+                                                     int ir1_num,
+                                                     void *pir1_base,
+                                                     int mode)
+{
+    if (!ir1_decode_templates || !pir1_base) {
+        return NULL;
+    }
+    size_t prefixes = MIN(code_size, 4);
+    for (size_t size = 1; size <= prefixes; size++) {
+        size_t index = ir1_decode_template_hash(code, size, mode);
+        Ir1DecodeTemplate *entry = &ir1_decode_templates[index];
+        if (ir1_decode_template_valid[index] && entry->mode == mode &&
+            entry->size <= code_size &&
+            !memcmp(entry->bytes, code, entry->size)) {
+            struct la_dt_insn *output = ir1_decode_template_output(
+                ir1_num, pir1_base);
+            memcpy(output, &entry->decoded, sizeof(*output));
+            output->address = address;
+            return output;
+        }
+    }
+    return NULL;
+}
+
+static bool ir1_decode_template_is_address_independent(
+        const struct la_dt_insn *info)
+{
+    /* Relative immediates and RIP-relative memory change with the guest PC. */
+    for (int i = 0; i < info->x86.op_count; i++) {
+        if (info->x86.operands[i].type == dt_X86_OP_IMM ||
+            (info->x86.operands[i].type == dt_X86_OP_MEM &&
+             (info->x86.operands[i].mem.base == dt_X86_REG_RIP ||
+              info->x86.operands[i].mem.index == dt_X86_REG_RIP))) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static void ir1_decode_template_insert(const uint8_t *code, size_t code_size,
+                                       int mode,
+                                       const struct la_dt_insn *info)
+{
+    if (!info->size || info->size > code_size || info->size > 15 ||
+        !ir1_decode_template_is_address_independent(info)) {
+        return;
+    }
+    if (!ir1_decode_templates) {
+        ir1_decode_templates = g_new(Ir1DecodeTemplate,
+                                     IR1_DECODE_TEMPLATE_CACHE_SIZE);
+        ir1_decode_template_valid = g_new0(uint8_t,
+                                           IR1_DECODE_TEMPLATE_CACHE_SIZE);
+        g_private_set(&ir1_decode_templates_owner, ir1_decode_templates);
+        g_private_set(&ir1_decode_template_valid_owner,
+                      ir1_decode_template_valid);
+    }
+    size_t prefix_size = MIN((size_t)info->size, 4);
+    size_t index = ir1_decode_template_hash(code, prefix_size, mode);
+    Ir1DecodeTemplate *entry = &ir1_decode_templates[index];
+    entry->mode = mode;
+    entry->size = info->size;
+    memcpy(entry->bytes, code, info->size);
+    memcpy(&entry->decoded, info, sizeof(entry->decoded));
+    ir1_decode_template_valid[index] = true;
+}
+
+#endif /* LATX_IR1_DECODE_H */

--- a/target/i386/latx/ir1/ir1.c
+++ b/target/i386/latx/ir1/ir1.c
@@ -130,6 +130,9 @@ void (*disassemble_trace_cmp)(const uint8_t *code, size_t code_size,
         uint64_t address,
         size_t count,
         struct la_dt_insn *inputinsn, int mode) = disassemble_trace_cmp_nop;
+
+#include "ir1-decode.h"
+
 static IR1_OPND ir1_opnd_new_static_reg(IR1_OPND_TYPE opnd_type, int size,
                                         dt_x86_reg reg)
 {
@@ -331,31 +334,44 @@ static void __attribute__((__constructor__)) x86tomisp_ir1_init(void)
 #endif
 };
 
-ADDRX ir1_disasm(IR1_INST *ir1, uint8_t *addr, ADDRX t_pc, int ir1_num, void *pir1_base)
+ADDRX ir1_disasm(IR1_INST *ir1, uint8_t *addr, ADDRX t_pc, int ir1_num,
+                 void *pir1_base)
 {
     struct la_dt_insn *info;
-    uint32_t nop = 0x401f0f;
-    uint64_t nop_5 = 0x441f0f;
+    bool original_code = true;
+    uint8_t nop[15] = { 0x0f, 0x1f, 0x40, 0 };
+    uint8_t nop_5[15] = { 0x0f, 0x1f, 0x44, 0, 0 };
     if (((*((uint32_t *)addr)) & 0xf8ffffff) == 0xc81e0ff3) {
         //repleace endbr32/rdsspd with 4 bytes nop, just a temporary solution
-        addr = (uint8_t *)&nop;
+        addr = nop;
+        original_code = false;
     }
 
     if (((*((uint64_t *)addr)) & 0xfffffaff) == 0x1e0f48f3) {
         /* repleace rdsspq with 5 bytes nop, just a temporary solution */
-        addr = (uint8_t *)&nop_5;
+        addr = nop_5;
+        original_code = false;
     }
 #ifdef CONFIG_LATX_AVX_OPT
     if (((*((uint64_t *)addr)) & 0xfffffaff) == 0xae0f48f3) {
         /* repleace incsspq with 5 bytes nop, just a temporary solution */
-        addr = (uint8_t *)&nop_5;
+        addr = nop_5;
+        original_code = false;
     }
 #endif
     /* FIXME:the count parameter in cs_disasm is 1, it means we translte 1 insn at a time,
      * there should be a performance improvement if we increase the number, but
      * for now there are some problems if we change it. It will be settled later.
      */
-    int count = la_disa_v1(addr, 15, (uint64_t)t_pc,
+    info = original_code ? ir1_hot_decode(
+        addr, t_pc, ir1_num, pir1_base, CODEIS64) : NULL;
+    bool hot_hit = info != NULL;
+    if (!hot_hit && original_code) {
+        info = ir1_decode_template_lookup(addr, 15, t_pc, ir1_num,
+                                          pir1_base, CODEIS64);
+    }
+    bool template_hit = !hot_hit && info != NULL;
+    int count = info ? 1 : la_disa_v1(addr, 15, (uint64_t)t_pc,
         1, &info, ir1_num, pir1_base, CODEIS64);
 
     ir1->info = info;
@@ -387,6 +403,9 @@ ADDRX ir1_disasm(IR1_INST *ir1, uint8_t *addr, ADDRX t_pc, int ir1_num, void *pi
                 info->x86.operands[i].mem.segment = dt_X86_REG_INVALID;
             }
         }
+    }
+    if (original_code && !hot_hit && !template_hit) {
+        ir1_decode_template_insert(addr, 15, CODEIS64, info);
     }
 #ifdef CONFIG_LATX_INSTS_PATTERN
     ir1->instptn.opc  = INSTPTN_OPC_NONE;

--- a/tests/unit/meson.build
+++ b/tests/unit/meson.build
@@ -233,3 +233,16 @@ test(
   test_kzt_address_policy,
   suite: 'lat-pr-fast',
 )
+
+if 'CONFIG_LATX_CAPSTONE_GIT' in config_host and 'CONFIG_LATX_DEBUG' not in config_host
+  test_ir1_decode = executable(
+    'test-ir1-decode',
+    files('test-ir1-decode.c') + genh,
+    include_directories: include_directories(
+      '../..', '../../target/i386/latx/include',
+    ),
+    dependencies: [glib, qemuutil, capstone_git],
+    build_by_default: false,
+  )
+  test('test-ir1-decode', test_ir1_decode, suite: 'lat-pr-fast', timeout: 30)
+endif

--- a/tests/unit/test-ir1-decode.c
+++ b/tests/unit/test-ir1-decode.c
@@ -1,0 +1,238 @@
+/*
+ * SPDX-FileCopyrightText: 2026 LAT Project Authors
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+#include "qemu/osdep.h"
+#include "capstone_git.h"
+#include "target/i386/latx/ir1/ir1-decode.h"
+
+csh handle[2];
+
+static unsigned int checked;
+static unsigned int failures;
+
+static void mismatch(const uint8_t *code, const char *field,
+                     int64_t actual, int64_t expected)
+{
+    static unsigned int shown[256];
+    unsigned int opcode =
+        code[0] >= 0x40 && code[0] <= 0x4f ? code[1] : code[0];
+    failures++;
+    if (shown[opcode]++ < 3) {
+        fprintf(stderr, "%s: got 0x%" PRIx64 " expected 0x%" PRIx64 " bytes:",
+                field, (uint64_t)actual, (uint64_t)expected);
+        for (int i = 0; i < 15; i++) {
+            fprintf(stderr, " %02x", code[i]);
+        }
+        fprintf(stderr, "\n");
+    }
+}
+
+#define SAME(field) do { \
+    if (fast.field != full->field) { \
+        mismatch(code, #field, fast.field, full->field); \
+    } \
+} while (0)
+
+static void compare(const uint8_t *code, uint64_t address)
+{
+    struct la_dt_insn fast = { 0 }, decoded = { 0 }, *full = NULL;
+    if (!ir1_hot_decode(code, address, 0, &fast, 1)) {
+        return;
+    }
+    checked++;
+    int count = gitcapstone_get(code, 15, address, 1, &full, 0, &decoded, 1);
+    if (count != 1 || !full) {
+        mismatch(code, "valid instruction", 1, 0);
+        return;
+    }
+    SAME(id);
+    SAME(size);
+    SAME(address);
+    SAME(x86.addr_size);
+    SAME(x86.rex);
+    SAME(x86.modrm);
+    SAME(x86.op_count);
+    SAME(x86.avx_cc);
+    for (int i = 0; i < 4; i++) {
+        SAME(x86.prefix[i]);
+        SAME(x86.opcode[i]);
+    }
+    for (int i = 0; i < fast.size; i++) {
+        SAME(bytes[i]);
+    }
+    for (int i = 0; i < fast.x86.op_count; i++) {
+        SAME(x86.operands[i].type);
+        SAME(x86.operands[i].size);
+        SAME(x86.operands[i].access);
+        SAME(x86.operands[i].avx_bcast);
+        SAME(x86.operands[i].avx_zero_opmask);
+        switch (fast.x86.operands[i].type) {
+        case dt_X86_OP_REG:
+            SAME(x86.operands[i].reg);
+            break;
+        case dt_X86_OP_IMM:
+            SAME(x86.operands[i].imm);
+            break;
+        case dt_X86_OP_MEM:
+            SAME(x86.operands[i].mem.segment);
+            SAME(x86.operands[i].mem.default_segment);
+            SAME(x86.operands[i].mem.base);
+            SAME(x86.operands[i].mem.index);
+            SAME(x86.operands[i].mem.scale);
+            SAME(x86.operands[i].mem.disp);
+            break;
+        default:
+            g_assert_not_reached();
+        }
+    }
+}
+
+static void test_cache(void)
+{
+    uint8_t code[15] = { 0x0f, 0xaf, 0xc1 }; /* imul eax, ecx */
+    struct la_dt_insn decoded = { 0 }, output[2] = { 0 }, *full;
+    g_assert_cmpint(gitcapstone_get(code, 15, 0x1000, 1, &full,
+                                   0, &decoded, 1), ==, 1);
+    ir1_decode_template_insert(code, 15, 1, full);
+    g_assert_true(ir1_decode_template_lookup(code, 15, 0x2000, 1,
+                                             output, 1) == &output[1]);
+    decoded.address = 0x2000;
+    g_assert_cmpmem(&decoded, sizeof(decoded), &output[1], sizeof(output[1]));
+    code[3] = 0xff; /* bytes beyond the instruction must not affect the key */
+    g_assert_nonnull(ir1_decode_template_lookup(
+        code, 15, 0x3000, 0, output, 1));
+    g_assert_null(ir1_decode_template_lookup(code, 2, 0x3000, 0, output, 1));
+    g_assert_null(ir1_decode_template_lookup(code, 15, 0x3000, 0, output, 0));
+    g_assert_null(ir1_decode_template_lookup(code, 15, 0x3000, 0, NULL, 1));
+    code[2] ^= 1;
+    g_assert_null(ir1_decode_template_lookup(code, 15, 0x3000, 0, output, 1));
+    decoded.x86.operands[0].type = dt_X86_OP_IMM;
+    g_assert_false(ir1_decode_template_is_address_independent(&decoded));
+    decoded.x86.operands[0].type = dt_X86_OP_MEM;
+    decoded.x86.operands[0].mem.base = dt_X86_REG_RIP;
+    g_assert_false(ir1_decode_template_is_address_independent(&decoded));
+}
+
+static void test_modes(void)
+{
+    /* The same bytes are DEC EAX in 32-bit mode and IMUL RAX, RCX in 64-bit. */
+    uint8_t code[15] = { 0x48, 0x0f, 0xaf, 0xc1 };
+    struct la_dt_insn decoded[2] = { 0 }, output = { 0 }, *full;
+    for (int mode = 0; mode < 2; mode++) {
+        g_assert_cmpint(gitcapstone_get(code, 15, 0x1000, 1, &full,
+            0, &decoded[mode], mode), ==, 1);
+        ir1_decode_template_insert(code, 15, mode, full);
+    }
+    g_assert_cmpuint(decoded[0].size, ==, 1);
+    g_assert_cmpuint(decoded[1].size, ==, 4);
+    for (int mode = 0; mode < 2; mode++) {
+        g_assert_nonnull(ir1_decode_template_lookup(code, 15, 0x2000,
+            0, &output, mode));
+        decoded[mode].address = 0x2000;
+        g_assert_cmpmem(&decoded[mode], sizeof(output), &output, sizeof(output));
+    }
+}
+
+static void test_collision(void)
+{
+    uint8_t a[15] = { 0x0f, 0x1f, 0x84, 0, 0x11, 0x22, 0x33, 0x44 };
+    uint8_t b[15];
+    struct la_dt_insn decoded = { 0 }, output = { 0 }, *full;
+    memcpy(b, a, sizeof(b));
+    b[7] ^= 1;
+    g_assert_cmpuint(ir1_decode_template_hash(a, 4, 1), ==,
+                     ir1_decode_template_hash(b, 4, 1));
+    g_assert_cmpint(gitcapstone_get(a, 15, 0, 1, &full,
+                                   0, &decoded, 1), ==, 1);
+    ir1_decode_template_insert(a, 15, 1, full);
+    g_assert_cmpint(gitcapstone_get(b, 15, 0, 1, &full,
+                                   0, &decoded, 1), ==, 1);
+    ir1_decode_template_insert(b, 15, 1, full);
+    g_assert_null(ir1_decode_template_lookup(a, 15, 0, 0, &output, 1));
+    g_assert_nonnull(ir1_decode_template_lookup(b, 15, 0, 0, &output, 1));
+    g_assert_cmpmem(&decoded, sizeof(decoded), &output, sizeof(output));
+}
+
+static gpointer cache_worker(gpointer opaque)
+{
+    const struct la_dt_insn *decoded = opaque;
+    struct la_dt_insn output = { 0 };
+    g_assert_null(ir1_decode_templates);
+    g_assert_null(ir1_decode_template_valid);
+    ir1_decode_template_insert(decoded->bytes, 15, 1, decoded);
+    g_assert_nonnull(ir1_decode_template_lookup(decoded->bytes, 15,
+        decoded->address, 0, &output, 1));
+    g_assert_cmpmem(decoded, sizeof(*decoded), &output, sizeof(output));
+    /* Both GPrivate owners release their storage when the thread exits. */
+    return NULL;
+}
+
+static void test_threads(void)
+{
+    uint8_t code[15] = { 0x0f, 0xaf, 0xc1 };
+    struct la_dt_insn decoded = { 0 }, *full;
+    g_assert_cmpint(gitcapstone_get(code, 15, 0x1000, 1, &full,
+                                   0, &decoded, 1), ==, 1);
+    for (int i = 0; i < 32; i++) {
+        GThread *worker = g_thread_new("decode-cache", cache_worker, &decoded);
+        g_thread_join(worker);
+    }
+}
+
+int main(void)
+{
+    gitcapstone_init(64);
+    uint8_t code[15];
+    /* Every opcode/ModRM/REX combination, with both displacement signs. */
+    for (int r = -1; r < 16; r++) {
+        for (int op = 0; op < 256; op++) {
+            for (int modrm = 0; modrm < 256; modrm++) {
+                memset(code, modrm & 1 ? 0x81 : 0x7e, sizeof(code));
+                int n = 0;
+                if (r >= 0) {
+                    code[n++] = 0x40 + r;
+                }
+                code[n++] = op;
+                code[n] = modrm;
+                compare(code, UINT64_C(0x7fff12345678));
+            }
+        }
+    }
+    /* Exercise each SIB byte and 32/64-bit register extension combination. */
+    for (int r = 0; r < 16; r++) {
+        for (int mod = 0; mod < 3; mod++) {
+            for (int sib = 0; sib < 256; sib++) {
+                memset(code, 0x80, sizeof(code));
+                code[0] = 0x40 + r;
+                code[1] = 0x8b;
+                code[2] = (mod << 6) | 4;
+                code[3] = sib;
+                compare(code, UINT64_MAX - 4);
+            }
+        }
+    }
+    /* Deterministic mixed prefixes, immediates and displacements. */
+    uint32_t random = 0x12345678;
+    for (int sample = 0; sample < 500000; sample++) {
+        for (int i = 0; i < 15; i++) {
+            random ^= random << 13;
+            random ^= random >> 17;
+            random ^= random << 5;
+            code[i] = random;
+        }
+        compare(code, sample & 1 ? 0 : UINT64_MAX - 4);
+    }
+    memset(code, 0x90, sizeof(code));
+    struct la_dt_insn output;
+    g_assert_null(ir1_hot_decode(code, 0, 0, &output, 0));
+    g_assert_null(ir1_hot_decode(code, 0, 0, NULL, 1));
+    test_cache();
+    test_collision();
+    test_modes();
+    test_threads();
+    g_assert_cmpuint(checked, >, 250000);
+    printf("fast decoder checked=%u field mismatches=%u\n", checked, failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
Common x86-64 instructions currently take the full Capstone path on every translation. Decode selected regular forms directly, then reuse exact decoded templates for other repeated encodings before falling back to Capstone. This is enabled in ordinary translation without latc or an environment switch.

The thread-local cache has 16,384 slots, validates the mode and complete instruction bytes, excludes immediate and RIP-relative operands, and releases storage at thread exit. The direct path preserves operand access metadata and Capstone's SIB zero-index representation. Memory TEST forms retain the full decoder's metadata. Debug builds and non-git Capstone backends retain full decoding for the direct-path portion.

Adapted from commits 6d1f4ed916809836e38a814d4e802e7d2f115a1a and e066fe9679827ab447c3d9b58e01f14a69558448, authored by Lu Zeng <luzeng87@gmail.com>. No latc source, generated copy, or AOT v2 dependency is included.

Validation on LoongArch:

- Clean configure/build/install; all 29 `lat-pr-fast` tests pass, including the installation test.
- Differential testing against the bundled Capstone adapter: 257,473 accepted fast-path instructions, zero differences in the compared decode fields. Covers opcode/ModRM/REX enumeration, SIB combinations and deterministic random inputs; also tests exact cache matching, collisions, address relocation, 32/64-bit mode separation and thread isolation.
- Signal handling with KZT off/on, thread visibility, two soft-float modes, Python threads and SQLite pass. All five gzip ref inputs match their reference output. Guest assembly fixtures were built in Docker on x86.
- SPEC CPU2000 `test all`: all 26 benchmarks (12 integer, 14 floating-point) pass the official output validation, with 29 benchmark invocations returning zero. Used prebuilt GCC 4.8 x86-64 executables, one iteration, AOT disabled and explicit optimized-runner invocation. Both CINT2000 and CFP2000 raw reports mark every benchmark valid. This is the test input set, not ref performance scoring.
- With AOT disabled, Python startup/imports plus `sum(range(100000))`, ten alternating runs per version after preheating: median wall 0.87 -> 0.68 s, user 0.42 -> 0.31 s, sys 0.00 -> 0.01 s. Peak RSS 112,352 -> 121,056 KiB (+8.5 MiB). Same upstream base and product configuration. A concurrent task shared the pinned CPU during this exploratory run, so these timings are not a validated isolated performance baseline or a general speedup claim.

A complete i386 runner build, debug/non-git backend builds and the entire integration suite were not run. No general SPEC performance claim is made.
