### PR TITLE
LATX, fix: Abort on ftemp register exhaustion

### DIFF
--- a/target/i386/latx/translator/reg-alloc.c
+++ b/target/i386/latx/translator/reg-alloc.c
@@ -326,7 +326,16 @@ IR2_OPND ra_alloc_itemp(void)
 IR2_OPND ra_alloc_ftemp(void)
 {
     IR2_OPND ir2_opnd;
-    ir2_opnd_build(&ir2_opnd, IR2_OPND_FPR, ra_alloc_ftemp_num());
+    int ftemp_reg_num;
+
+    ftemp_reg_num = ra_alloc_ftemp_num();
+    if (unlikely(ftemp_reg_num < 0)) {
+        fprintf(stderr,
+                "[LATX] ftemp register exhausted, status=0x%x\n",
+                lsenv->tr_data->ftemp_status);
+        abort();
+    }
+    ir2_opnd_build(&ir2_opnd, IR2_OPND_FPR, ftemp_reg_num);
     return ir2_opnd;
 }
 


### PR DESCRIPTION
## Summary / 变更说明

Follow up on #480: when all floating-point temporary registers are in use,
`ra_alloc_ftemp_num()` returns `-1`, which `ra_alloc_ftemp()` currently passes
to `ir2_opnd_build()` as a register number.

Check the allocation result before constructing the operand, print the ftemp
allocation bitmap, and abort explicitly in release builds as well. This
matches the itemp exhaustion handling added by #480.

## Validation / 验证

- Focused RED/GREEN on macOS and native LoongArch, in both `-O0` and
  `-O2 -DNDEBUG` builds. A temporary C harness extracts the production temp
  allocation macro, ftemp map and allocation wrappers, with minimal translation
  state and an instrumented operand builder. LoongArch executes the real
  `cto.w`; the macOS harness emulates only that instruction.
- Before the fix, allocating a ninth ftemp reaches the operand builder with
  `-1`. After the fix, it prints `ftemp register exhausted, status=0xff` and
  terminates with SIGABRT before operand construction. Normal allocation,
  reuse of a freed slot, and existing itemp exhaustion protection pass.
- These focused results cover the allocator seam; no real-application
  exhaustion scenario or generated guest-code execution is claimed.
- `git diff --check` and `scripts/checkpatch.pl --no-tree` pass.
- Native LoongArch x86_64 guest build with KZT and tests enabled:
  `meson test -C build-tests --suite lat-pr-fast --print-errorlogs`:
  **28 passed, 0 failed, 0 skipped**. Final `ninja -C build-tests` passed.
  The reused build directory was reconfigured with its existing options to
  generate the operand-access metadata configuration newly required by master.
- The native build and suite used the exact submitted source tree before the
  commit-message/DCO amendment; the amendment changed no source files.
- No permanent test target was added. No application reproducer was supplied;
  application-level and i386 product validation were not run.

## Checklist / 检查项

- [x] I have read `CONTRIBUTING.md`.
- [x] Every commit contains an explicitly authorized DCO sign-off.
- [x] Relevant build and test results and their limits are included above.
