### PR TITLE
LATX, infra: Simplify manual CI requests and default to SPEC

### DIFF
--- a/.github/workflows/request-lat-ci.yml
+++ b/.github/workflows/request-lat-ci.yml
@@ -8,12 +8,8 @@ on:
         description: "Open pull request number in lat-opensource/lat"
         required: true
         type: string
-      expected_head_sha:
-        description: "Exact current PR head SHA approved for this test"
-        required: true
-        type: string
       test_request:
-        description: 'Optional JSON, e.g. {"schema_version":1,"suites":[{"suite_key":"spec2000","parameters":{"input_size":"ref","runs_per_invocation":3,"test_set":"197","times":2,"performance_analysis":true},"environment":{"LATX_AOT":"0"}}]}'
+        description: 'Optional JSON. Blank runs SPEC2000 ref 3 all twice in serialized performance mode, with no user environment variables.'
         required: false
         type: string
         default: ""
@@ -49,13 +45,11 @@ jobs:
         id: resolve
         env:
           MANUAL_PR_NUMBER: ${{ inputs.pr_number }}
-          EXPECTED_HEAD_SHA: ${{ inputs.expected_head_sha }}
           MANUAL_TARGET_REPOSITORY: ${{ github.repository }}
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           python3 scripts/ci/lat_ci_request.py \
             --pr-number "$MANUAL_PR_NUMBER" \
-            --expected-head-sha "$EXPECTED_HEAD_SHA" \
             --target-repository "$MANUAL_TARGET_REPOSITORY" \
             --output "$GITHUB_OUTPUT"
 
@@ -98,7 +92,20 @@ jobs:
                   "head_sha": os.environ["HEAD_SHA"],
                   "base_sha": os.environ["BASE_SHA"],
                   "head_ref": os.environ["HEAD_REF"],
-                  "test_request": os.environ["TEST_REQUEST"],
+                  "test_request": os.environ["TEST_REQUEST"].strip() or json.dumps({
+                      "schema_version": 1,
+                      "suites": [{
+                          "suite_key": "spec2000",
+                          "parameters": {
+                              "input_size": "ref",
+                              "runs_per_invocation": 3,
+                              "test_set": "all",
+                              "times": 2,
+                              "performance_analysis": True,
+                          },
+                          "environment": {},
+                      }],
+                  }),
                   "requester": os.environ["REQUESTER"],
               },
           }))

--- a/scripts/ci/lat_ci_request.py
+++ b/scripts/ci/lat_ci_request.py
@@ -47,14 +47,13 @@ def get_json(path, token, opener=urllib.request.urlopen):
         return json.load(response)
 
 
-def resolve_pull_request(pr_number_value, expected_head_sha, target, fetch_json):
+def resolve_pull_request(pr_number_value, target, fetch_json):
     """Return immutable dispatch values after validating a GitHub PR response."""
     if not isinstance(pr_number_value, str) or not POSITIVE_INTEGER_PATTERN.fullmatch(pr_number_value.strip()):
         raise LatCIRequestError("pr_number must be a positive integer")
     pr_number = int(pr_number_value)
     if target != EXPECTED_TARGET_REPOSITORY:
         raise LatCIRequestError(f"This workflow must run in {EXPECTED_TARGET_REPOSITORY}")
-    expected_head_sha = _sha(expected_head_sha, "expected_head_sha")
 
     pr = fetch_json(f"repos/{target}/pulls/{pr_number}")
     if not isinstance(pr, dict):
@@ -86,13 +85,6 @@ def resolve_pull_request(pr_number_value, expected_head_sha, target, fetch_json)
     base_sha = _sha(base.get("sha"), "The PR base SHA")
     head_ref = _one_line_string(head.get("ref"), "The PR head ref")
 
