### PR TITLE
LATX, infra: Streamline PR CI and automate validated releases

### DIFF
--- a/.github/.ci/aosc/Dockerfile
+++ b/.github/.ci/aosc/Dockerfile
@@ -1,4 +1,5 @@
-FROM aosc/aosc-os:container
+# The floating container tag may omit LoongArch from its manifest.
+FROM aosc/aosc-os:container-20260909-loongarch64@sha256:40fe33ba8393bc4420ad88cd3eedf40ff09531e430e58895609da4769a8ad1d2
 ARG TARGETARCH
 
 ARG DEPENDENCIES="         \

--- a/.github/.ci/clang/Dockerfile
+++ b/.github/.ci/clang/Dockerfile
@@ -2,6 +2,7 @@ FROM ghcr.io/fedora-remix-loongarch/mini-image:f43
 ARG TARGETARCH
 
 ARG DEPENDENCIES="         \
+        ccache             \
         clang              \
         make               \
         git                \

--- a/.github/.ci/fedora/Dockerfile
+++ b/.github/.ci/fedora/Dockerfile
@@ -2,6 +2,7 @@ FROM ghcr.io/fedora-remix-loongarch/mini-image:f43
 ARG TARGETARCH
 
 ARG DEPENDENCIES="         \
+        ccache             \
         gcc                \
         g++                \
         make               \

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -16,6 +16,10 @@ on:
       - '.github/.ci/**'
       - '.github/workflows/build-docker-images.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     runs-on: ${{ matrix.IMAGE.RUNNER }}
@@ -50,6 +54,8 @@ jobs:
         run: |
           ATTEST_IMAGE=$(echo "${{ matrix.IMAGE.TAG_NAME }}" | cut -d ':' -f 1)
           echo "ATTEST_IMAGE=${ATTEST_IMAGE}" | tee -a "$GITHUB_OUTPUT"
+          DOCKERFILE_HASH=$(sha256sum "${{ matrix.IMAGE.DOCKERFILE_PATH }}/Dockerfile" | cut -d ' ' -f 1)
+          echo "CONTENT_TAG=${{ matrix.IMAGE.TAG_NAME }}-${DOCKERFILE_HASH}" >> "$GITHUB_OUTPUT"
 
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v4
@@ -73,7 +79,9 @@ jobs:
         with:
           context: ${{ matrix.IMAGE.DOCKERFILE_PATH }}
           cache-from: ghcr.io/${{ github.repository_owner }}/${{ matrix.IMAGE.TAG_NAME }}