-    # The maintainer approves a concrete (PR number, head SHA) pair.  A force
-    # push after review must require a fresh approval and dispatch.
-    if head_sha != expected_head_sha:
-        raise LatCIRequestError(
-            "PR head changed since approval; review the new commit and dispatch again"
-        )
-
     return {
         "should_dispatch": "true",
         "source_repository": source_repository,
@@ -115,7 +107,6 @@ def write_github_output(values, output_path):
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--pr-number", required=True)
-    parser.add_argument("--expected-head-sha", required=True)
     parser.add_argument("--target-repository", required=True)
     parser.add_argument("--output", required=True)
     args = parser.parse_args()
@@ -123,7 +114,6 @@ def main():
     try:
         values = resolve_pull_request(
             args.pr_number,
-            args.expected_head_sha,
             args.target_repository,
             lambda path: get_json(path, os.environ.get("GITHUB_TOKEN", "")),
         )

--- a/tests/ci/test_lat_ci_workflows.py
+++ b/tests/ci/test_lat_ci_workflows.py
@@ -5,6 +5,8 @@
 import importlib.util
 import io
 import json
+import os
+import subprocess
 import unittest
 from pathlib import Path
 
@@ -49,9 +51,9 @@ class Response(io.BytesIO):
 
 
 class LatCIRequestTest(unittest.TestCase):
-    def resolve(self, pr, expected_head_sha=HEAD_SHA, pr_number="466"):
+    def resolve(self, pr, pr_number="466"):
         return REQUEST.resolve_pull_request(
-            pr_number, expected_head_sha, TARGET, lambda path: pr
+            pr_number, TARGET, lambda path: pr
         )
 
     def test_accepts_upstream_branch_with_s_in_repository_name(self):
@@ -62,9 +64,9 @@ class LatCIRequestTest(unittest.TestCase):
         result = self.resolve(pull_request("reviewers/test-suite"))
         self.assertEqual(result["source_repository"], "reviewers/test-suite")
 
-    def test_rejects_head_changed_after_manual_approval(self):
-        with self.assertRaisesRegex(REQUEST.LatCIRequestError, "head changed since approval"):
-            self.resolve(pull_request(head_sha="c" * 40))
+    def test_resolves_current_head_without_manual_sha(self):
+        result = self.resolve(pull_request(head_sha="c" * 40))
+        self.assertEqual(result["head_sha"], "c" * 40)
 
     def test_rejects_invalid_pr_number(self):
         with self.assertRaisesRegex(REQUEST.LatCIRequestError, "positive integer"):
@@ -135,15 +137,43 @@ class LatCICallbackTest(unittest.TestCase):
 
 
 class WorkflowDefinitionTest(unittest.TestCase):
-    def test_request_workflow_binds_approval_to_sha_and_uses_github_token(self):
+    def test_dispatch_defaults_and_explicit_request(self):
+        workflow = (ROOT / ".github/workflows/request-lat-ci.yml").read_text()
+        # Execute the actual payload builder embedded in the workflow.
+        import textwrap
+        code = textwrap.dedent(workflow.split("<<'PY'\n", 1)[1].split("\n          PY", 1)[0])
+        environment = dict(os.environ, **{name: "test" for name in (
+            "REQUEST_KIND", "SOURCE_REPOSITORY", "SOURCE_REPOSITORY_ID",
+            "TARGET_REPOSITORY", "PR_NUMBER", "HEAD_SHA", "BASE_SHA",
+            "HEAD_REF", "REQUESTER",
+        )})
+        explicit = '{"schema_version":1,"suites":[]}'
+        for value in ("", "   ", explicit):
+            environment["TEST_REQUEST"] = value
+            payload = json.loads(subprocess.check_output(
+                ["python3", "-c", code], env=environment, text=True
+            ))
+            request = payload["inputs"]["test_request"]
+            if value == explicit:
+                self.assertEqual(request, explicit)
+            else:
+                self.assertEqual(json.loads(request), {
+                    "schema_version": 1,
+                    "suites": [{"suite_key": "spec2000", "parameters": {
+                        "input_size": "ref", "runs_per_invocation": 3,
+                        "test_set": "all", "times": 2,
+                        "performance_analysis": True,
+                    }, "environment": {}}],
+                })
+
+    def test_request_workflow_resolves_sha_and_uses_github_token(self):
         workflow = (ROOT / ".github" / "workflows" / "request-lat-ci.yml").read_text(
             encoding="utf-8"
         )
-        self.assertIn("expected_head_sha:", workflow)
-        self.assertIn("EXPECTED_HEAD_SHA: ${{ inputs.expected_head_sha }}", workflow)
+        self.assertNotIn("expected_head_sha", workflow)
+        self.assertNotIn("EXPECTED_HEAD_SHA", workflow)
         self.assertIn("GITHUB_TOKEN: ${{ github.token }}", workflow)
         self.assertIn("scripts/ci/lat_ci_request.py", workflow)
-        self.assertIn("--expected-head-sha \"$EXPECTED_HEAD_SHA\"", workflow)
         self.assertIn("actions/checkout@v5", workflow)
         self.assertNotIn("[^/\\\\s]+/[^/\\\\s]+", workflow)
 


### PR DESCRIPTION
## Summary

- Remove manual SHA confirmation and resolve the current head commit from the PR number.
- Default an empty test request to SPEC2000 `ref/all`, with three runs per invocation and two invocations.
- Enable serialized performance testing by default, without user environment variables.
- Preserve explicitly supplied test requests. CI remains manually triggered.

## Validation

- `python3 tests/ci/test_lat_ci_workflows.py`: 11 tests passed.
- `git diff --check`: passed.
- Verified the default request through the personal repository CI.
- Verified that INT and FP results appear under one result entry using a shorter `test/all` run.
- The updated upstream entry has not yet been tested end to end.

## Checklist

- [x] I have read `CONTRIBUTING.md`.
- [x] Every commit contains a DCO sign-off (`git commit -s`).
- [x] I have included relevant build or test results, or explained why they are not applicable.