-          tags: ghcr.io/${{ github.repository_owner }}/${{ matrix.IMAGE.TAG_NAME }}
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/${{ matrix.IMAGE.TAG_NAME }}
+            ghcr.io/${{ github.repository_owner }}/${{ steps.image-name.outputs.CONTENT_TAG }}
           platforms: ${{ matrix.IMAGE.DOCKER_PLATFORM }}
           pull: true
           push: ${{ (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/master' }}

--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -1,7 +1,14 @@
 name: Clang Compile
 
 on:
+  workflow_call:
+  # Select the exact release-candidate ref when running manually before release.
   workflow_dispatch:
+  schedule:
+    # Daily at 02:00 China Standard Time.
+    - cron: "0 18 * * *"
+  release:
+    types: [published]
   push:
     branches:
       - master
@@ -13,11 +20,18 @@ on:
       - "**/*.py"
       - "**/meson.build"
       - "meson.options"
+      - "meson_options.txt"
+      - "configs/**"
+      - "**/*.mak"
+      - ".gitmodules"
       - "configure"
+      - "Makefile"
+      - "GNUmakefile"
+      - "meson"
+      - "meson/**"
       - "latxbuild/**"
       - ".github/.ci/clang/**"
-      - ".github/workflows/build-docker-images.yml"
-      - ".github/workflows/clang.yml"
+      - ".github/workflows/**"
   pull_request:
     paths:
       - "**/*.c"
@@ -27,19 +41,30 @@ on:
       - "**/*.py"
       - "**/meson.build"
       - "meson.options"
+      - "meson_options.txt"
+      - "configs/**"
+      - "**/*.mak"
+      - ".gitmodules"
       - "configure"
+      - "Makefile"
+      - "GNUmakefile"
+      - "meson"
+      - "meson/**"
       - "latxbuild/**"
       - ".github/.ci/clang/**"
-      - ".github/workflows/build-docker-images.yml"
-      - ".github/workflows/clang.yml"
+      - ".github/workflows/**"
 
 permissions:
   contents: read
 
+concurrency:
+  # github.workflow is the caller's name in a reusable workflow.
+  group: lat-clang-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   compile:
-    # Native LoongArch clang coverage.  The existing GCC release matrix stays
-    # in release.yml and is intentionally not part of this job.
+    # LoongArch clang runs under QEMU; GCC coverage lives in release.yml.
     name: "compile (Fedora, clang)"
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -53,10 +78,35 @@ jobs:
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v4
 
-      - name: Set up Docker Buildx
+      - name: Cache clang compilation
+        uses: actions/cache@v6
+        with:
+          path: /tmp/lat-clang-cache
+          key: clang-v1-${{ hashFiles('.github/.ci/clang/Dockerfile') }}-${{ github.sha }}
+          restore-keys: |
+            clang-v1-${{ hashFiles('.github/.ci/clang/Dockerfile') }}-
+
+      - name: Pull matching clang image
+        id: clang-image
+        env:
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+        run: |
+          DOCKERFILE_HASH=$(sha256sum .github/.ci/clang/Dockerfile | cut -d ' ' -f 1)
+          IMAGE="ghcr.io/${REPOSITORY_OWNER}/latx-runner-fedora-clang:loongarch64-${DOCKERFILE_HASH}"
+          if docker pull --platform linux/loong64 "$IMAGE"; then
+            docker tag "$IMAGE" lat-ci-clang:local
+            echo "build_local=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Matching image unavailable; building the checked-out Dockerfile."
+            echo "build_local=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Docker Buildx for a new image
+        if: steps.clang-image.outputs.build_local == 'true'
         uses: docker/setup-buildx-action@v4
 
       - name: Build dedicated clang image
+        if: steps.clang-image.outputs.build_local == 'true'
         run: |
           docker buildx build \
             --platform linux/loong64 \
@@ -68,14 +118,22 @@ jobs:
         run: |
           docker run --rm \
             --platform linux/loong64 \
-            --env CC=clang \
-            --env CXX=clang++ \
+            --env "CC=ccache clang" \
+            --env "CXX=ccache clang++" \
+            --env CCACHE_DIR=/root/.cache/ccache \
+            --volume /tmp/lat-clang-cache:/root/.cache \
             --volume "$(pwd):/io" \
             --workdir /io \
             lat-ci-clang:local \
             sh -eux -c '
               clang --version
               clang++ --version
+              # The compiler on PATH is a wrapper. Include the real compiler
+              # as well so a toolchain upgrade cannot reuse stale objects.
+              compiler_hash=$(sha256sum /usr/bin/clang /usr/bin/clang++ /usr/local/bin/clang | sha256sum | cut -d " " -f 1)
+              export CCACHE_COMPILERCHECK="string:$compiler_hash"
+              ccache --zero-stats
+              trap "ccache --show-stats" EXIT
               mkdir build-clang
               cd build-clang
               ../configure \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,13 @@ on:
   push:
     branches:
       - master
+    # Existing LAT tags use 1.6.7; also accept v-prefixed and RC tags.
+    # GitHub does not apply path filters to tag pushes.
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+-*'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-*'
     paths:
       - "**/*.c"
       - "**/*.h"
@@ -67,11 +74,11 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  # A manual candidate run covers all three workflows together.
-  # Automatic runs trigger tests.yml and clang.yml directly.
+  # Tag pushes and manual candidate runs cover all three workflows together.
+  # Branch pushes, schedules and release events trigger each workflow directly.
   candidate-tests:
     needs: select-matrix
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
     permissions:
       contents: read
       pull-requests: read
@@ -79,10 +86,74 @@ jobs:
 
   candidate-clang:
     needs: select-matrix
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
     permissions:
       contents: read
     uses: ./.github/workflows/clang.yml
+
+  release-validation:
+    name: Full release validation
+    needs: [select-matrix, build, candidate-tests, candidate-clang]
+    if: always() && (github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')))
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require the complete candidate matrix
+        env:
+          SELECT_RESULT: ${{ needs.select-matrix.result }}
+          BUILD_RESULT: ${{ needs.build.result }}
+          TEST_RESULT: ${{ needs.candidate-tests.result }}
+          CLANG_RESULT: ${{ needs.candidate-clang.result }}
+          BUILD_TYPES: ${{ needs.select-matrix.outputs.build_types }}
+          TEST_CONTAINERS: ${{ needs.select-matrix.outputs.test_containers }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+
+          for key in ("SELECT_RESULT", "BUILD_RESULT", "TEST_RESULT", "CLANG_RESULT"):
+              if os.environ[key] != "success":
+                  raise SystemExit(f"Full validation did not pass: {key}={os.environ[key]}")
+          builds = json.loads(os.environ["BUILD_TYPES"])
+          containers = json.loads(os.environ["TEST_CONTAINERS"])
+          if len(builds) != 5 or {item["NAME"] for item in builds} != {
+              "build-release", "build32", "build32-dbg", "build64", "build64-dbg"
+          }:
+              raise SystemExit("Release validation requires all five GCC build configurations")
+          if len(containers) != 3 or {item["name"] for item in containers} != {
+              "latx-runner-aosc", "latx-runner-debian", "latx-runner-fedora"
+          }:
+              raise SystemExit("Release validation requires all three test containers")
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary:
+              summary.write("## Full release validation passed\n\n")
+              summary.write(f"Commit: `{os.environ['GITHUB_SHA']}`\n\n")
+              summary.write("15 GCC builds, 3 lat-pr-fast jobs and 1 Clang build passed.\n")
+          PY
+
+  publish-release:
+    name: Publish verified release
+    needs: release-validation
+    if: github.repository == 'lat-opensource/lat' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - name: Download this run's release packages
+        uses: actions/download-artifact@v8
+        with:
+          pattern: latx-runner-*-build-release-*
+          path: release-artifacts
+          merge-multiple: false
+      - name: Publish packages after full validation
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: python3 scripts/ci/lat_ci_release.py publish
 
   select-matrix:
     name: Select CI coverage
@@ -98,6 +169,9 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
+      - name: Check version tag before building
+        if: startsWith(github.ref, 'refs/tags/')
+        run: python3 scripts/ci/lat_ci_release.py check-version
       - name: Select PR or full matrix
         id: matrix
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,16 @@
 name: Build and Release LAT
 
 on:
+  # Select the exact release-candidate ref when running manually before release.
   workflow_dispatch:
+  schedule:
+    # Daily at 02:00 China Standard Time.
+    - cron: "0 18 * * *"
   release:
+    types: [published]
   push:
+    branches:
+      - master
     paths:
       - "**/*.c"
       - "**/*.h"
@@ -12,12 +19,23 @@ on:
       - "**/*.py"
       - "**/meson.build"
       - "meson.options"
+      - "meson_options.txt"
+      - "configure"
+      - "Makefile"
+      - "GNUmakefile"
+      - "meson"
+      - "meson/**"
+      - "latxbuild/**"
+      - "configs/**"
+      - "**/*.mak"
+      - ".gitmodules"
+      - ".github/.ci/**"
       - "**/*.inc"
       - "**/*.yml"
       - "runtime/**"
       - "tests/runtime/**"
   pull_request:
-    types: [assigned, opened, synchronize, reopened]
+    types: [opened, synchronize, reopened]
     paths:
       - "**/*.c"
       - "**/*.h"
@@ -25,13 +43,70 @@ on:
       - "**/*.py"
       - "**/meson.build"
       - "meson.options"
+      - "meson_options.txt"
+      - "configure"
+      - "Makefile"
+      - "GNUmakefile"
+      - "meson"
+      - "meson/**"
+      - "latxbuild/**"
+      - "configs/**"
+      - "**/*.mak"
+      - ".gitmodules"
+      - ".github/.ci/**"
       - "**/*.inc"
       - "**/*.yml"
       - "runtime/**"
       - "tests/runtime/**"
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
+  # A manual candidate run covers all three workflows together.
+  # Automatic runs trigger tests.yml and clang.yml directly.
+  candidate-tests:
+    needs: select-matrix
+    if: github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: read
+      pull-requests: read
+    uses: ./.github/workflows/tests.yml
+
+  candidate-clang:
+    needs: select-matrix
+    if: github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/clang.yml
+
+  select-matrix:
+    name: Select CI coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      build_types: ${{ steps.matrix.outputs.build_types }}
+      test_containers: ${{ steps.matrix.outputs.test_containers }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Select PR or full matrix
+        id: matrix
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: python3 scripts/ci/lat_ci_matrix.py
+
   build:
+    needs: select-matrix
+    timeout-minutes: 45
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -40,16 +115,12 @@ jobs:
           - { NAME: 'latx-runner-aosc', ARCH_NAME: 'loong64' }
           - { NAME: 'latx-runner-debian', ARCH_NAME: 'loong64' }
           - { NAME: 'latx-runner-fedora', ARCH_NAME: 'loongarch64' }
-        type:
-          - { NAME: 'build-release', OPT: '' }
-          - { NAME: 'build32', OPT: '-c -a' }
-          - { NAME: 'build32-dbg', OPT: '-c' }
-          - { NAME: 'build64', OPT: '-c -a' }
-          - { NAME: 'build64-dbg', OPT: '-c' }
+        type: ${{ fromJSON(needs.select-matrix.outputs.build_types) }}
 
     steps:
       - uses: actions/checkout@v7
         with:
+          persist-credentials: false
           submodules: true
 
       - name: Setup Cache
@@ -61,9 +132,6 @@ jobs:
 
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
 
       - name: "Build LATX"
         run: |
@@ -90,4 +158,6 @@ jobs:
             ${{ matrix.type.NAME }}/latx-x86_64
             *.tar.xz
           retention-days: 7
-
+          # Allow retrying this build job within the same workflow run.
+          overwrite: true
+          if-no-files-found: error

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,14 @@
 name: LAT Tests
 
 on:
+  workflow_call:
+  # Select the exact release-candidate ref when running manually before release.
   workflow_dispatch:
+  schedule:
+    # Daily at 02:00 China Standard Time.
+    - cron: "0 18 * * *"
+  release:
+    types: [published]
   push:
     branches:
       - master
@@ -13,11 +20,20 @@ on:
       - "**/*.py"
       - "**/meson.build"
       - "meson_options.txt"
+      - "meson.options"
+      - "latxbuild/**"
+      - "configs/**"
+      - "**/*.mak"
+      - ".gitmodules"
       - "configure"
+      - "Makefile"
+      - "GNUmakefile"
+      - "meson"
+      - "meson/**"
       - "runtime/**"
       - "tests/runtime/**"
       - ".github/.ci/**"
-      - ".github/workflows/tests.yml"
+      - ".github/workflows/**"
   pull_request:
     paths:
       - "**/*.c"
@@ -27,18 +43,53 @@ on:
       - "**/*.py"
       - "**/meson.build"
       - "meson_options.txt"
+      - "meson.options"
+      - "latxbuild/**"
+      - "configs/**"
+      - "**/*.mak"
+      - ".gitmodules"
       - "configure"
+      - "Makefile"
+      - "GNUmakefile"
+      - "meson"
+      - "meson/**"
       - "runtime/**"
       - "tests/runtime/**"
       - ".github/.ci/**"
-      - ".github/workflows/tests.yml"
+      - ".github/workflows/**"
 
 permissions:
   contents: read
 
 # Test registration and suite selection rules are documented in tests/README.md.
+concurrency:
+  # Keep reusable calls separate from the caller and from Clang.
+  group: lat-tests-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
+  select-matrix:
+    name: Select CI coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      build_types: ${{ steps.matrix.outputs.build_types }}
+      test_containers: ${{ steps.matrix.outputs.test_containers }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Select PR or full matrix
+        id: matrix
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: python3 scripts/ci/lat_ci_matrix.py
+
   meson-fast:
+    needs: select-matrix
     name: "test (${{ matrix.container.name }}, lat-pr-fast)"
     runs-on: ubuntu-latest
     timeout-minutes: 40
@@ -46,24 +97,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        container:
-          - name: "latx-runner-aosc"
-            tag: "loong64"
-            sanitizers: false
-            prepare_meson: "command -v meson >/dev/null || oma install -y meson"
-          - name: "latx-runner-debian"
-            tag: "loong64"
-            sanitizers: true
-            prepare_meson: "command -v meson >/dev/null || { apt-get update && apt-get install -y meson; }"
-          - name: "latx-runner-fedora"
-            tag: "loongarch64"
-            sanitizers: false
-            prepare_meson: "command -v meson >/dev/null"
+        container: ${{ fromJSON(needs.select-matrix.outputs.test_containers) }}
 
     steps:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
+
+      - name: Cache test compilation
+        uses: actions/cache@v6
+        with:
+          path: /tmp/lat-test-cache
+          key: tests-v1-${{ matrix.container.name }}-${{ matrix.container.sanitizers }}-${{ hashFiles('.github/.ci/**/Dockerfile') }}-${{ github.sha }}
+          restore-keys: |
+            tests-v1-${{ matrix.container.name }}-${{ matrix.container.sanitizers }}-${{ hashFiles('.github/.ci/**/Dockerfile') }}-
 
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v4
@@ -72,12 +119,19 @@ jobs:
         run: |
           docker run --rm \
             --platform linux/loong64 \
+            --env CCACHE_DIR=/root/.cache/ccache \
+            --volume /tmp/lat-test-cache:/root/.cache \
             --volume "$(pwd):/io" \
             --workdir /io \
             "ghcr.io/${{ github.repository_owner }}/${{ matrix.container.name }}:${{ matrix.container.tag }}" \
             sh -eux -c '
               ${{ matrix.container.prepare_meson }}
               meson --version
+              # Older Fedora images did not include ccache; keep the first
+              # full run working while the updated image is being published.
+              command -v ccache >/dev/null || dnf install -y ccache
+              ccache --zero-stats
+              trap "ccache --show-stats" EXIT
               export CFLAGS="-Wno-error=unused-but-set-variable -Wno-error=unused-function -Wformat -Werror=format-y2k"
               mkdir -p build64-tests
               cd build64-tests

--- a/docs/devel/ci-validation.md
+++ b/docs/devel/ci-validation.md
@@ -1,0 +1,79 @@
+# CI validation tiers
+
+Ordinary source pull requests run eight build/test jobs:
+
+- AOSC, Debian and Fedora each run `build32 -c -a` and `build64 -c -a`.
+  These retain the existing AVX options and the 64-bit script's KZT option.
+- Debian runs `lat-pr-fast` with debug mode and ASan/UBSan enabled.
+- Fedora runs the Clang build for both guest architectures.
+
+The separate `build32-dbg`, `build64-dbg`, and `build-release` jobs are omitted
+from ordinary PR coverage. The sanitizer test job deliberately retains debug
+mode. Two short selection jobs run in addition to the eight build/test jobs.
+
+## Full coverage
+
+Full coverage retains all 15 GCC build jobs, all three `lat-pr-fast` jobs and
+the Clang build. It runs on:
+
+- pushes to `master`;
+- the daily schedule at 18:00 UTC (02:00 China Standard Time);
+- manual workflow runs;
+- published releases, as a post-publication check;
+- PRs changing build definitions, CI workflows/images/helpers, runtime
+  installation code, or preprocessor directives.
+
+The shared selector is `scripts/ci/lat_ci_matrix.py`. It checks the complete
+paginated PR file list, including previous paths of renamed files, and added
+or removed preprocessor directives. Unchanged preprocessor context alone does
+not expand coverage. Missing/truncated patches, incomplete lists and API
+failures select full coverage rather than silently dropping checks. This is a conservative
+heuristic; changes to code inside an existing conditional block may still need
+a manually requested full run.
+
+## Before publishing a release
+
+Run **Build and Release LAT** manually on the exact candidate branch or tag.
+It runs the full GCC matrix and calls **LAT Tests** and **Clang Compile** at the
+same revision. Wait for the entire run to succeed before publishing, and rerun
+validation if the candidate changes. This workflow uploads artifacts but does
+not publish a GitHub release.
+
+The release-event trigger is a post-publication check. QEMU containers do not
+replace native LoongArch compatibility, integration or performance acceptance.
+
+## Avoiding repeated work
+
+Each PR workflow cancels older runs of the same workflow and PR when a new run
+starts. Different PRs do not cancel one another. Master, scheduled, manual and
+release runs are not cancelled by this policy. GCC push builds run only on
+`master`, and assigning a PR no longer triggers a build.
+
+Test and Clang jobs persist ccache separately from product build caches, with
+keys separating the container, sanitizer mode where applicable, Dockerfiles and
+commit. Prefix restoration reuses prior compilations, and the container prints
+ccache statistics even when compilation or testing fails. Meson build trees are
+not restored across fresh runners. The Fedora and Clang images include ccache;
+the test job can install it in older Fedora images during rollout.
+
+The image builder publishes the existing image tags plus tags suffixed with
+the SHA-256 of each Dockerfile. Clang first pulls its matching Dockerfile tag.
+If that tag is not available (including a new Dockerfile in a PR), it builds the
+checked-out Dockerfile locally. Thus the first run may still build an image;
+subsequent runs use the image after the master image-builder run publishes it.
+The Clang ccache identity includes the real compiler binaries and the wrapper,
+so changing the toolchain behind the wrapper invalidates cached compilations.
+
+## Local workflow checks
+
+```sh
+python3 -B tests/ci/test_lat_ci_matrix.py
+python3 -B tests/ci/test_lat_ci_workflows.py
+actionlint .github/workflows/release.yml .github/workflows/tests.yml \
+  .github/workflows/clang.yml .github/workflows/build-docker-images.yml
+git diff --check
+```
+
+These validate selection logic and workflow definitions. Actual queue time,
+cache hit rates, image publication and build/test completion must be measured
+in GitHub Actions after rollout; job-count reduction is not a timing guarantee.

--- a/docs/devel/ci-validation.md
+++ b/docs/devel/ci-validation.md
@@ -17,6 +17,7 @@ Full coverage retains all 15 GCC build jobs, all three `lat-pr-fast` jobs and
 the Clang build. It runs on:
 
 - pushes to `master`;
+- version tag pushes, including `1.6.8`, `v1.6.8`, and `1.6.8-rc1`;
 - the daily schedule at 18:00 UTC (02:00 China Standard Time);
 - manual workflow runs;
 - published releases, as a post-publication check;
@@ -31,23 +32,69 @@ failures select full coverage rather than silently dropping checks. This is a co
 heuristic; changes to code inside an existing conditional block may still need
 a manually requested full run.
 
-## Before publishing a release
+## Automatic releases
 
-Run **Build and Release LAT** manually on the exact candidate branch or tag.
-It runs the full GCC matrix and calls **LAT Tests** and **Clang Compile** at the
-same revision. Wait for the entire run to succeed before publishing, and rerun
-validation if the candidate changes. This workflow uploads artifacts but does
-not publish a GitHub release.
+After these workflow changes are integrated, update `VERSION` in the candidate
+commit and push its version tag to `lat-opensource/lat`. The repository's existing
+numeric tag convention is supported, as are optional `v` prefixes and prerelease
+suffixes. For example, tag `1.6.8` requires `VERSION` to contain `1.6.8`;
+`1.6.8-rc1` accepts `VERSION` containing either `1.6.8` or `1.6.8-rc1`.
+Mismatches fail before building. Existing tags are not republished automatically.
 
-The release-event trigger is a post-publication check. QEMU containers do not
-replace native LoongArch compatibility, integration or performance acceptance.
+**Build and Release LAT** then runs the full GCC matrix and invokes **LAT Tests**
+and **Clang Compile** as reusable workflows at the same commit. The final
+**Full release validation** job requires all five GCC configurations, all three
+test containers, and successful build/test/Clang jobs. Failed, cancelled or
+skipped dependencies cannot pass this gate. Its summary records the tested SHA.
+
+Only after that gate passes does **Publish verified release** create a GitHub
+Release on the upstream repository. It downloads packages from this run only,
+checks their commit/version, and gives the three packages unique names:
+
+```text
+lat-1.6.8-aosc-loongarch64.tar.xz
+lat-1.6.8-debian-loongarch64.tar.xz
+lat-1.6.8-fedora-loongarch64.tar.xz
+SHA256SUMS
+```
+
+The publisher verifies that the remote tag still resolves to the tested commit
+(including annotated tags), creates a draft with a CI link and release notes,
+uploads all four assets, rechecks the tag, and finally publishes the draft.
+Tags with a suffix such as `-rc1` produce GitHub prereleases. Normal version tags
+produce stable releases. Only the publishing job receives `contents: write`;
+the repository's built-in `GITHUB_TOKEN` is sufficient.
+
+If validation fails, no release is created. If uploading fails, the release
+remains a draft. Rerunning the failed job resumes a draft created by this
+workflow for the same commit. A completed release is not overwritten; reruns
+verify that its expected assets exist. Maintainer-created drafts or releases
+are not modified. A moved/deleted tag prevents publication.
+
+Tag/manual candidate runs have 19 build/test jobs, two selection jobs and one
+final validation job. Automatic upstream tag releases add one publishing job.
+The automatic flow publishes the validated candidate; finish any separate
+native acceptance work before pushing a stable version tag.
+
+## Optional validation without publication
+
+The Actions page's manual **Build and Release LAT** entry point remains useful
+for checking a candidate branch or tag before deciding to release. It runs the
+same full validation gate but does not publish, even when a tag is selected.
+Push a new version tag when ready to use the automatic publication flow.
+
+The `release: published` trigger is an additional check for releases published
+outside this flow; it is not a pre-publication gate. Releases created using
+`GITHUB_TOKEN` do not start another release-event run. These workflows use QEMU
+LoongArch containers and do not replace native LoongArch compatibility,
+integration or performance acceptance testing.
 
 ## Avoiding repeated work
 
 Each PR workflow cancels older runs of the same workflow and PR when a new run
 starts. Different PRs do not cancel one another. Master, scheduled, manual and
 release runs are not cancelled by this policy. GCC push builds run only on
-`master`, and assigning a PR no longer triggers a build.
+`master` or version tags, and assigning a PR no longer triggers a build.
 
 Test and Clang jobs persist ccache separately from product build caches, with
 keys separating the container, sanitizer mode where applicable, Dockerfiles and
@@ -69,6 +116,7 @@ so changing the toolchain behind the wrapper invalidates cached compilations.
 ```sh
 python3 -B tests/ci/test_lat_ci_matrix.py
 python3 -B tests/ci/test_lat_ci_workflows.py
+python3 -B tests/ci/test_lat_ci_release.py
 actionlint .github/workflows/release.yml .github/workflows/tests.yml \
   .github/workflows/clang.yml .github/workflows/build-docker-images.yml
 git diff --check

--- a/scripts/ci/lat_ci_matrix.py
+++ b/scripts/ci/lat_ci_matrix.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-2.0-or-later
+"""Select PR or full CI coverage, falling back to full on incomplete evidence."""
+
+import json
+import os
+import re
+import urllib.request
+from pathlib import Path
+
+
+BUILD_TYPES = [
+    {"NAME": "build-release", "OPT": ""},
+    {"NAME": "build32", "OPT": "-c -a"},
+    {"NAME": "build32-dbg", "OPT": "-c"},
+    {"NAME": "build64", "OPT": "-c -a"},
+    {"NAME": "build64-dbg", "OPT": "-c"},
+]
+TEST_CONTAINERS = [
+    {"name": "latx-runner-aosc", "tag": "loong64", "sanitizers": False,
+     "prepare_meson": "command -v meson >/dev/null || oma install -y meson"},
+    {"name": "latx-runner-debian", "tag": "loong64", "sanitizers": True,
+     "prepare_meson": "command -v meson >/dev/null || { apt-get update && apt-get install -y meson; }"},
+    {"name": "latx-runner-fedora", "tag": "loongarch64", "sanitizers": False,
+     "prepare_meson": "command -v meson >/dev/null"},
+]
+BUILD_FILES = {
+    "configure", "meson.build", "meson.options", "meson_options.txt",
+    ".gitmodules", "Makefile", "GNUmakefile", "meson",
+}
+BUILD_PREFIXES = (
+    ".github/.ci/", ".github/workflows/", "latxbuild/", "configs/",
+    "scripts/ci/", "tests/ci/", "runtime/", "tests/runtime/", "meson/",
+)
+PREPROCESSOR_CHANGE = re.compile(
+    r"^[+-]\s*#\s*(?:if|ifdef|ifndef|elif|else|endif|define|undef)\b",
+    re.MULTILINE,
+)
+
+
+def needs_full_matrix(files):
+    for item in files:
+        for name in (item["filename"], item.get("previous_filename", "")):
+            if (name in BUILD_FILES or name.startswith(BUILD_PREFIXES)
+                    or name.endswith(("/meson.build", ".mak"))):
+                return True
+        # GitHub may omit patches for large diffs or binary files. Do not
+        # silently narrow coverage when the diff cannot be inspected.
+        patch = item.get("patch")
+        if patch is None or PREPROCESSOR_CHANGE.search(patch):
+            return True
+        for field, prefix in (("additions", "+"), ("deletions", "-")):
+            if field in item and sum(line.startswith(prefix) for line in
+                                     patch.splitlines()) < item[field]:
+                return True
+    return False
+
+
+def pull_request_files(repository, number, token, expected_count,
+                       opener=urllib.request.urlopen):
+    # The list-files endpoint returns at most 3,000 files.
+    if expected_count >= 3000:
+        raise ValueError("PR file list may exceed the GitHub API limit")
+    files = []
+    for page in range(1, 31):
+        request = urllib.request.Request(
+            f"https://api.github.com/repos/{repository}/pulls/{number}/files"
+            f"?per_page=100&page={page}",
+            headers={"Authorization": f"Bearer {token}",
+                     "Accept": "application/vnd.github+json",
+                     "X-GitHub-Api-Version": "2022-11-28"},
+        )
+        with opener(request, timeout=30) as response:
+            batch = json.load(response)
+        files.extend(batch)
+        if len(batch) < 100:
+            break
+    if len(files) != expected_count:
+        raise ValueError("PR file list is incomplete or changed during selection")
+    return files
+
+
+def select_matrix(event_name, event, token="", fetch_files=pull_request_files):
+    if event_name != "pull_request":
+        return True, "Full coverage for master, scheduled, release or manual runs"
+    pr = event["pull_request"]
+    try:
+        files = fetch_files(event["repository"]["full_name"], pr["number"],
+                            token, pr["changed_files"])
+        full = needs_full_matrix(files)
+    except Exception:
+        # Fail closed without logging API credentials or response bodies.
+        return True, "Full coverage: PR changes could not be inspected completely"
+    return full, ("Full coverage: build, runtime or preprocessor changes"
+                  if full else "PR coverage: non-debug builds and Debian sanitizers")
+
+
+def matrix_outputs(full):
+    return {
+        "build_types": [entry for entry in BUILD_TYPES if full or
+                        entry["NAME"] in ("build32", "build64")],
+        "test_containers": [entry for entry in TEST_CONTAINERS if full or
+                            entry["sanitizers"]],
+    }
+
+
+def main():
+    event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text())
+    full, reason = select_matrix(os.environ["GITHUB_EVENT_NAME"], event,
+                                 os.environ.get("GITHUB_TOKEN", ""))
+    with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+        for key, value in matrix_outputs(full).items():
+            output.write(f"{key}={json.dumps(value, separators=(',', ':'))}\n")
+    print(reason)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/lat_ci_release.py
+++ b/scripts/ci/lat_ci_release.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-2.0-or-later
+"""Publish the tested tag's three packages, keeping partial uploads in a draft."""
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shutil
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+
+DISTROS = ("aosc", "debian", "fedora")
+
+
+def release_version(tag, version):
+    match = re.fullmatch(r"v?(\d+\.\d+\.\d+)(-[0-9A-Za-z][0-9A-Za-z.-]*)?", tag)
+    if not match:
+        raise ValueError("Expected a version tag such as 1.6.8 or 1.6.8-rc1")
+    normalized = match[1] + (match[2] or "")
+    if version not in (match[1], normalized):
+        raise ValueError(f"VERSION {version!r} does not match tag {tag!r}")
+    return normalized, bool(match[2])
+
+
+def prepare_assets(artifact_dir, output_dir, tag, version, sha):
+    normalized, _ = release_version(tag, version)
+    if not re.fullmatch(r"[0-9a-f]{40}", sha):
+        raise ValueError("Expected the exact tested commit SHA")
+    sources = []
+    for distro in DISTROS:
+        prefix = f"latx-runner-{distro}-build-release-"
+        directories = list(artifact_dir.glob(f"{prefix}*"))
+        if len(directories) != 1:
+            raise ValueError(f"Expected exactly one {distro} release artifact")
+        directory = directories[0]
+        short_sha = directory.name[len(prefix):]
+        if len(short_sha) < 7 or not sha.startswith(short_sha):
+            raise ValueError(f"Artifact does not belong to tested commit: {directory.name}")
+        archives = list(directory.rglob("*.tar.xz"))
+        if len(archives) != 1:
+            raise ValueError(f"Expected exactly one package for {distro}")
+        archive = archives[0]
+        if (archive.is_symlink() or not archive.is_file() or archive.stat().st_size == 0
+                or not re.fullmatch(rf"lat-{re.escape(version)}-\d{{8}}\.tar\.xz", archive.name)):
+            raise ValueError(f"Invalid package for {distro}: {archive.name}")
+        sources.append((archive, f"lat-{normalized}-{distro}-loongarch64.tar.xz"))
+    output_dir.mkdir(parents=True, exist_ok=False)
+    assets = []
+    checksums = []
+    for source, name in sources:
+        destination = output_dir / name
+        shutil.copyfile(source, destination)
+        digest = hashlib.sha256()
+        with destination.open("rb") as stream:
+            for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                digest.update(chunk)
+        checksums.append(f"{digest.hexdigest()}  {name}\n")
+        assets.append(destination)
+    checksum_file = output_dir / "SHA256SUMS"
+    checksum_file.write_text("".join(checksums), encoding="utf-8")
+    return assets + [checksum_file]
+
+
+class GitHub:
+    def __init__(self, repository, token):
+        self.repository = repository
+        self.token = token
+
+    def request(self, method, path, payload=None):
+        url = f"https://api.github.com/repos/{self.repository}/{path}"
+        data = None if payload is None else json.dumps(payload).encode()
+        return self.send(method, url, data, "application/json")
+
+    def send(self, method, url, data, content_type):
+        request = urllib.request.Request(url, data=data, method=method, headers={
+            "Authorization": f"Bearer {self.token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "Content-Type": content_type,
+        })
+        with urllib.request.urlopen(request, timeout=120) as response:
+            body = response.read()
+        return json.loads(body) if body else None
+
+    def upload(self, release, asset):
+        base_url = release["upload_url"].split("{", 1)[0]
+        if urllib.parse.urlsplit(base_url).hostname != "uploads.github.com":
+            raise ValueError("Unexpected GitHub asset upload host")
+        url = base_url + "?" + urllib.parse.urlencode({"name": asset.name})
+        return self.send("POST", url, asset.read_bytes(), "application/octet-stream")
+
+
+def verify_tag(api, tag, sha):
+    result = api.request("GET", "git/ref/tags/" + urllib.parse.quote(tag, safe=""))
+    obj = result["object"]
+    # Dereference annotated tags too; the tag object SHA is not the commit SHA.
+    for _ in range(10):
+        if obj["type"] == "commit":
+            if obj["sha"] != sha:
+                raise ValueError("Remote tag no longer points to the tested commit")
+            return
+        if obj["type"] != "tag":
+            break
+        obj = api.request("GET", f"git/tags/{obj['sha']}")["object"]
+    raise ValueError("Version tag does not resolve to a commit")
+
+
+def find_release(api, tag):
+    # Listing with a write token includes drafts; the release-by-tag endpoint
+    # is documented for published releases and cannot be used to resume drafts.
+    for page in range(1, 101):
+        releases = api.request("GET", f"releases?per_page=100&page={page}")
+        matches = [release for release in releases if release["tag_name"] == tag]
+        if len(matches) > 1:
+            raise ValueError("More than one release uses this tag")
+        if matches:
+            return matches[0]
+        if len(releases) < 100:
+            return None
+    raise ValueError("Release history is too large to inspect completely")
+
+
+def publish(api, tag, sha, assets, prerelease, run_url):
+    verify_tag(api, tag, sha)
+    marker = f"<!-- lat-ci-release commit={sha} -->"
+    release = find_release(api, tag)
+    if release is None:
+        release = api.request("POST", "releases", {
+            "tag_name": tag, "target_commitish": sha, "name": f"LAT {tag}",
+            "draft": True, "prerelease": prerelease, "generate_release_notes": True,
+            "body": f"{marker}\n\nCommit: `{sha}`\n\n"
+                    f"[Full CI validation]({run_url})\n\n"
+                    "15 GCC builds, 3 lat-pr-fast jobs and 1 Clang build passed.\n",
+        })
+    if marker not in (release.get("body") or ""):
+        raise ValueError("Existing release was not created by this workflow for this commit")
+    if release.get("prerelease") != prerelease:
+        raise ValueError("Existing release has a different prerelease classification")
+    existing_assets = release.get("assets", [])
+    names = {asset.name for asset in assets}
+    if not release["draft"]:
+        existing_names = {item["name"] for item in existing_assets if item["size"] > 0}
+        if not names.issubset(existing_names):
+            raise ValueError("Published release is missing expected assets; refusing to overwrite it")
+        print(f"Release {tag} is already published for this commit")
+        return release["html_url"]
+    # Only replace assets in this workflow's own unpublished draft. A failed
+    # upload leaves a draft that can be completed by rerunning the failed job.
+    for item in existing_assets:
+        if item["name"] not in names:
+            raise ValueError("Draft contains unexpected assets; refusing to modify it")
+    for item in existing_assets:
+        api.request("DELETE", f"releases/assets/{item['id']}")
+    for asset in assets:
+        uploaded = api.upload(release, asset)
+        if uploaded.get("state") != "uploaded" or uploaded.get("size") != asset.stat().st_size:
+            raise ValueError(f"Upload incomplete for {asset.name}")
+    verify_tag(api, tag, sha)
+    result = api.request("PATCH", f"releases/{release['id']}", {"draft": False})
+    if result.get("draft") is not False:
+        raise ValueError("Release remained a draft after the publish request")
+    return result["html_url"]
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("check-version", "publish"))
+    parser.add_argument("--artifact-dir", type=Path, default=Path("release-artifacts"))
+    parser.add_argument("--output-dir", type=Path, default=Path("release-assets"))
+    args = parser.parse_args()
+    tag = os.environ["GITHUB_REF_NAME"]
+    version = Path("VERSION").read_text().strip()
+    _, prerelease = release_version(tag, version)
+    if args.command == "check-version":
+        print(f"Release tag {tag} matches VERSION {version}")
+        return
+    sha = os.environ["GITHUB_SHA"]
+    assets = prepare_assets(args.artifact_dir, args.output_dir, tag, version, sha)
+    repository = os.environ["GITHUB_REPOSITORY"]
+    api = GitHub(repository, os.environ["GITHUB_TOKEN"])
+    run_url = f"https://github.com/{repository}/actions/runs/{os.environ['GITHUB_RUN_ID']}"
+    url = publish(api, tag, sha, assets, prerelease, run_url)
+    with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary:
+        summary.write(f"Published [{tag}]({url}) from commit `{sha}`.\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/README.md
+++ b/tests/README.md
@@ -3,6 +3,9 @@
 LAT tests are registered with Meson and are configured only when
 `--enable-tests` is passed to `configure`.
 
+See [CI validation tiers](../docs/devel/ci-validation.md) for PR coverage,
+daily full matrices and the pre-release validation entry point.
+
 ## Choose a test suite
 
 - `lat-pr-fast`: deterministic, self-contained regression tests that need no

--- a/tests/ci/test_lat_ci_matrix.py
+++ b/tests/ci/test_lat_ci_matrix.py
@@ -184,5 +184,49 @@ class ClangImageSelectionTest(unittest.TestCase):
         self.assertNotIn("\ntag ", log)
 
 
+class ReleaseValidationGateTest(unittest.TestCase):
+    def run_gate(self, **overrides):
+        workflow = (ROOT / ".github/workflows/release.yml").read_text()
+        code = textwrap.dedent(workflow.split("<<'PY'\n", 1)[1].split(
+            "\n          PY", 1)[0])
+        outputs = MATRIX.matrix_outputs(True)
+        with tempfile.TemporaryDirectory() as directory:
+            summary = Path(directory) / "summary.md"
+            environment = dict(os.environ, SELECT_RESULT="success",
+                               BUILD_RESULT="success", TEST_RESULT="success",
+                               CLANG_RESULT="success", GITHUB_SHA="a" * 40,
+                               BUILD_TYPES=json.dumps(outputs["build_types"]),
+                               TEST_CONTAINERS=json.dumps(outputs["test_containers"]),
+                               GITHUB_STEP_SUMMARY=str(summary))
+            environment.update(overrides)
+            result = subprocess.run(["python3", "-c", code], env=environment,
+                                    capture_output=True, text=True)
+            return result, summary.read_text() if summary.exists() else ""
+
+    def test_success_records_exact_commit_and_full_coverage(self):
+        result, summary = self.run_gate()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("a" * 40, summary)
+        self.assertIn("15 GCC builds, 3 lat-pr-fast jobs and 1 Clang build", summary)
+
+    def test_failed_cancelled_or_skipped_dependencies_cannot_pass(self):
+        for key in ("SELECT_RESULT", "BUILD_RESULT", "TEST_RESULT", "CLANG_RESULT"):
+            for value in ("failure", "cancelled", "skipped"):
+                with self.subTest(key=key, value=value):
+                    result, summary = self.run_gate(**{key: value})
+                    self.assertNotEqual(result.returncode, 0)
+                    self.assertEqual(summary, "")
+
+    def test_reduced_gcc_matrix_cannot_pass(self):
+        result, _ = self.run_gate(BUILD_TYPES=json.dumps(
+            MATRIX.matrix_outputs(False)["build_types"]))
+        self.assertNotEqual(result.returncode, 0)
+
+    def test_reduced_test_matrix_cannot_pass(self):
+        result, _ = self.run_gate(TEST_CONTAINERS=json.dumps(
+            MATRIX.matrix_outputs(False)["test_containers"]))
+        self.assertNotEqual(result.returncode, 0)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/ci/test_lat_ci_matrix.py
+++ b/tests/ci/test_lat_ci_matrix.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-2.0-or-later
+"""Regression tests for CI coverage selection and incomplete PR evidence."""
+
+import importlib.util
+import io
+import json
+import os
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+HELPER = ROOT / "scripts/ci/lat_ci_matrix.py"
+SPEC = importlib.util.spec_from_file_location("lat_ci_matrix", HELPER)
+MATRIX = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MATRIX)
+
+
+def changed_file(name="target/i386/latx/translator/translate.c", patch="+return 1;"):
+    return {"filename": name, "patch": patch}
+
+
+class MatrixSelectionTest(unittest.TestCase):
+    def select(self, files):
+        event = {"repository": {"full_name": "lat-opensource/lat"},
+                 "pull_request": {"number": 123, "changed_files": len(files)}}
+        return MATRIX.select_matrix("pull_request", event,
+                                    fetch_files=lambda *args: files)[0]
+
+    def test_ordinary_pr_preserves_both_architectures_avx_and_sanitizers(self):
+        outputs = MATRIX.matrix_outputs(self.select([changed_file()]))
+        self.assertEqual(outputs["build_types"], [
+            {"NAME": "build32", "OPT": "-c -a"},
+            {"NAME": "build64", "OPT": "-c -a"},
+        ])
+        self.assertEqual(len(outputs["test_containers"]), 1)
+        self.assertEqual(outputs["test_containers"][0]["name"], "latx-runner-debian")
+        self.assertTrue(outputs["test_containers"][0]["sanitizers"])
+
+    def test_non_pr_events_always_run_full_without_api(self):
+        def unexpected_api(*args):
+            self.fail("Non-PR coverage must not depend on the PR API")
+
+        for event in ("push", "schedule", "release", "workflow_dispatch", "workflow_call"):
+            with self.subTest(event=event):
+                full, _ = MATRIX.select_matrix(event, {}, fetch_files=unexpected_api)
+                self.assertTrue(full)
+                outputs = MATRIX.matrix_outputs(full)
+                self.assertEqual(len(outputs["build_types"]), 5)
+                self.assertEqual(len(outputs["test_containers"]), 3)
+
+    def test_build_runtime_and_ci_changes_expand_coverage(self):
+        for name in ("configure", "meson.options", "meson_options.txt",
+                     "tests/unit/meson.build", "configs/targets/i386.mak",
+                     "latxbuild/build64-dbg.sh", ".gitmodules",
+                     ".github/.ci/clang/Dockerfile", ".github/workflows/tests.yml",
+                     "scripts/ci/lat_ci_matrix.py", "tests/ci/test_lat_ci_matrix.py",
+                     "runtime/latu-runtime-manager", "tests/runtime/fixture.sh"):
+            with self.subTest(name=name):
+                self.assertTrue(self.select([changed_file(name)]))
+
+    def test_rename_out_of_build_directory_expands_coverage(self):
+        item = changed_file("docs/old-script.txt")
+        item["previous_filename"] = "latxbuild/build32.sh"
+        self.assertTrue(self.select([item]))
+
+    def test_preprocessor_additions_and_removals_expand_coverage(self):
+        for directive in ("if X", "ifdef X", "ifndef X", "elif X", "else",
+                          "endif", "define X 1", "undef X"):
+            for sign in ("+", "-"):
+                with self.subTest(directive=directive, sign=sign):
+                    self.assertTrue(self.select([changed_file(
+                        patch=f"@@ -1 +1 @@\n{sign}  # {directive}\n")]))
+
+    def test_unchanged_preprocessor_context_keeps_pr_coverage(self):
+        self.assertFalse(self.select([changed_file(
+            patch="@@ -1,3 +1,3 @@\n #ifdef DEBUG\n-old();\n+new();\n #endif\n")]))
+
+    def test_missing_patch_expands_coverage(self):
+        self.assertTrue(self.select([{"filename": "large.c"}]))
+
+    def test_truncated_patch_expands_coverage(self):
+        item = changed_file(patch="@@ -1 +1 @@\n-old();\n+new();\n")
+        item.update(additions=2, deletions=1)
+        self.assertTrue(self.select([item]))
+
+    def test_api_failure_expands_coverage(self):
+        def failing_api(*args):
+            raise OSError("network unavailable")
+
+        event = {"repository": {"full_name": "lat-opensource/lat"},
+                 "pull_request": {"number": 123, "changed_files": 1}}
+        full, _ = MATRIX.select_matrix("pull_request", event, fetch_files=failing_api)
+        self.assertTrue(full)
+
+    def test_api_paginates_before_deciding_coverage(self):
+        requested = []
+        batches = [[changed_file() for _ in range(100)],
+                   [changed_file("configure")]]
+
+        def opener(request, timeout):
+            requested.append(request.full_url)
+            return io.BytesIO(json.dumps(batches.pop(0)).encode())
+
+        files = MATRIX.pull_request_files("lat-opensource/lat", 123, "test-token",
+                                          101, opener=opener)
+        self.assertTrue(MATRIX.needs_full_matrix(files))
+        self.assertEqual(len(requested), 2)
+        self.assertTrue(requested[-1].endswith("page=2"))
+
+    def test_incomplete_api_list_is_rejected(self):
+        def opener(request, timeout):
+            return io.BytesIO(b"[]")
+
+        with self.assertRaisesRegex(ValueError, "incomplete"):
+            MATRIX.pull_request_files("lat-opensource/lat", 123, "test-token",
+                                      1, opener=opener)
+
+    def test_api_limit_is_rejected_without_fetching(self):
+        def unexpected_api(*args, **kwargs):
+            self.fail("Do not fetch a file list known to be incomplete")
+
+        with self.assertRaisesRegex(ValueError, "limit"):
+            MATRIX.pull_request_files("lat-opensource/lat", 123, "test-token",
+                                      3000, opener=unexpected_api)
+
+    def test_cli_emits_single_line_json_outputs(self):
+        with tempfile.TemporaryDirectory() as directory:
+            event = Path(directory) / "event.json"
+            output = Path(directory) / "outputs"
+            event.write_text("{}")
+            subprocess.run(["python3", "-B", str(HELPER)], check=True,
+                           capture_output=True, env=dict(os.environ,
+                           GITHUB_EVENT_NAME="workflow_dispatch",
+                           GITHUB_EVENT_PATH=str(event), GITHUB_OUTPUT=str(output)))
+            values = dict(line.split("=", 1) for line in output.read_text().splitlines())
+            self.assertEqual(len(json.loads(values["build_types"])), 5)
+            self.assertEqual(len(json.loads(values["test_containers"])), 3)
+
+
+class ClangImageSelectionTest(unittest.TestCase):
+    def run_selection(self, pull_status):
+        workflow = (ROOT / ".github/workflows/clang.yml").read_text()
+        step = workflow.split("      - name: Pull matching clang image\n", 1)[1]
+        code = textwrap.dedent(step.split("        run: |\n", 1)[1].split(
+            "\n      - name:", 1)[0])
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory)
+            docker = path / "docker"
+            docker.write_text("#!/bin/sh\n"
+                              'printf "%s\\n" "$*" >> "$DOCKER_LOG"\n'
+                              'if [ "$1" = pull ]; then exit "$PULL_STATUS"; fi\n')
+            docker.chmod(0o755)
+            # macOS has shasum even when GNU sha256sum is not installed.
+            checksum = path / "sha256sum"
+            checksum.write_text('#!/bin/sh\nexec shasum -a 256 "$@"\n')
+            checksum.chmod(0o755)
+            output = path / "outputs"
+            log = path / "docker.log"
+            subprocess.run(["bash", "-e", "-c", code], check=True, cwd=ROOT,
+                           capture_output=True, env=dict(os.environ,
+                           PATH=f"{path}:{os.environ['PATH']}",
+                           REPOSITORY_OWNER="lat-opensource",
+                           GITHUB_OUTPUT=str(output), DOCKER_LOG=str(log),
+                           PULL_STATUS=str(pull_status)))
+            return output.read_text(), log.read_text()
+
+    def test_published_image_uses_dockerfile_hash_and_skips_local_build(self):
+        import hashlib
+        digest = hashlib.sha256((ROOT / ".github/.ci/clang/Dockerfile").read_bytes()).hexdigest()
+        output, log = self.run_selection(0)
+        self.assertEqual(output.strip(), "build_local=false")
+        self.assertIn(f"loongarch64-{digest}", log)
+        self.assertIn("tag ghcr.io/lat-opensource/", log)
+        self.assertIn("lat-ci-clang:local", log)
+
+    def test_unpublished_image_requests_local_build_without_tagging(self):
+        output, log = self.run_selection(1)
+        self.assertEqual(output.strip(), "build_local=true")
+        self.assertNotIn("\ntag ", log)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ci/test_lat_ci_release.py
+++ b/tests/ci/test_lat_ci_release.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-2.0-or-later
+"""Exercise release preparation and publication without network mutations."""
+
+import copy
+import hashlib
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location("lat_ci_release", ROOT / "scripts/ci/lat_ci_release.py")
+RELEASE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(RELEASE)
+SHA = "a" * 40
+TAG = "1.6.8"
+
+
+class PrepareAssetsTest(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+        self.root = Path(self.directory.name)
+        self.artifacts = self.root / "artifacts"
+        self.archives = []
+        for distro in RELEASE.DISTROS:
+            directory = self.artifacts / f"latx-runner-{distro}-build-release-{SHA[:11]}"
+            directory.mkdir(parents=True)
+            archive = directory / "lat-1.6.8-20260912.tar.xz"
+            archive.write_bytes(distro.encode())
+            self.archives.append(archive)
+
+    def prepare(self):
+        return RELEASE.prepare_assets(self.artifacts, self.root / "output", TAG, TAG, SHA)
+
+    def test_same_named_distro_packages_get_unique_names_and_checksums(self):
+        assets = self.prepare()
+        self.assertEqual({item.name for item in assets}, {
+            "lat-1.6.8-aosc-loongarch64.tar.xz", "lat-1.6.8-debian-loongarch64.tar.xz",
+            "lat-1.6.8-fedora-loongarch64.tar.xz", "SHA256SUMS",
+        })
+        for line in assets[-1].read_text().splitlines():
+            digest, name = line.split("  ")
+            self.assertEqual(digest, hashlib.sha256((assets[-1].parent / name).read_bytes()).hexdigest())
+
+    def test_missing_distro_fails_before_preparing_output(self):
+        self.archives[0].unlink()
+        self.archives[0].parent.rmdir()
+        with self.assertRaisesRegex(ValueError, "exactly one aosc"):
+            self.prepare()
+        self.assertFalse((self.root / "output").exists())
+
+    def test_wrong_artifact_commit_is_rejected(self):
+        directory = self.archives[0].parent
+        directory.rename(directory.with_name("latx-runner-aosc-build-release-bbbbbbb"))
+        with self.assertRaisesRegex(ValueError, "tested commit"):
+            self.prepare()
+
+    def test_duplicate_package_is_rejected(self):
+        self.archives[0].with_name("lat-1.6.8-20260913.tar.xz").write_bytes(b"duplicate")
+        with self.assertRaisesRegex(ValueError, "exactly one package"):
+            self.prepare()
+
+    def test_wrong_package_version_is_rejected(self):
+        self.archives[0].rename(self.archives[0].with_name("lat-1.6.5-20260912.tar.xz"))
+        with self.assertRaisesRegex(ValueError, "Invalid package"):
+            self.prepare()
+
+    def test_empty_package_is_rejected(self):
+        self.archives[0].write_bytes(b"")
+        with self.assertRaisesRegex(ValueError, "Invalid package"):
+            self.prepare()
+
+    def test_release_and_prerelease_tag_version_rules(self):
+        for tag in ("1.6.8", "v1.6.8"):
+            self.assertEqual(RELEASE.release_version(tag, "1.6.8"), ("1.6.8", False))
+        for version in ("1.6.8", "1.6.8-rc1"):
+            self.assertEqual(RELEASE.release_version("v1.6.8-rc1", version), ("1.6.8-rc1", True))
+        for tag, version in (("1.6.8", "1.6.5"), ("nightly", "1.6.8"), ("1.6.8-", "1.6.8")):
+            with self.subTest(tag=tag, version=version), self.assertRaises(ValueError):
+                RELEASE.release_version(tag, version)
+
+
+class FakeGitHub:
+    def __init__(self):
+        self.release = None
+        self.calls = []
+        self.sha = SHA
+        self.annotated = False
+        self.upload_failure = False
+        self.move_after_upload = False
+        self.list_failure = False
+
+    def request(self, method, path, payload=None):
+        self.calls.append((method, path, payload))
+        if path.startswith("git/ref/tags/"):
+            return {"object": {"type": "tag" if self.annotated else "commit",
+                               "sha": "tag-object" if self.annotated else self.sha}}
+        if path == "git/tags/tag-object":
+            return {"object": {"type": "commit", "sha": self.sha}}
+        if path.startswith("releases?"):
+            if self.list_failure:
+                raise OSError("API unavailable")
+            return [copy.deepcopy(self.release)] if self.release else []
+        if method == "POST" and path == "releases":
+            self.release = dict(payload, id=1, assets=[], html_url="https://github.com/example/release")
+            return copy.deepcopy(self.release)
+        if method == "DELETE":
+            asset_id = int(path.rsplit("/", 1)[1])
+            self.release["assets"] = [item for item in self.release["assets"] if item["id"] != asset_id]
+            return None
+        if method == "PATCH":
+            self.release.update(payload)
+            return copy.deepcopy(self.release)
+        raise AssertionError((method, path, payload))
+
+    def upload(self, release, asset):
+        self.calls.append(("UPLOAD", asset.name, None))
+        if self.upload_failure:
+            raise OSError("upload interrupted")
+        item = {"id": len(self.release["assets"]) + 1, "name": asset.name,
+                "size": asset.stat().st_size, "state": "uploaded"}
+        self.release["assets"].append(item)
+        if self.move_after_upload:
+            self.sha = "b" * 40
+        return item
+
+
+class PublishTest(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+        self.assets = []
+        for name in ("aosc.tar.xz", "debian.tar.xz", "fedora.tar.xz", "SHA256SUMS"):
+            asset = Path(self.directory.name) / name
+            asset.write_bytes(name.encode())
+            self.assets.append(asset)
+        self.api = FakeGitHub()
+
+    def publish(self, prerelease=False):
+        return RELEASE.publish(self.api, TAG, SHA, self.assets, prerelease, "https://github.com/example/run/1")
+
+    def test_create_draft_upload_all_then_publish(self):
+        self.publish()
+        methods = [call[0] for call in self.api.calls]
+        self.assertLess(methods.index("POST"), methods.index("UPLOAD"))
+        self.assertEqual(methods[-1], "PATCH")
+        self.assertEqual(methods.count("UPLOAD"), 4)
+        create = next(call[2] for call in self.api.calls if call[0] == "POST")
+        self.assertTrue(create["draft"])
+        self.assertFalse(self.api.release["draft"])
+
+    def test_prerelease_is_not_published_as_stable(self):
+        self.publish(prerelease=True)
+        self.assertTrue(self.api.release["prerelease"])
+
+    def test_annotated_tag_resolves_to_tested_commit(self):
+        self.api.annotated = True
+        self.publish()
+        self.assertFalse(self.api.release["draft"])
+
+    def test_moved_tag_is_rejected_before_release_creation(self):
+        self.api.sha = "b" * 40
+        with self.assertRaisesRegex(ValueError, "tested commit"):
+            self.publish()
+        self.assertIsNone(self.api.release)
+
+    def test_tag_moved_during_upload_stays_draft(self):
+        self.api.move_after_upload = True
+        with self.assertRaisesRegex(ValueError, "tested commit"):
+            self.publish()
+        self.assertTrue(self.api.release["draft"])
+        self.assertNotIn("PATCH", [call[0] for call in self.api.calls])
+
+    def test_failed_upload_stays_draft_and_rerun_resumes(self):
+        self.api.upload_failure = True
+        with self.assertRaises(OSError):
+            self.publish()
+        self.assertTrue(self.api.release["draft"])
+        self.api.upload_failure = False
+        self.publish()
+        self.assertFalse(self.api.release["draft"])
+        self.assertEqual(sum(call[0] == "POST" for call in self.api.calls), 1)
+
+    def test_partial_draft_assets_can_be_replaced_on_retry(self):
+        self.api.move_after_upload = True
+        with self.assertRaises(ValueError):
+            self.publish()
+        self.api.move_after_upload = False
+        self.api.sha = SHA
+        self.publish()
+        self.assertEqual(sum(call[0] == "DELETE" for call in self.api.calls), 4)
+        self.assertFalse(self.api.release["draft"])
+
+    def test_published_release_rerun_makes_no_mutations(self):
+        self.publish()
+        self.api.calls.clear()
+        self.publish()
+        self.assertTrue(all(call[0] == "GET" for call in self.api.calls))
+
+    def test_missing_published_asset_is_not_silently_accepted(self):
+        self.publish()
+        self.api.release["assets"].pop()
+        self.api.calls.clear()
+        with self.assertRaisesRegex(ValueError, "missing expected assets"):
+            self.publish()
+        self.assertTrue(all(call[0] == "GET" for call in self.api.calls))
+
+    def test_user_owned_release_is_not_modified(self):
+        self.publish()
+        self.api.release.update(draft=True, body="Maintainer's release draft")
+        self.api.calls.clear()
+        with self.assertRaisesRegex(ValueError, "not created by this workflow"):
+            self.publish()
+        self.assertTrue(all(call[0] == "GET" for call in self.api.calls))
+
+    def test_api_failure_does_not_create_duplicate_release(self):
+        self.api.list_failure = True
+        with self.assertRaises(OSError):
+            self.publish()
+        self.assertIsNone(self.api.release)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary / 变更说明

普通源码 PR 的重任务由 19 项降为 8 项：保留三个发行版的非 dbg 32/64 位构建、Debian sanitizer 快速测试和 Clang。master、定时、手动验证及相关配置变更保留完整矩阵。新增矩阵选择 job，取消同一 PR 的过时运行，补充测试和 Clang 编译缓存，并优先使用 Dockerfile 哈希匹配的预构建镜像。AOSC 基础镜像固定为官方已验证的 LoongArch 版本和摘要，避免浮动标签丢失架构条目。

版本标签推送后自动运行完整的 15 项 GCC 构建、3 项快速测试和 1 项 Clang 构建。只有完整验证通过，才从本次运行收集三个发行版安装包和 SHA256SUMS，创建并发布 GitHub Release。发布前核对 VERSION 和被测提交；上传失败保留草稿，重跑可继续，已发布版本及维护者创建的草稿不会被覆盖。带后缀的标签发布为 prerelease；手动入口只验证，不发布。

自动发布仅在上游仓库的版本标签 push 上启用，只有发布 job 获得 contents: write。发版步骤及覆盖边界见 docs/devel/ci-validation.md。

## Validation / 验证

- `python3 -B -m unittest discover -s tests/ci -p 'test_lat_ci_*.py'`：48 项通过，覆盖矩阵选择、镜像命中/回退、发布阻断、产物校验和重跑行为。
- 四个修改的 workflow 通过 `actionlint`，`git diff --check` 通过。
- 已 rebase 到包含 64 位编译修复的 master `b052f6db4f6`；固定的 AOSC 镜像摘要及 `linux/loong64` 配置已通过 registry API 校验。
- 发布 API 使用 mock 验证，尚未执行真实 Release 创建；完整构建与测试状态以此 PR 最新 head 的 CI 结果为准。
- 本次未修改产品源码或正常产品构建目标。

## Checklist / 检查项

- [x] I have read `CONTRIBUTING.md`. / 我已阅读 `CONTRIBUTING.md`。
- [x] Every commit contains a DCO sign-off (`git commit -s`). / 每个提交都包含 DCO 签署。
- [x] I have included relevant build or test results, or explained why they are not applicable. / 已提供验证结果及边界。
